### PR TITLE
Fixes for a few broken links in the Continuous Aggregations How-To

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/adding-automatic-refresh-policies.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/adding-automatic-refresh-policies.md
@@ -9,7 +9,7 @@ use cases. For example, you might want to:
   source data from the hypertable.
 
 These use cases are supported by different configuration to
-[`add_continuous_aggregate_policy`][add-continuous-aggregate-policy].
+[`add_continuous_aggregate_policy`][api-add-continuous-aggregate-policy].
 
 This function takes three arguments:
 
@@ -94,3 +94,4 @@ DROP MATERIALIZED VIEW conditions_summary_hourly;
 
 [sec-data-retention]: /hot-to-guides/data-retention
 [api-drop-chunks]: /api/:currentVersion:/hypertable/drop_chunks
+[api-add-continuous-aggregate-policy]: /api/:currentVersion:/continuous-aggregates/add_continuous_aggregate_policy

--- a/timescaledb/how-to-guides/continuous-aggregates/best-practices.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/best-practices.md
@@ -91,5 +91,5 @@ SELECT min_time::timestamp FROM device_summary;
 
 
 
-[api-continuous-aggregates-info]: /api/:currentVersion:/informational-views/timescaledb_information-continuous_aggregates/
+[api-continuous-aggregates-info]: /api/:currentVersion:/informational-views/timescaledb_information.continuous_aggregates/
 [api-set-chunk-interval]: /api/:currentVersion:/hypertable/set_chunk_time_interval

--- a/timescaledb/how-to-guides/continuous-aggregates/best-practices.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/best-practices.md
@@ -91,5 +91,5 @@ SELECT min_time::timestamp FROM device_summary;
 
 
 
-[api-continuous-aggregates-info]: /api/:currentVersion:/informational-views/timescaledb_information.continuous_aggregates/
+[api-continuous-aggregates-info]: /api/:currentVersion:/informational-views/continuous_aggregates/
 [api-set-chunk-interval]: /api/:currentVersion:/hypertable/set_chunk_time_interval

--- a/timescaledb/how-to-guides/continuous-aggregates/drop-raw-data.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/drop-raw-data.md
@@ -20,5 +20,5 @@ raw data has subsequently been dropped.
 
 
 [api-drop-chunks]: /api/:currentVersion:/hypertable/drop_chunks
-[retention-aggregate]: /how-to-guides/data-retention-with-continuous-aggregates/
+[data-retention-with-continuous-aggregates]: /how-to-guides/data-retention-with-continuous-aggregates/
 [api-add-retention-policy]: /api/:currentVersion:/data-retention/add_retention_policy

--- a/timescaledb/how-to-guides/continuous-aggregates/drop-raw-data.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/drop-raw-data.md
@@ -1,7 +1,7 @@
 # Dropping raw data
 
 Note that if any still-refreshing (more recent than `start_offset`) part of the
-continuous aggregate is dropped via a [retention policy][api-add-retention] or
+continuous aggregate is dropped via a [retention policy][api-add-retention-policy] or
 direct [`drop_chunks`][api-drop-chunks] call, the aggregate will be updated to
 reflect the loss of data. For this reason, if it is desired to retain the continuous
 aggregate after dropping the underlying data, the `start_offset` of the aggregate
@@ -9,7 +9,7 @@ policy must be set to a smaller interval than the `drop_after` parameter of a
 hypertable's retention policy. Similiarly, when calling `drop_chunks`, extra
 care should also be taken to ensure that any such chunks are not within the
 refresh window of a continuous aggregate that still needs the data.  More detail
-and examples of this can be seen in the the [data retention documentation][retention-aggregate].
+and examples of this can be seen in the the [data retention documentation][data-retention-with-continuous-aggregates].
 
 This is also a consideration when manually refreshing a continuous aggregate.
 Calling `refresh_continuous_aggregate` on a region containing dropped chunks will

--- a/timescaledb/how-to-guides/continuous-aggregates/drop-raw-data.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/drop-raw-data.md
@@ -21,3 +21,4 @@ raw data has subsequently been dropped.
 
 [api-drop-chunks]: /api/:currentVersion:/hypertable/drop_chunks
 [retention-aggregate]: /how-to-guides/data-retention-with-continuous-aggregates/
+[api-add-retention-policy]: /api/:currentVersion:/data-retention/add_retention_policy


### PR DESCRIPTION
# Description

This PR fixes a few broken links in the caggs how-to pages.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

