### PR TITLE
fix broken link

### DIFF
--- a/timescaledb/how-to-guides/hypertables/create.md
+++ b/timescaledb/how-to-guides/hypertables/create.md
@@ -26,7 +26,7 @@ SELECT create_hypertable('conditions', 'time');
 If you need to *migrate* data from an existing table to a hypertable, make
 sure to set the `migrate_data` argument to `true` when calling the function.
 If you would like finer control over index formation and other aspects
-of your hypertable, [follow these migration instructions instead](/timescaledb/latest/how-to-guides/migrate-existing-data).
+of your hypertable, [follow these migration instructions instead](/timescaledb/latest/how-to-guides/migrate-data).
 </highlight>
 
 <highlight type="warning">

--- a/timescaledb/how-to-guides/hypertables/create.md
+++ b/timescaledb/how-to-guides/hypertables/create.md
@@ -26,7 +26,7 @@ SELECT create_hypertable('conditions', 'time');
 If you need to *migrate* data from an existing table to a hypertable, make
 sure to set the `migrate_data` argument to `true` when calling the function.
 If you would like finer control over index formation and other aspects
-of your hypertable, [follow these migration instructions instead](/timescaledb/latest/how-to-guides/migrate-data).
+of your hypertable, [follow these migration instructions instead][migrate-date].
 </highlight>
 
 <highlight type="warning">
@@ -46,3 +46,4 @@ monotonically increasing id would work.
 [create_hypertable]: /api/:currentVersion:/hypertable/create_hypertable
 [create_distributed_hypertable]: /api/:currentVersion:/distributed-hypertables/create_distributed_hypertable
 [using-distributed-hypertables]: /how-to-guides/distributed-hypertables
+[migrate-data]/timescaledb/latest/how-to-guides/migrate-data

--- a/timescaledb/how-to-guides/hypertables/create.md
+++ b/timescaledb/how-to-guides/hypertables/create.md
@@ -27,7 +27,7 @@ scales out across multiple data nodes.
 If you need to *migrate* data from an existing table to a hypertable, make
 sure to set the `migrate_data` argument to `true` when calling the function.
 If you would like finer control over index formation and other aspects
-of your hypertable, [follow these migration instructions instead][migrate-date].
+of your hypertable, [follow these migration instructions instead][migrate-data].
 </highlight>
 
 <highlight type="warning">

--- a/timescaledb/how-to-guides/hypertables/create.md
+++ b/timescaledb/how-to-guides/hypertables/create.md
@@ -23,12 +23,10 @@ scales out across multiple data nodes.
  SELECT create_hypertable('conditions', 'time');
  ```
 
-<highlight type="tip">
 If you need to *migrate* data from an existing table to a hypertable, make
 sure to set the `migrate_data` argument to `true` when calling the function.
 If you would like finer control over index formation and other aspects
 of your hypertable, [follow these migration instructions instead][migrate-data].
-</highlight>
 
 <highlight type="warning">
 The use of the `migrate_data` argument to convert a non-empty table can

--- a/timescaledb/how-to-guides/hypertables/create.md
+++ b/timescaledb/how-to-guides/hypertables/create.md
@@ -3,24 +3,25 @@
 Creating a hypertable is a two-step process.
 <!-- add steps format?-->
 1. Create a standard table ([PostgreSQL docs][postgres-createtable]).
-```sql
-CREATE TABLE conditions (
-    time        TIMESTAMPTZ       NOT NULL,
-    location    TEXT              NOT NULL,
-    temperature DOUBLE PRECISION  NULL
-);
-```
 
-1. Then, execute the TimescaleDB
+ ```sql
+ CREATE TABLE conditions (
+     time        TIMESTAMPTZ       NOT NULL,
+     location    TEXT              NOT NULL,
+     temperature DOUBLE PRECISION  NULL
+ );
+ ```
+
+1. Execute the TimescaleDB
 [`create_hypertable`][create_hypertable] command on this newly created
 table, or use
 [`create_distributed_hypertable`][create_distributed_hypertable] to
 create a [distributed hypertable][using-distributed-hypertables] that
 scales out across multiple data nodes.
 
-```sql
-SELECT create_hypertable('conditions', 'time');
-```
+ ```sql
+ SELECT create_hypertable('conditions', 'time');
+ ```
 
 <highlight type="tip">
 If you need to *migrate* data from an existing table to a hypertable, make
@@ -46,4 +47,4 @@ monotonically increasing id would work.
 [create_hypertable]: /api/:currentVersion:/hypertable/create_hypertable
 [create_distributed_hypertable]: /api/:currentVersion:/distributed-hypertables/create_distributed_hypertable
 [using-distributed-hypertables]: /how-to-guides/distributed-hypertables
-[migrate-data] /timescaledb/latest/how-to-guides/migrate-data
+[migrate-data]: /how-to-guides/migrate-data

--- a/timescaledb/how-to-guides/hypertables/create.md
+++ b/timescaledb/how-to-guides/hypertables/create.md
@@ -46,4 +46,4 @@ monotonically increasing id would work.
 [create_hypertable]: /api/:currentVersion:/hypertable/create_hypertable
 [create_distributed_hypertable]: /api/:currentVersion:/distributed-hypertables/create_distributed_hypertable
 [using-distributed-hypertables]: /how-to-guides/distributed-hypertables
-[migrate-data]/timescaledb/latest/how-to-guides/migrate-data
+[migrate-data] /timescaledb/latest/how-to-guides/migrate-data


### PR DESCRIPTION
# Description

The link to https://docs.timescale.com/timescaledb/latest/how-to-guides/migrate-data/ from the https://docs.timescale.com/timescaledb/latest/how-to-guides/hypertables/create/#create-a-hypertable page was broken. This updates the broken link. Also fixes some other general issues with syntax on this page.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Report from community: https://timescaledb.slack.com/archives/C4GT3N90X/p1620696533186300
