### PR TITLE
Remove URL from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,6 @@ assignees: ''
 ---
 
 _Use this template for reporting bugs in the docs._
-_For bugs in the site, use https://github.com/timescale/web-documentation/issues/new instead_
 
 
 # Describe the bug


### PR DESCRIPTION
# Description

Removes URL to private repo from template.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
