### PR TITLE
Updated Forge compute numbers

### DIFF
--- a/timescale-forge/create-a-service.md
+++ b/timescale-forge/create-a-service.md
@@ -30,7 +30,7 @@ and, failing that, please [contact us][contact-timescale].
 
 1. First, supply your service name (e.g., `acmecorp-test` or `acmecorp-dev`).
 1. Next, choose your CPU and memory configuration, from (0.25 CPU, 1GB RAM) to
-(8 CPU, 32 GB RAM).
+(32 CPU, 128 GB RAM).
 1. Select your storage requirements, from 10 GB to 1 TB.  Note that with TimescaleDB
 compression, this is typically equivalent to 170 GB to 67+ TB of uncompressed
 storage (although compression rates can vary based on your data).


### PR DESCRIPTION
# Description

Updated compute numbers to 32CPU / 128GB RAM for the "create service" docs.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
