### PR TITLE
fix broken links in yum install

### DIFF
--- a/timescaledb/how-to-guides/install-timescaledb/installation-yum.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-yum.md
@@ -80,9 +80,9 @@ sudo -u postgres service postgres-13 start
 ```
 
 [pgdg]: https://yum.postgresql.org/repopackages.php
-[config]: /administration/configuration/
+[config]: /how-to-guides/configuration/
 [createuser]: https://www.postgresql.org/docs/current/sql-createrole.html
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
 [multi-node-basic]: /how-to-guides/install-timescaledb/post-install-setup/-multi-node-basic
-[update-tsdb-2]: /update-timescaledb/update-tsdb-2
+[update-tsdb-2]: /how-to-guides/update-timescaledb/


### PR DESCRIPTION
# Description

Two xrefs in the yum install page were broken. This PR updates them to the correct pages.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/76
