### PR TITLE
Add back missing link refs

### DIFF
--- a/api/compression.md
+++ b/api/compression.md
@@ -20,5 +20,8 @@ decompress the chunk(s) first.
 
 Starting with TimescaleDB 2.1, users have the ability to modify the schema
 of hypertables that have compressed chunks.
-Specifically, you can add columns to and rename existing columns of 
+Specifically, you can add columns to and rename existing columns of
 such compressed hypertables.
+
+[blog-compression]: https://blog.timescale.com/blog/building-columnar-compression-in-a-row-oriented-database/
+[using-compression]: /how-to-guides/compression/index/


### PR DESCRIPTION
# Description

The link references were missing from the bottom of the page. This PR adds them back so that the links work again.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

https://timescaledb.slack.com/archives/C63MYDZ35/p1621460405005700
