### PR TITLE
Remove pg_version entity and replace with version.

### DIFF
--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-debian.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-debian.md
@@ -37,7 +37,7 @@ wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo ap
 sudo apt-get update
 
 # Now install appropriate package for PG version
-sudo apt-get install timescaledb-2-postgresql-:pg_version:
+sudo apt-get install timescaledb-2-postgresql-13
 ```
 
 #### Upgrading from TimescaleDB 1.x
@@ -47,7 +47,7 @@ binaries. The feedback in your terminal should look similar to the following:
 
 ```bash
 Reading package lists... Done
-Building dependency tree       
+Building dependency tree
 Reading state information... Done
 The following additional packages will be installed:
   timescaledb-2-loader-postgresql-12

--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -38,7 +38,7 @@ sudo add-apt-repository ppa:timescale/timescaledb-ppa
 sudo apt-get update
 
 # Now install appropriate package for PG version
-sudo apt install timescaledb-2-postgresql-:pg_version:
+sudo apt install timescaledb-2-postgresql-13
 ```
 
 #### Upgrading from TimescaleDB 1.x
@@ -48,7 +48,7 @@ binaries. The feedback in your terminal should look similar to the following:
 
 ```bash
 Reading package lists... Done
-Building dependency tree       
+Building dependency tree
 Reading state information... Done
 The following additional packages will be installed:
   timescaledb-2-loader-postgresql-12

--- a/timescaledb/how-to-guides/install-timescaledb/installation-source-windows.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-source-windows.md
@@ -4,7 +4,7 @@
 
 #### Prerequisites
 
-- A standard **PostgreSQL :pg_version: 64-bit** installation
+- A standard **PostgreSQL 13 64-bit** installation
 - Visual Studio 2017 (with [CMake][] and Git components)
   **or** Visual Studio 2015/2016 (with [CMake][] version 3.11+ and Git components)
 - Make sure all relevant binaries are in your PATH: `pg_config` and `cmake`

--- a/timescaledb/how-to-guides/install-timescaledb/installation-source.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-source.md
@@ -4,7 +4,7 @@
 
 #### Prerequisites
 
