### PR TITLE
Fix Windows installer URL

### DIFF
--- a/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
@@ -50,7 +50,7 @@ to `bootstrap`.
 
 [c_plus]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 [pg_config]: https://www.postgresql.org/docs/10/static/app-pgconfig.html
-[windows-dl]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-12_2.2.1-windows-amd64.zip
+[windows-dl]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-13_2.2.1-windows-amd64.zip
 [config]: /administration/configuration/
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/


### PR DESCRIPTION
# Description

Fix Windows installer URL to point to PostgreSQL 13 instead of 12.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

Fixes https://github.com/timescale/timescaledb/issues/3276
