### PR TITLE
Fix TIME to time as it refers to the column

### DIFF
--- a/timescaledb/tutorials/analyze-cryptocurrency-data.md
+++ b/timescaledb/tutorials/analyze-cryptocurrency-data.md
@@ -616,7 +616,7 @@ SELECT
 FROM
    daily_factor
 GROUP BY
-   TIME
+   time
 ```
 
 ### Next steps


### PR DESCRIPTION
# Description

Just a small fix in the TIME as we up case only the SQL commands.

<img width="155" alt="Screen Shot 2021-05-26 at 14 49 58" src="https://user-images.githubusercontent.com/15484/119707564-ab353d00-be31-11eb-9f3e-abee447e0997.png">


# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

https://docs.timescale.com/timescaledb/latest/tutorials/analyze-cryptocurrency-data/
