### PR TITLE
Update page-index.js

### DIFF
--- a/timescale-forge/page-index/page-index.js
+++ b/timescale-forge/page-index/page-index.js
@@ -7,12 +7,15 @@ module.exports = [
     excerpt: 'Timescale Forge is a fully managed TimescaleDB service that allows you to start querying data in less than a minute!',
     children: [
       {
+        title: "Create a service",
         href: "create-a-service",
       },
       {
+        title: "Scale a service",
         href: "scaling-a-service",
       },
       {
+        title: "Customize configuration",
         href: "customize-configuration",
       },
       {


### PR DESCRIPTION
# Description

The parsing mechanism for hrefs in sidebars capitalizes every "word" rather than using sentence capitalization.  This change is to correct that for the Forge items.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
