### PR TITLE
Pg11 compatibility fix

### DIFF
--- a/timescaledb/how-to-guides/update-timescaledb/index.md
+++ b/timescaledb/how-to-guides/update-timescaledb/index.md
@@ -24,7 +24,7 @@ currently running a compatible release, please upgrade before updating Timescale
  --------------------|-------------------------------
  1.7                 | 9.6, 10, 11, 12
  2.0                 | 11, 12
- 2.1-2.3             | 12, 13
+ 2.1-2.3             | 11, 12, 13
  2.4+                | 12, 13
 
 If you need to upgrade PostgreSQL first,

--- a/timescaledb/how-to-guides/update-timescaledb/update-timescaledb-2.md
+++ b/timescaledb/how-to-guides/update-timescaledb/update-timescaledb-2.md
@@ -18,7 +18,7 @@ currently running a compatible release, please upgrade before updating Timescale
  --------------------|-------------------------------
  1.7                 | 9.6, 10, 11, 12
  2.0                 | 11, 12
- 2.1-2.3             | 12, 13
+ 2.1-2.3             | 11, 12, 13
  2.4+                | 12, 13
 
 If you need to upgrade PostgreSQL first,


### PR DESCRIPTION
# Description

During the initial PR of these changes I inadvertently removed PG11 compatibility for TimescaleDB 2.1-2.3. This has caused confusion with some recent users.

# Version

Which documentation version does this PR apply to?

- [ ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links


