### PR TITLE
Remove Postgres FDW, as remote connections not yet enabled

### DIFF
--- a/timescale-forge/customize-configuration.md
+++ b/timescale-forge/customize-configuration.md
@@ -101,7 +101,6 @@ These are the currently supported extensions:
 |postgis_sfcgal|PostGIS SFCGAL functions|
 |postgis_tiger_geocoder|PostGIS tiger geocoder and reverse geocoder|
 |postgis_topology|PostGIS topology spatial types and functions|
-|postgres_fdw|Foreign-data wrapper for remote PostgreSQL servers|
 |promscale|Promscale support functions|
 |seg|data type for representing line segments or floating-point intervals|
 |tablefunc|Functions that manipulate whole tables, including crosstab|


### PR DESCRIPTION
# Description

While the FDW extension might be installed, it's not yet enabled as the platform does not yet expose inter-service connections for security reasons.

# Version

Which documentation version does this PR apply to?

**N/A ?**

- [ ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
