### PR TITLE
Docs for timescaledb_experimental.time_bucket_ng()

### DIFF
--- a/api/experimental.md
+++ b/api/experimental.md
@@ -1,0 +1,8 @@
+# Experimental
+
+TimescaleDB exposes some experimental functionality to get early feedback from 
+the users. Corresponding functions, VIEWs, etc are available in 
+`timescaledb_experimental` schema. Please note that all experimental features 
+are **dangerous** in terms that they may have bugs, don't guarantee any 
+backward compatibility, and may be deleted in future releases. Use at your 
+own risk!

--- a/api/experimental.md
+++ b/api/experimental.md
@@ -1,8 +1,11 @@
 # Experimental
 
-TimescaleDB exposes some experimental functionality to get early feedback from 
-the users. Corresponding functions, VIEWs, etc are available in 
-`timescaledb_experimental` schema. Please note that all experimental features 
-are **dangerous** in terms that they may have bugs, don't guarantee any 
-backward compatibility, and may be deleted in future releases. Use at your 
-own risk!
+TimescaleDB includes some experimental functionality to get early feedback from
+users. These experimental functions are available in the `timescaledb_experimental`
+schema. 
+
+<highlight="warning">
+Experimental features could have bugs! They might not be backwards compatible,
+and could be removed in future releases. Use these features at your own risk, and
+do not use any experimental features in production.
+</highlight>

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -355,7 +355,7 @@ module.exports = [
             ]
           },          
         ]
-      },
+      }, 
       {
         title: "Informational views",
         type: 'directory',
@@ -421,7 +421,18 @@ module.exports = [
             href: "dump_meta_data"
           }
         ]
+      },
+      {
+        title: "Experimental",
+        type: 'directory',
+        href: "experimental",
+        children: [
+          {
+            title: "time_bucket_ng",
+            href: "time_bucket_ng"
+          }     
+        ]
       }
-],
+    ],
   }
 ]

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -87,4 +87,4 @@ For more information, see the [continuous aggregates documentation][caggs].
 
 
 [time_bucket]: hyperfunctions/time_bucket/
-[2]: https://docs.timescale.com/timescaledb/latest/overview/core-concepts/continuous-aggregates/
+[caggs]: timescaledb/latest/overview/core-concepts/continuous-aggregates/

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -32,7 +32,7 @@ SELECT timescaledb_experimental.time_bucket_ng('1 year', date '2021-08-01');
 (1 row)
 ```
 
-Here’s how to use `time_bucket_ng()` when creating continuous aggregates.
+You can also use `time_bucket_ng()` with continuous aggregates.
 In this case, we track the temperature in Moscow over 7 day intervals: 
 
 ```

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -5,6 +5,12 @@ similar to [`time_bucket()`][time_bucket], but works with years and
 months. It is expected that the feature will also support timezones
 in a future release.
 
+<highlight="warning">
+Experimental features could have bugs! They might not be backwards compatible,
+and could be removed in future releases. Use these features at your own risk, and
+do not use any experimental features in production.
+</highlight>
+
 Here’s how to use `time_bucket_ng()` to create bucket data in 3 month 
 intervals: 
 

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -1,8 +1,9 @@
 ## timescaledb_experimental.time_bucket_ng()
 
-`time_bucket_ng()` (**n**ew **g**eneration) is an experimental function
-similar to [`time_bucket()`][1], but it also works with years, month and 
-going to support timezones in the future.
+The `time_bucket_ng()` (new generation) experimental function is
+similar to [`time_bucket()`][time_bucket], but works with years and
+months. It is expected that the feature will also support timezones
+in a future release.
 
 Here’s how to use `time_bucket_ng()` to create bucket data in 3 month 
 intervals: 

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -86,5 +86,5 @@ ORDER BY bucket;
 For more information, see the [continuous aggregates documentation][caggs].
 
 
-[1]: https://docs.timescale.com/api/latest/hyperfunctions/time_bucket/
+[time_bucket]: hyperfunctions/time_bucket/
 [2]: https://docs.timescale.com/timescaledb/latest/overview/core-concepts/continuous-aggregates/

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -22,7 +22,7 @@ SELECT timescaledb_experimental.time_bucket_ng('3 month', date '2021-08-01');
 (1 row)
 ```
 
-Here’s how to use `time_bucket_ng()` to bucket data in 1 year intervals:
+This example uses `time_bucket_ng()` to bucket data in one year intervals:
 
 ```
 SELECT timescaledb_experimental.time_bucket_ng('1 year', date '2021-08-01');

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -33,7 +33,7 @@ SELECT timescaledb_experimental.time_bucket_ng('1 year', date '2021-08-01');
 ```
 
 You can also use `time_bucket_ng()` with continuous aggregates.
-In this case, we track the temperature in Moscow over 7 day intervals: 
+This example tracks the temperature in Moscow over seven day intervals: 
 
 ```
 CREATE TABLE conditions(

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -83,8 +83,7 @@ ORDER BY bucket;
 (3 rows)
 ```
 
-See the [Continuous Aggregates][2] docs for the general information about
-continuous aggregates and how to use them.
+For more information, see the [continuous aggregates documentation][caggs].
 
 
 [1]: https://docs.timescale.com/api/latest/hyperfunctions/time_bucket/

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -11,7 +11,7 @@ and could be removed in future releases. Use these features at your own risk, an
 do not use any experimental features in production.
 </highlight>
 
-Here’s how to use `time_bucket_ng()` to create bucket data in 3 month 
+In this example, `time_bucket_ng()` is used to create bucket data in three month 
 intervals: 
 
 ```


### PR DESCRIPTION
# Description

This PR adds the documentation to the new experimental schema and the experimental `time_bucket_ng()` function.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Nope 🤷‍♂️