-- A standard **PostgreSQL :pg_version:** installation with development environment (header files) (see https://www.postgresql.org/download/ for the appropriate package)
+- A standard **PostgreSQL 13** installation with development environment (header files) (see https://www.postgresql.org/download/ for the appropriate package)
 - C compiler (e.g., gcc or clang)
 - [CMake][] version 3.11 or greater
 

--- a/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
@@ -5,7 +5,7 @@
 #### Prerequisites
 
 - [Visual C++ Redistributable for Visual Studio 2015][c_plus] (included in VS 2015 and later)
-- A standard **PostgreSQL :pg_version: 64-bit** installation
+- A standard **PostgreSQL 13 64-bit** installation
 - Make sure all relevant binaries are in your PATH: (use [pg_config][])
 - Installation must be performed from an account with admin privileges
 
@@ -23,7 +23,7 @@ Press ENTER/Return key to close...
 Go ahead and press ENTER to close the window
 
 #### Updating from TimescaleDB 1.x to 2.0
-Once the latest TimescaleDB 2.0 are installed, you can update the EXTENSION 
+Once the latest TimescaleDB 2.0 are installed, you can update the EXTENSION
 in your database as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 
 #### Configure your database
@@ -45,7 +45,7 @@ Our standard binary releases are licensed under the Timescale License,
 which allows to use all our capabilities.
 To build a version of this software that contains
 source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
-to `bootstrap`.   
+to `bootstrap`.
 </highlight>
 
 [c_plus]: https://www.microsoft.com/en-us/download/details.aspx?id=48145

--- a/timescaledb/how-to-guides/install-timescaledb/installation-yum.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-yum.md
@@ -50,11 +50,11 @@ sudo yum update -y
 if command -v dnf; then sudo dnf -qy module disable postgresql; fi
 
 # Now install appropriate package for PG version
-sudo yum install -y timescaledb-2-postgresql-:pg_version:
+sudo yum install -y timescaledb-2-postgresql-13
 ```
 
 #### Upgrading from TimescaleDB 1.x
-If you are upgrading from TimescaleDB 1.x, the EXTENSION must be updated 
+If you are upgrading from TimescaleDB 1.x, the EXTENSION must be updated
 in the database as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 
 #### Configure your database
@@ -76,7 +76,7 @@ To get started you'll need to restart PostgreSQL and add
 a `postgres` [superuser][createuser] (used in the rest of the docs). Please
 refer to your distribution for how to restart services, for example:
 ```
-sudo -u postgres service postgres-:pg_version: start
+sudo -u postgres service postgres-13 start
 ```
 
 [pgdg]: https://yum.postgresql.org/repopackages.php

--- a/timescaledb/how-to-guides/install-timescaledb/timescale-forge.md
+++ b/timescaledb/how-to-guides/install-timescaledb/timescale-forge.md
@@ -1,8 +1,8 @@
 # Exploring Timescale Forge
 
-Welcome to Timescale Forge! Timescale Forge is a cloud-native TimescaleDB 
-as a service that is easy to get started and powerful enough for the most 
-demanding scenarios. You can 
+Welcome to Timescale Forge! Timescale Forge is a cloud-native TimescaleDB
+as a service that is easy to get started and powerful enough for the most
+demanding scenarios. You can
 [try Timescale Forge for free][forge-signup], no credit card required.
 
 This tutorial will walk you through setting up your Timescale Forge account and
@@ -16,13 +16,13 @@ Provide your full name, email address, and a strong password to start:
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-signup-page.png" alt="Sign up for Timescale Forge"/>
 
-You will need to confirm your account by clicking the link you receive via 
-email. If you do not receive this link, please first check your spam folder 
+You will need to confirm your account by clicking the link you receive via
+email. If you do not receive this link, please first check your spam folder
 and, failing that, please [contact us][contact-timescale].
 
 ### Step 2: Create your first service [](step2-create-service)
 
- After you complete account verification, you can visit the 
+ After you complete account verification, you can visit the
  [Timescale Forge console][forge-console] and login with your credentials.
 
  To begin, click 'Create service'.
@@ -30,26 +30,26 @@ and, failing that, please [contact us][contact-timescale].
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-creation.png" alt="Set up a Timescale Forge service"/>
 
 1. First, supply your service name (e.g., `acmecorp-test` or `acmecorp-dev`).
-1. Next, choose your CPU and memory configuration, from (0.25 CPU, 1GB RAM) to 
+1. Next, choose your CPU and memory configuration, from (0.25 CPU, 1GB RAM) to
 (8 CPU, 32 GB RAM).
-1. Select your storage requirements, from 10 GB to 1 TB.  Note that with TimescaleDB 
-compression, this is typically equivalent to 170 GB to 67+ TB of uncompressed 
+1. Select your storage requirements, from 10 GB to 1 TB.  Note that with TimescaleDB
+compression, this is typically equivalent to 170 GB to 67+ TB of uncompressed
 storage (although compression rates can vary based on your data).
-1. Note the estimated cost of running your chosen configuration. Feel free to 
-[contact us][contact-timescale] if you would like to discuss pricing and 
+1. Note the estimated cost of running your chosen configuration. Feel free to
+[contact us][contact-timescale] if you would like to discuss pricing and
 configuration options best suited for your use case.
 1. Click 'Create service' once your configuration is complete.
 
 <highlight type="tip">
 Don't worry if too much about the size settings that you choose initially. With
-Timescale Forge, it's easy to modify both the compute (CPU/Memory) and storage 
-associated with the service that you just created. As you get to know 
-TimescaleDB and how your data processing needs vary, it's easy to 
+Timescale Forge, it's easy to modify both the compute (CPU/Memory) and storage
+associated with the service that you just created. As you get to know
+TimescaleDB and how your data processing needs vary, it's easy to
 [right-size your service with a few clicks](#forge-resize)!
 </highlight>
 
 After you select 'Create service', you will see confirmation of your service account and
-password information. You should save the information in this confirmation screen in 
+password information. You should save the information in this confirmation screen in
 a safe place:
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-confirmation.png" alt="View Timescale Forge service information"/>
@@ -58,13 +58,13 @@ a safe place:
  If you forget your password in the future, you can reset your password from the *service dashboard*.
 </highlight>
 
-It will take a couple minutes for your service to be provisioned. When your database is 
+It will take a couple minutes for your service to be provisioned. When your database is
 ready for connection, you should see a green `Running` label above the service in the
 service dashboard.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-dashboard.png" alt="View all Timescale Forge services"/>
 
-Select any service to view *service details*. You can obtain connection, 
+Select any service to view *service details*. You can obtain connection,
 configuration, and utilization information. In addition, you can reset the
 password for your service, power down or power up any service (which stops
 or starts your compute, although your storage persists), or delete
@@ -99,22 +99,22 @@ Read about TimescaleDB features in our documentation:
 
 You’re now on your way to a great start with Timescale!
 
-You will have an unthrottled, 30-day free trial with Timescale Forge to 
-continue to test your use case. Before the end of your trial, we encourage you 
-to add your credit card information. This will ensure a smooth transition after 
+You will have an unthrottled, 30-day free trial with Timescale Forge to
+continue to test your use case. Before the end of your trial, we encourage you
+to add your credit card information. This will ensure a smooth transition after
 your trial period concludes.
 
 ### Summary
 
-We’re excited to play a small part in helping you build a best-in-class 
-time-series application or monitoring tool. If you have any questions, please 
-feel free to [join our community Slack group][slack-info] 
+We’re excited to play a small part in helping you build a best-in-class
+time-series application or monitoring tool. If you have any questions, please
+feel free to [join our community Slack group][slack-info]
 or [contact us][contact-timescale] directly.
 
 Now, it's time to forge!
 
 ## Advanced configuration and Multi-node setup
-Timescale Forge is a versatile hosting service that provides a growing list of 
+Timescale Forge is a versatile hosting service that provides a growing list of
 advanced features for your PostgreSQL and time-series data workloads.
 
 Please see additional documentation on how to:


### PR DESCRIPTION
The `:pg_version:` entity was not being replaced in the Installation docs. After discussion with @tedsczelecki we decided to hard code it. I've gone with 13, as it's the latest version, LMK if it should be 12.

Fixes: https://github.com/timescale/docs/issues/31