### PR TITLE
Fix broken links in Grafana tutorial

### DIFF
--- a/timescaledb/tutorials/grafana/setup-alerts.md
+++ b/timescaledb/tutorials/grafana/setup-alerts.md
@@ -280,7 +280,7 @@ and PagerDuty (API or Integration Key).
 Complete your Grafana knowledge by following [all the TimescaleDB + Grafana tutorials][tutorial-grafana].
 
 [install-timescale]: /how-to-guides/install-timescaledb/
-[install-grafana]: /getting-started/installation-grafana
+[install-grafana]: /tutorials/grafana/installation
 [tutorial-prometheus]: /tutorials/tutorial-setup-timescale-prometheus
 [tutorial-grafana]: /tutorials/grafana
 [slack-webhook-instructions]: https://slack.com/help/articles/115005265063-Incoming-Webhooks-for-Slack


### PR DESCRIPTION
# Description

This fixes some broken links in the Grafana tutorial.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/126
Fixes https://github.com/timescale/docs/issues/125
