### PR TITLE
Update Windows link to 2.3.0 and show both PG 12 and 13

### DIFF
--- a/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
@@ -5,13 +5,13 @@
 #### Prerequisites
 
 - [Visual C++ Redistributable for Visual Studio 2015][c_plus] (included in VS 2015 and later)
-- A standard **PostgreSQL 13 64-bit** installation
+- A standard **PostgreSQL 12 or 13 64-bit** installation
 - Make sure all relevant binaries are in your PATH: (use [pg_config][])
 - Installation must be performed from an account with admin privileges
 
 #### Build and install
 
-1. Download the the [.zip file for your PostgreSQL version][windows-dl].
+1. Download the the .zip file for your PostgreSQL version - [12][windows-dl-12] or [13][windows-dl-13].
 1. Extract the zip file locally
 1. Run `setup.exe`, making sure that PostgreSQL is not currently running
 1. If successful, a `cmd.exe` window will pop open and you will see the following:
@@ -50,7 +50,8 @@ to `bootstrap`.
 
 [c_plus]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 [pg_config]: https://www.postgresql.org/docs/10/static/app-pgconfig.html
-[windows-dl]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-13_2.2.1-windows-amd64.zip
+[windows-dl-12]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-12_2.3.0-windows-amd64.zip
+[windows-dl-13]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-13_2.3.0-windows-amd64.zip
 [config]: /administration/configuration/
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/


### PR DESCRIPTION
# Description

The download link for Windows points to a version that was not the most recent one.

Also, even though PostgreSQL 12 is supported, there was no download link shown.

This PR updates the version and shows links for PG 12 and 13.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

