### PR TITLE
add missing link refs

### DIFF
--- a/timescaledb/how-to-guides/user-defined-actions/create-and-register.md
+++ b/timescaledb/how-to-guides/user-defined-actions/create-and-register.md
@@ -41,3 +41,9 @@ To get a list of all currently registered jobs you can query
 ```sql
 SELECT * FROM timescaledb_information.jobs;
 ```
+
+[postgres-createfunction]: https://www.postgresql.org/docs/current/sql-createfunction.html
+[postgres-createprocedure]: https://www.postgresql.org/docs/current/sql-createprocedure.html
+[api-add_job]: api/add_job/
+[api-alter_job]: api/alter_job/
+[api-run_job]: api/run_job/


### PR DESCRIPTION
# Description

This page was missing its block of link references. This PR adds it back in.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

![image](https://user-images.githubusercontent.com/3914967/119585575-4a483d80-be0e-11eb-9bea-8adbe97c49fb.png)

