### PR TITLE
Add missing link, and remove admon markup

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/manually-refresh-specific-ranges.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/manually-refresh-specific-ranges.md
@@ -15,7 +15,6 @@ would trigger a refresh of time buckets that are not yet completely
 filled. It might also materialize a lot of data, increase write
 amplification, and affect other policies such as data retention.
 
-<highlight type="tip">
 You should avoid refreshing time intervals that still see a lot
 of writes, which is usually the last bucket of the continuous
 aggregate. These intervals are still changing and are unlikely to
@@ -23,9 +22,10 @@ produce accurate aggregates, while at the same time slowing down the
 ingest rate of the hypertable due to write amplification. If you want
 to include the latest bucket in your queries, you should instead rely
 on [real-time aggregation][real-time-aggregates].
-</highlight>
 
 The `schedule_interval` option to `add_continuous_aggregate_policy`
 controls how frequently materialization jobs will be run. Setting a
 shorter interval will refresh more frequently but at the same time
 consume more background worker resources.
+
+[real-time-aggregates]: https://blog.timescale.com/blog/achieving-the-best-of-both-worlds-ensuring-up-to-date-results-with-real-time-aggregation/


### PR DESCRIPTION
# Description

Link was written, but no URL provided. This PR adds a URL, and removes the unnecessary admon markup.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Community report: https://timescaledb.slack.com/archives/C4GT3N90X/p1620772714211200 
