### PR TITLE
Cleaned up left nav entries and tutorials pages for consistency

### DIFF
--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -8,7 +8,7 @@ module.exports = [
     excerpt: 'The API Reference is your go-to resource for all functions, VIEWs and special feature interfaces available with the TimescaleDB extension',
     children: [
       {
-        title: "Hypertables & Chunks",
+        title: "Hypertables & chunks",
         type: 'directory',
         href: "hypertable",
         children: [
@@ -91,7 +91,7 @@ module.exports = [
         ]
       },
       {
-        title: "Distributed Hypertables",
+        title: "Distributed hypertables",
         type: 'directory',
         href: "distributed-hypertables",
         children: [
@@ -165,7 +165,7 @@ module.exports = [
         ]
       },
       {
-        title: "Continuous Aggregates",
+        title: "Continuous aggregates",
         type: 'directory',
         href: "continuous-aggregates",
         children: [
@@ -196,7 +196,7 @@ module.exports = [
         ]
       },
       {
-        title: "Data Retention",
+        title: "Data retention",
         type: 'directory',
         href: "data-retention",
         children: [
@@ -211,7 +211,7 @@ module.exports = [
         ]
       },
       {
-        title: "Actions and Automation",
+        title: "Actions and automation",
         type: 'directory',
         href: "actions",
         children: [
@@ -259,7 +259,7 @@ module.exports = [
             href: "time_bucket"
           },  
           {
-            title: "Gapfilling and Interpolation",
+            title: "Gapfilling and interpolation",
             type: 'directory',
             href: "gapfilling-interpolation",
             children: [
@@ -278,7 +278,7 @@ module.exports = [
             ]
           },
           {
-            title: "Percentile Approximation",
+            title: "Percentile approximation",
             type: 'directory',
             href: "percentile-approximation",
             children: [
@@ -319,7 +319,7 @@ module.exports = [
                 href: "num_vals"
               },
               {
-                title: "Advanced Aggregation Methods",
+                title: "Advanced aggregation methods",
                 type: 'directory',
                 href: "percentile-aggregation-methods",
                 children: [
@@ -336,7 +336,7 @@ module.exports = [
             ]
           },
           {
-            title: "Time Weighted Averages",
+            title: "Time weighted averages",
             type: 'directory',
             href: "time-weighted-averages",
             children: [
@@ -357,7 +357,7 @@ module.exports = [
         ]
       },
       {
-        title: "Informational Views",
+        title: "Informational views",
         type: 'directory',
         href: "informational-views",
         children: [

--- a/timescale-cloud/page-index/page-index.js
+++ b/timescale-cloud/page-index/page-index.js
@@ -10,17 +10,18 @@ module.exports = [
         href: "create-a-service",
       },
       {
-        title: "Create a Multi-node Cluster",
+        title: "Create a multi-node cluster",
         href: "cloud-multi-node"
       },
       {
         href: "viewing-service-logs",
       },
       {
-        title: "VPC Peering",
+        title: "VPC peering",
         href: "vpc-peering",
       },
       {
+        title: "Security",
         href: "security",
       }
     ]

--- a/timescaledb/how-to-guides/page-index/page-index.js
+++ b/timescaledb/how-to-guides/page-index/page-index.js
@@ -328,12 +328,15 @@ module.exports = [
         ]
       },
       {
+        title: "User-defined actions",
         href: "user-defined-actions",
         children: [
           {
+            title: "Create and register",
             href: "create-and-register"
           },
           {
+            title: "Test and debug",
             href: "test-and-debug"
           },
           {
@@ -341,12 +344,15 @@ module.exports = [
             href: "alter-and-delete"
           },
           {
+            title: "Example of generic retention",
             href: "example-generic-retention"
           },
           {
+            title: "Example of tiered storage",
             href: "example-tiered-storage"
           },
           {
+            title: "Example of downsample and compress",
             href: "example-downsample-and-compress"
           }
         ]
@@ -355,12 +361,15 @@ module.exports = [
         href: "data-retention",
         children: [
           {
+            title: "Create a retention policy",
             href: "create-a-retention-policy"
           },
           {
+            title: "Manually drop chunks",
             href: "manually-drop-chunks"
           },
           {
+            title: "Data retention with continuous aggregates",
             href: "data-retention-with-continuous-aggregates"
           }
         ]
@@ -385,6 +394,7 @@ module.exports = [
         ]
       },
       {
+        title: "Backup and restore",
         href: "backup-and-restore",
         children: [
           {
@@ -402,6 +412,7 @@ module.exports = [
         ]
       },
       {
+        title: "Schema management",
         href: "schema-management",
         children: [
           {

--- a/timescaledb/how-to-guides/page-index/page-index.js
+++ b/timescaledb/how-to-guides/page-index/page-index.js
@@ -438,7 +438,7 @@ module.exports = [
         ]
       },
       {
-        title: "Migrate Existing Data",
+        title: "Migrate existing data",
         href: "migrate-data",
         children: [
           {

--- a/timescaledb/tutorials/analyze-cryptocurrency-data.md
+++ b/timescaledb/tutorials/analyze-cryptocurrency-data.md
@@ -1,4 +1,4 @@
-# Tutorial: Analyze cryptocurrency market data
+# Analyze cryptocurrency market data
 
 This tutorial is a step-by-step guide on how to analyze a time-series
 cryptocurrency dataset using TimescaleDB. The instructions in this tutorial

--- a/timescaledb/tutorials/index.md
+++ b/timescaledb/tutorials/index.md
@@ -6,9 +6,18 @@ Most of these tutorials require a working [installation of TimescaleDB][install-
 
 ### Common scenarios for using TimescaleDB
 
-- **[Time-series Forecasting][Forecasting]**: Use R, Apache MADlib and Python to perform
+- **[Introduction to TimescaleDB][nyc-taxi]**: The tried and true tutorial for learning TimescaleDB.
+- **[Time-series forecasting][Forecasting]**: Use R, Apache MADlib and Python to perform
 data analysis and make forecasts on your data.
-- **[Analyze Cryptocurrency Data][Crypto]**: Use TimescaleDB to analyze historic cryptocurrency data. Learn how to build your own schema, ingest data, and analyze information in TimescaleDB.
+- **[Analyze cryptocurrency data][Crypto]**: Use TimescaleDB to analyze historic cryptocurrency data. Learn how to build your own schema, ingest data, and analyze information in TimescaleDB.
+- **[Analyze intraday stock data][Stocks]**: One of the most common uses for time-series data is to collect intraday securities information. Learn how to collect stock data, store it in TimescaleDB, and perform the most common queries.
+- **[Build custom TimescaleDB dashboards][custom-dashboards]**: Learn how to obtain metrics data from TimescaleDB and visualize it using a basic React app.
+
+### Observability scenarios
+
+- **[Getting started with Promscale][promscale]**: Promscale is the long‑term store for Prometheus data, designed for analytics
+- **[Setup a Prometheus endpoint for Timescale Cloud][prometheus-tsc-endpoint]**: Learn how to create a monitoring system to ingest and analyze Prometheus metrics from your Timescale Cloud instance.
+- **[Monitor a Django application with Prometheus][monitor-django-prometheus]**: Use how to use Prometheus to monitor your Django application.
 
 ### Integrating with Grafana
 
@@ -18,9 +27,14 @@ data analysis and make forecasts on your data.
 - **[Visualizing Missing Data with Grafana][tutorial-grafana-missing-data]**: Learn how to visualize and aggregate missing time-series data in Grafana.
 - **[Setting up Grafana alerts][tutorial-grafana-alerts]**: Configure Grafana to alert you in Slack, PagerDuty, and more.
 
+### Other integrations
+
+- **[Collect metrics with Telegraf][telegraf]**: Telegraf is an extensible plug-in for collecting and outputting data.
+- **[Visualize data in Tableau][tableau]**: Tableau is a widely used business intelligence tool used to visualize data.
+
 ### Additional resources
 
-- **[Sample data sets][Data Sets]**: And if you want to explore on your own
+- **[Sample data sets][sample-data-sets]**: And if you want to explore on your own
 with some sample data, we have some ready-made data sets for you to explore.
 - **[Simulate IoT Sensor Data][simul-iot-data]**: Simulate a basic IoT sensor dataset
 on PostgreSQL or TimescaleDB.
@@ -34,18 +48,21 @@ and pick up some valuable `psql` tips and tricks along the way.
 [Continuous Aggregates]: /tutorials/continuous-aggs-tutorial
 [Outflux]: /tutorials/outflux
 [Grafana]: /tutorials/grafana
-[Telegraf Output Plugin]: /tutorials/telegraf-output-plugin
-[Data Sets]: /tutorials/sample-datasets
+[telegraf]: /tutorials/telegraf-output-plugin
+[sample-data-sets]: /tutorials/sample-datasets
 [install-timescale]: /how-to-guides/install-timescaledb/
+[promscale]: /tutorials/promscale/
 [psql]: /how-to-guides/connecting/psql/
 [Crypto]: /tutorials/analyze-cryptocurrency-data
-[Tableau]: /tutorials/visualizing-time-series-data-in-tableau
-[prometheus-tsc-endpoint]: /tutorials/tutorial-setting-up-timescale-cloud-endpoint-for-prometheus
-[monitor-django-prometheus]: /tutorials/tutorial-howto-monitor-django-prometheus
+[Stocks]: /tutorials/analyze-intraday-stocks/
+[custom-dashboard]: /tutorials/custom-timescaledb-dashboards/
+[tableau]: /tutorials/visualizing-time-series-data-in-tableau
+[prometheus-tsc-endpoint]: /tutorials/setting-up-timescale-cloud-endpoint-for-prometheus
+[monitor-django-prometheus]: /tutorials/howto-monitor-django-prometheus
 [tutorial-grafana-dashboards]: /tutorials/grafana/create-dashboard-and-panel
 [tutorial-grafana-geospatial]: /tutorials/grafana/geospatial-dashboards
 [tutorial-grafana-variables]: /tutorials/grafana/grafana-variables
 [tutorial-grafana-missing-data]: /tutorials/grafana/visualize-missing-data
 [tutorial-grafana-alerts]: /tutorials/grafana/setup-alerts
 [simul-iot-data]: /tutorials/simulate-iot-sensor-data
-
+[nyc-taxi]: /tutorials/nyc-taxi-cab/

--- a/timescaledb/tutorials/index.md
+++ b/timescaledb/tutorials/index.md
@@ -55,10 +55,10 @@ and pick up some valuable `psql` tips and tricks along the way.
 [psql]: /how-to-guides/connecting/psql/
 [Crypto]: /tutorials/analyze-cryptocurrency-data
 [Stocks]: /tutorials/analyze-intraday-stocks/
-[custom-dashboard]: /tutorials/custom-timescaledb-dashboards/
-[tableau]: /tutorials/visualizing-time-series-data-in-tableau
+[custom-dashboards]: /tutorials/custom-timescaledb-dashboards/
+[tableau]: /tutorials/visualize-with-tableau
 [prometheus-tsc-endpoint]: /tutorials/setting-up-timescale-cloud-endpoint-for-prometheus
-[monitor-django-prometheus]: /tutorials/howto-monitor-django-prometheus
+[monitor-django-prometheus]: /tutorials/monitor-django-prometheus
 [tutorial-grafana-dashboards]: /tutorials/grafana/create-dashboard-and-panel
 [tutorial-grafana-geospatial]: /tutorials/grafana/geospatial-dashboards
 [tutorial-grafana-variables]: /tutorials/grafana/grafana-variables

--- a/timescaledb/tutorials/monitor-django-with-prometheus.md
+++ b/timescaledb/tutorials/monitor-django-with-prometheus.md
@@ -1,4 +1,4 @@
-# Tutorial: How to monitor a Django application with Prometheus
+# How to monitor a Django application with Prometheus
 
 ## Introduction
 Prometheus is an open-source systems monitoring and alerting toolkit that can be

--- a/timescaledb/tutorials/monitor-timescale-cloud-with-prometheus.md
+++ b/timescaledb/tutorials/monitor-timescale-cloud-with-prometheus.md
@@ -1,4 +1,4 @@
-# Tutorial: How to set up a Prometheus endpoint for a Timescale Cloud database
+# How to set up a Prometheus endpoint for a Timescale Cloud database
 
 You can get more insights into the performance of your Timescale Cloud
 database by monitoring it using [Prometheus][get-prometheus], a popular

--- a/timescaledb/tutorials/nyc-taxi-cab.md
+++ b/timescaledb/tutorials/nyc-taxi-cab.md
@@ -1,4 +1,4 @@
-# Tutorial: New York City Taxicabs
+# Introduction to IoT: New York City Taxicabs
 
 Use case: IoT Analysis and Monitoring
 

--- a/timescaledb/tutorials/page-index/page-index.js
+++ b/timescaledb/tutorials/page-index/page-index.js
@@ -4,6 +4,36 @@ module.exports = [
         href: "tutorials",
         children: [
           {
+            title: "Introduction to IoT",
+            href: "nyc-taxi-cab"
+          },
+          {
+            title: "Introduction to time-series forecasting",
+            href: "time-series-forecast"
+          },
+          {
+            title: "Analyze cryptocurrency data",
+            href: "analyze-cryptocurrency-data"
+          },
+          {
+            title: "Analyze intraday stock data",
+            href: "analyze-intraday-stocks",
+            children: [
+              {
+                title: "Design database schema",
+                href: "design-schema"
+              },
+              {
+                title: "Fetch and ingest stock data",
+                href: "fetch-and-ingest"
+              },
+              {
+                title: "Explore stock market data",
+                href: "explore-stocks-data"
+              }
+            ]
+          },
+          {
             title: "Getting started with Promscale",
             href: "promscale",
             children: [
@@ -26,34 +56,16 @@ module.exports = [
             ]
           },
           {
-            title: "Introduction to IoT",
-            href: "nyc-taxi-cab"
+            title: "Monitor Timescale Cloud with Prometheus",
+            href: "setting-up-timescale-cloud-endpoint-for-prometheus"
           },
           {
-            title: "Introduction to time-series forecasting",
-            href: "time-series-forecast"
+            title: "Monitor a Django application with Prometheus",
+            href: "monitor-django-with-prometheus"
           },
           {
-            title: "Analyzing cryptocurrency data",
-            href: "analyze-cryptocurrency-data"
-          },
-          {
-            title: "Analyze intraday stock data",
-            href: "analyze-intraday-stocks",
-            children: [
-              {
-                title: "Design database schema",
-                href: "design-schema"
-              },
-              {
-                title: "Fetch and ingest stock data",
-                href: "fetch-and-ingest"
-              },
-              {
-                title: "Explore stock market data",
-                href: "explore-stocks-data"
-              }
-            ]
+            title: "Collect metrics with Telegraf",
+            href: "telegraf-output-plugin"
           },
           {
             title: "Grafana",
@@ -95,18 +107,6 @@ module.exports = [
           {
             title: "Simulate IoT Sensor Data",
             href: "simulate-iot-sensor-data"
-          },
-          {
-            title: "Monitor Timescale Cloud with Prometheus",
-            href: "setting-up-timescale-cloud-endpoint-for-prometheus"
-          },
-          {
-            title: "Collecting metrics with Telegraf",
-            href: "telegraf-output-plugin"
-          },
-          {
-            title: "Monitor a Django application with Prometheus",
-            href: "monitor-django-with-prometheus"
           },
           {
             href: "sample-datasets"

--- a/timescaledb/tutorials/setting-up-timescale-cloud-endpoint-for-prometheus.md
+++ b/timescaledb/tutorials/setting-up-timescale-cloud-endpoint-for-prometheus.md
@@ -1,4 +1,4 @@
-# Tutorial: How to set up a Prometheus endpoint for a Timescale Cloud database
+# How to set up a Prometheus endpoint for a Timescale Cloud database
 
 You can get more insights into the performance of your Timescale Cloud
 database by monitoring it using [Prometheus][get-prometheus], a popular

--- a/timescaledb/tutorials/simulate-iot-sensor-data.md
+++ b/timescaledb/tutorials/simulate-iot-sensor-data.md
@@ -1,4 +1,4 @@
-# Tutorial: How to simulate a basic IoT sensor dataset on PostgreSQL or TimescaleDB
+# How to simulate a basic IoT sensor dataset on PostgreSQL or TimescaleDB
 ## Introduction [](introduction)
 The Internet of Things (IoT) describes a trend where computing is
 becoming ubiquitous and is embedded in more and more physical things.

--- a/timescaledb/tutorials/time-series-forecast.md
+++ b/timescaledb/tutorials/time-series-forecast.md
@@ -1,4 +1,4 @@
-# Tutorial: Time-series forecasting
+# Time-series forecasting
 
 Time-series forecasting enables us to predict likely
 future values for a dataset based on historical time-series


### PR DESCRIPTION
# Description

Several elements of the left nav were inconsistently named. Also, the tutorials section didn't have a proper order. Cleaned up both for consistency.

# Version

Which documentation version does this PR apply to?

- [ ] Latest (Default)
- [X] Version 1.7
- [ ] Older [specify]

# Links

Fixes: https://github.com/timescale/docs/issues/166