### PR TITLE
Fix #181 broken link reference

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/index.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/index.md
@@ -19,7 +19,7 @@ only the data that has changed needs to be computed, not the entire dataset.
 [postgres-materialized-views]: https://www.postgresql.org/docs/current/rules-materializedviews.html
 [about-caggs]: /how-to-guides/continuous-aggregates/about-continuous-aggregates
 [cagg-create]: /how-to-guides/continuous-aggregates/create-a-continuous-aggregate
-[cagg-autorefresh]: /how-to-guides/continuous-aggregates/adding-automatic-refresh-policies
+[cagg-autorefresh]: /how-to-guides/continuous-aggregates/refresh-policies
 [cagg-time]: /how-to-guides/continuous-aggregates/time
 [cagg-drop]: /how-to-guides/continuous-aggregates/drop-data
 [cagg-mat-hypertables]: /how-to-guides/continuous-aggregates/materialized-hypertables


### PR DESCRIPTION
# Description

Adding refreshing policies on the autocomplete is redirecting to [this](https://docs.timescale.com/timescaledb/latest/how-to-guides/continuous-aggregates/adding-automatic-refresh-policies/) page that is broken as the content page changed to not say `adding-automatic` in the URL: https://docs.timescale.com/timescaledb/latest/how-to-guides/continuous-aggregates/refresh-policies/


[Add Refresh Policies] is also broken trying from [this link](https://docs.timescale.com/timescaledb/latest/how-to-guides/continuous-aggregates/#continuous-aggregates).



# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #181.
