### PR TITLE
Update pg version in all Install pages.

### DIFF
--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-debian.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-debian.md
@@ -2,7 +2,7 @@
 
 This will install TimescaleDB via `apt` on Debian distros.
 
-**Note: TimescaleDB requires PostgreSQL 11, 12 or 13.**
+**Note: TimescaleDB requires PostgreSQL 12 or 13.**
 
 #### Prerequisites
 

--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -2,7 +2,7 @@
 
 This will install TimescaleDB via `apt` on Ubuntu distros.
 
-**Note: TimescaleDB requires PostgreSQL 11, 12 or 13.**
+**Note: TimescaleDB requires PostgreSQL 12 or 13.**
 
 #### Prerequisites
 

--- a/timescaledb/how-to-guides/install-timescaledb/installation-homebrew.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-homebrew.md
@@ -2,7 +2,7 @@
 
 This will install both TimescaleDB *and* PostgreSQL via Homebrew.
 
-**Note: TimescaleDB requires PostgreSQL 11, 12 or 13.**
+**Note: TimescaleDB requires PostgreSQL 12 or 13.**
 
 #### Prerequisites
 

--- a/timescaledb/how-to-guides/install-timescaledb/installation-source-windows.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-source-windows.md
@@ -1,6 +1,6 @@
 ## From Source (Windows) [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 11 or 12.**
+**Note: TimescaleDB requires PostgreSQL 12 or 13.**
 
 #### Prerequisites
 

--- a/timescaledb/how-to-guides/install-timescaledb/installation-source.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-source.md
@@ -1,6 +1,6 @@
 ## From source [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 11, 12 or 13.**
+**Note: TimescaleDB requires PostgreSQL 12 or 13.**
 
 #### Prerequisites
 

--- a/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
@@ -1,6 +1,6 @@
 ## Windows ZIP Installer [](installation-windows)
 
-**Note: TimescaleDB requires PostgreSQL 11, 12 or 13.**
+**Note: TimescaleDB requires PostgreSQL 12 or 13.**
 
 #### Prerequisites
 

--- a/timescaledb/how-to-guides/install-timescaledb/installation-yum.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-yum.md
@@ -3,7 +3,7 @@
 This will install both TimescaleDB *and* PostgreSQL via `yum`
 (or `dnf` on Fedora).
 
-**Note: TimescaleDB requires PostgreSQL 11, 12 or 13.**
+**Note: TimescaleDB requires PostgreSQL 12 or 13.**
 
 #### Prerequisites
 

--- a/timescaledb/how-to-guides/update-timescaledb/index.md
+++ b/timescaledb/how-to-guides/update-timescaledb/index.md
@@ -1,12 +1,12 @@
 # Updating TimescaleDB versions [](update)
 
 The instructions below all you to update TimescaleDB within the same major release
-version (for example, from TimescaleDB 2.1 to 2.2, or from 1.7 to 1.7.4). If you need 
-to upgrade between TimescaleDB 1.x and 2.x, see our [separate upgrade document][update-tsdb-2] 
+version (for example, from TimescaleDB 2.1 to 2.2, or from 1.7 to 1.7.4). If you need
+to upgrade between TimescaleDB 1.x and 2.x, see our [separate upgrade document][update-tsdb-2]
 for detailed instructions.
 
-TimescaleDB supports **in-place updates only**: you don't need to dump and 
-restore your data, and versions are published with automated migration scripts 
+TimescaleDB supports **in-place updates only**: you don't need to dump and
+restore your data, and versions are published with automated migration scripts
 that convert any internal state if necessary.
 
 <highlight type="warning">
@@ -24,16 +24,16 @@ currently running a compatible release, please upgrade before updating Timescale
  --------------------|-------------------------------
  1.7                 | 9.6, 10, 11, 12
  2.0                 | 11, 12
- 2.1-2.3             | 11, 12, 13
+ 2.1-2.3             | 12, 13
  2.4+                | 12, 13
 
-If you need to upgrade PostgreSQL first, 
+If you need to upgrade PostgreSQL first,
 see [our documentation][upgrade-pg].
 
 <highlight type="tip">
-We always recommend that you update PostgreSQL and TimescaleDB as 
-separate actions to make sure that each process completes properly. 
-For example, if you are currently running PostgreSQL 10 and 
+We always recommend that you update PostgreSQL and TimescaleDB as
+separate actions to make sure that each process completes properly.
+For example, if you are currently running PostgreSQL 10 and
 TimescaleDB 1.7.5, and you want to upgrade to PostgreSQL 13 and
 TimescaleDB 2.2, upgrade in this order:
 

--- a/timescaledb/how-to-guides/update-timescaledb/update-timescaledb-2.md
+++ b/timescaledb/how-to-guides/update-timescaledb/update-timescaledb-2.md
@@ -18,16 +18,16 @@ currently running a compatible release, please upgrade before updating Timescale
  --------------------|-------------------------------
  1.7                 | 9.6, 10, 11, 12
  2.0                 | 11, 12
- 2.1-2.3             | 11, 12, 13
+ 2.1-2.3             | 12, 13
  2.4+                | 12, 13
 
-If you need to upgrade PostgreSQL first, 
+If you need to upgrade PostgreSQL first,
 see [our documentation][upgrade-pg].
 
 <highlight type="tip">
-We always recommend that you update PostgreSQL and TimescaleDB as 
-separate actions to make sure that each process completes properly. 
-For example, if you are currently running PostgreSQL 10 and 
+We always recommend that you update PostgreSQL and TimescaleDB as
+separate actions to make sure that each process completes properly.
+For example, if you are currently running PostgreSQL 10 and
 TimescaleDB 1.7.5, and you want to upgrade to PostgreSQL 13 and
 TimescaleDB 2.2, upgrade in this order:
 
@@ -38,8 +38,8 @@ TimescaleDB 2.2, upgrade in this order:
 </highlight>
 
 ### Notice of breaking changes from TimescaleDB 1.3+
-TimescaleDB 2.0 supports **in-place updates** just like previous releases. During 
-the update, scripts will automatically configure updated features to work as expected 
+TimescaleDB 2.0 supports **in-place updates** just like previous releases. During
+the update, scripts will automatically configure updated features to work as expected
 with TimescaleDB 2.0.
 
 Because this is our first major version release in two years, however, we’re providing additional guidance


### PR DESCRIPTION
# Description

Removes reference to pg11 pre-req in all install pages, and updates to pg 12 or 13.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/103
