### PR TITLE
Updated with larger storage numbers.

### DIFF
--- a/timescale-forge/scaling-a-service.md
+++ b/timescale-forge/scaling-a-service.md
@@ -12,7 +12,7 @@ note the following limitations and when a change to these settings will result i
 within a few seconds. Other things to note about storage changes:
  * At the current time, storage can only be _increased_ in size.
  * Storage size changes can only be made once every six (6) hours.
- * Storage can be modified in various increments between 25GB and 4TB.
+ * Storage can be modified in various increments between 10GB and 10TB.
 
 **Compute**: Modifications to the compute size of your service (increases or 
 decreases) can be applied at any time, however, please note the following:


### PR DESCRIPTION
# Description

Updated storage limit from 4TB to 10TB.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
