### PR TITLE
Fix SQL missing alias

### DIFF
--- a/timescaledb/getting-started/compress-data.md
+++ b/timescaledb/getting-started/compress-data.md
@@ -68,7 +68,7 @@ While we recommend using compression policies to automated compression data, the
 -- Manual compression
 ---------------------------------------------------
 SELECT compress_chunk(i)
-FROM show_chunks('weather_metrics', older_than => INTERVAL ' 10 years');
+FROM show_chunks('weather_metrics', older_than => INTERVAL ' 10 years') i;
 ```
 We can see the size of the compressed chunks before and after applying compression by using the following query:
 


### PR DESCRIPTION
# Description
Alias missing at the end of the sql statement. Found the inconsistency helping a user in the [community](https://timescaledb.slack.com/archives/C4GT3N90X/p1626175697283500).

I confirmed that all other statements are right.

<details>
  <summary> ~/c/t/docs on fix-sql-query ◦ ag -B 3 -A 2 "SELECT (de)?compress_chunk\(i\)"  </summary>

```
timescaledb/getting-started/compress-data.md
67----------------------------------------------------
68--- Manual compression
69----------------------------------------------------
70:SELECT compress_chunk(i)
71-FROM show_chunks('weather_metrics', older_than => INTERVAL ' 10 years') i;
72-```

timescaledb/how-to-guides/compression/decompress-chunks.md
30-To decompress a set of chunks based on a time range, you can use the output of
31-`show_chunks` to decompress each one:
32-```sql
33:SELECT decompress_chunk(i) from show_chunks('table_name', newer_than, older_than) i;
34-```
35-
--
105-    Repeat for each chunk. Alternatively, you can decompress a set of chunks
106-    based on a time range using `show_chunks`:
107-    ``` sql
108:    SELECT decompress_chunk(i) from show_chunks('conditions', newer_than, older_than) i;
109-    ```
110-1.  When you have decompressed all the chunks you want to modify, perform the

timescaledb/how-to-guides/compression/backfill-historical-data.md
69-time range by first looking up this set of chunks via `show_chunks`:
70-
71-``` sql
72:SELECT decompress_chunk(i) from show_chunks('conditions', newer_than, older_than) i;
73-```
74-

timescaledb/how-to-guides/compression/manually-compress-chunks.md
52-this:
53-
54-```sql
55:SELECT compress_chunk(i) from show_chunks('example', now() - interval '1 week', now() - interval '3 weeks') i;
56-```
57-
```

</details>

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)