### PR TITLE
Ryanb 404 fixes

### DIFF
--- a/api/mean.md
+++ b/api/mean.md
@@ -17,7 +17,7 @@ You can simply compute a single percentile estimator and do not need to specify 
 
 |Name|Type|Description|
 |---|---|---|
-| `sketch` / `digest` | `UddSketch`/`tdigest` |  The sketch to extract the mean value from, usually from a [`percentile_agg()`](/hyperfunctions/percentile-approximation/aggregation-methods/percentile_agg/) call. |
+| `sketch` / `digest` | `UddSketch`/`tdigest` |  The sketch to extract the mean value from, usually from a [`percentile_agg()`](/hyperfunctions/percentile-approximation/percentile_agg/) call. |
 
 ### Returns
 

--- a/api/percentile_agg.md
+++ b/api/percentile_agg.md
@@ -7,7 +7,7 @@ percentile_agg(
 ```
 
 This is the default percentile aggregation function. It uses the [UddSketch
-algorithm](/hyperfunctions/percentile-approximation/aggregation-methods/uddsketch/)
+algorithm](/hyperfunctions/percentile-approximation/percentile-aggregation-methods/uddsketch/)
 with 200 buckets and an initial maximum error of 0.001. This is appropriate for
 most common use cases of percentile approximation. For more advanced use of
 percentile approximation algorithms,

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -86,5 +86,5 @@ ORDER BY bucket;
 For more information, see the [continuous aggregates documentation][caggs].
 
 
-[time_bucket]: hyperfunctions/time_bucket/
-[caggs]: timescaledb/latest/overview/core-concepts/continuous-aggregates/
+[time_bucket]: /hyperfunctions/time_bucket/
+[caggs]: /timescaledb/:currentVersion:/overview/core-concepts/continuous-aggregates/

--- a/timescaledb/getting-started/next-steps.md
+++ b/timescaledb/getting-started/next-steps.md
@@ -51,5 +51,5 @@ time-series data and data analysis using TimescaleDB.
 
 [migrate-data]: /how-to-guides/migrate-data/
 [visualize-data]: /tutorials/grafana/
-[connect-with-code]: /tutorials/quick-starts/
+[connect-with-code]: /quick-start/
 [sample-data]: /tutorials/sample-datasets/

--- a/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
+++ b/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
@@ -44,7 +44,7 @@ database and restore the data.
     SELECT timescaledb_post_restore();
     ```
 
-## Back up individual hypertables[](backup-hypertable)
+## Back up individual hypertables [](backup-hypertable)
 The `pg_dump` command provides flags that allow you to specify tables or schemas
 to back up. However, using these flags means that the dump lacks necessary
 information that TimescaleDB requires to understand the relationship between

--- a/timescaledb/overview/faq/faq-products.md
+++ b/timescaledb/overview/faq/faq-products.md
@@ -196,7 +196,7 @@ or [join our Slack group][join_slack].
 [SELECT]: /how-to-guides/query-data/select/
 [rdbms > nosql]: http://www.timescale.com/blog/time-series-data-why-and-how-to-use-a-relational-database-instead-of-nosql-d0cd6975e87c
 [benchmarks]: https://blog.timescale.com/blog/timescaledb-2-0-a-multi-node-petabyte-scale-completely-free-relational-database-for-time-series/
-[distributed-hypertable]: /timescaledb/:currentProduct:/how-to-guides/distributed-hypertables
+[distributed-hypertable]: /how-to-guides/distributed-hypertables
 [docs-architecture]: /overview/core-concepts/hypertables-and-chunks/
 [hypertable-best-practices]: /how-to-guides/hypertables/best-practices/
 [PostgreSQL-benchmark]: https://www.timescale.com/blog/timescaledb-vs-6a696248104e

--- a/timescaledb/overview/index.md
+++ b/timescaledb/overview/index.md
@@ -78,12 +78,12 @@ we leverage its characteristics when building TimescaleDB.
 If you prefer to learn by watching and want an intro to TimescaleDB, be
 sure to check out our [YouTube channel][youtube].
 
-[hyperfunctions]: /api/latest/hyperfunctions/
-[grafana]: /timescaledb/latest/tutorials/grafana/
-[continuous-aggregates]: /api/latest/continuous-aggregates/
-[multinode]: /api/latest/distributed-hypertables/
-[backups]: timescaledb/how-to-guides/backup-and-restore/
-[replication]: timescaledb/how-to-guides/replication-and-ha/
-[compression]: timescaledb/how-to-guides/compression/
-[data-retention]: timescaledb/how-to-guides/data-retention/
+[hyperfunctions]: /api/:currentVersion:/hyperfunctions/
+[grafana]: /tutorials/grafana/
+[continuous-aggregates]: /api/:currentVersion:/continuous-aggregates/
+[multinode]: /api/:currentVersion:/distributed-hypertables/
+[backups]: /how-to-guides/backup-and-restore/
+[replication]: /how-to-guides/replication-and-ha/
+[compression]: /how-to-guides/compression/
+[data-retention]: /how-to-guides/data-retention/
 [youtube]: https://www.youtube.com/c/TimescaleDB/featured/

--- a/timescaledb/overview/release-notes/changes-in-timescaledb-2.md
+++ b/timescaledb/overview/release-notes/changes-in-timescaledb-2.md
@@ -37,7 +37,7 @@ about the impetus for these changes and our design decisions. For a more in-dept
 
 Once you have read through this guide and understand the impact that upgrading to the latest
  version may have on your existing application and infrastructure, please follow our
- [upgrade to TimescaleDB 2.0](/how-to-guides/update-timescaledb/update-tsdb-2)
+ [upgrade to TimescaleDB 2.0](/how-to-guides/update-timescaledb/update-timescaledb-2/)
   documentation. You will find straight-forward instructions and recommendations to ensure
   everything is updated and works correctly.
 
@@ -446,7 +446,7 @@ separate retention policy on each continuous aggregate.
 *   [`add_retention_policy`](/api/:currentVersion:/data-retention/add_retention_policy), [`remove_retention_policy`](/api/:currentVersion:/data-retention/remove_retention_policy):  
 Creating (or removing) a data retention policy now has explicit functions. Additionally, the arguments `cascade`
 and `cascade_to_materializations` were removed (and behave as if the arguments were set to `false` in earlier versions).
-*   [`timescaledb_information.jobs`](/api/:currentVersion:/informational-views/timescaledb_information-jobs/): General information about data retention
+*   [`timescaledb_information.jobs`](/api/:currentVersion:/informational-views/jobs/): General information about data retention
 policies are now available in the main jobs view.
 
 #### Removed

--- a/timescaledb/quick-start/ruby.md
+++ b/timescaledb/quick-start/ruby.md
@@ -249,7 +249,7 @@ A hypertable is defined by a standard schema with column names and types, with a
 least one column specifying a time value.
 
 <highlight type="tip">
-The TimescaleDB documentation on [schema management and indexing](/how-to-guides/schema-management/)
+The TimescaleDB documentation on [schema management and indexing](/timescaledb/latest/how-to-guides/schema-management/)
 explains this in further detail.
 </highlight>
 
@@ -714,7 +714,7 @@ be sure to check out these advanced TimescaleDB tutorials:
 [indexing-api-guide]: /how-to-guides/schema-management/indexing/
 [crypto-tutorial]: /tutorials/analyze-cryptocurrency-data
 [time-series-forecasting]: /tutorials/time-series-forecast/
-[continuous-aggregates]: /tutorials/continuous-aggs-tutorial
+[continuous-aggregates]: /how-to-guides/continuous-aggregates/
 [other-samples]: /tutorials/sample-datasets/
 [migrate]: /how-to-guides/migrate-data/
 [hypertables]: /overview/core-concepts/

--- a/timescaledb/tutorials/analyze-cryptocurrency-data.md
+++ b/timescaledb/tutorials/analyze-cryptocurrency-data.md
@@ -635,4 +635,4 @@ Ready for even more learning? Here's a few suggestions:
 [time-series-forecasting]: /tutorials/time-series-forecast/
 [continuous-aggregates]: /getting-started/create-cagg
 [other-samples]: /tutorials/sample-datasets/
-[migrate]: /how-to-guides/migrating-data/
+[migrate]: /how-to-guides/migrate-data/

--- a/timescaledb/tutorials/grafana/setup-alerts.md
+++ b/timescaledb/tutorials/grafana/setup-alerts.md
@@ -281,7 +281,7 @@ Complete your Grafana knowledge by following [all the TimescaleDB + Grafana tuto
 
 [install-timescale]: /how-to-guides/install-timescaledb/
 [install-grafana]: /tutorials/grafana/installation
-[tutorial-prometheus]: /tutorials/tutorial-setup-timescale-prometheus
+[tutorial-prometheus]: /tutorials/setting-up-timescale-cloud-endpoint-for-prometheus/
 [tutorial-grafana]: /tutorials/grafana
 [slack-webhook-instructions]: https://slack.com/help/articles/115005265063-Incoming-Webhooks-for-Slack
 [pagerduty-integration-key]: https://support.pagerduty.com/docs/services-and-integrations


### PR DESCRIPTION
# Description

After fixing some web-documentation issues, we re-ran MOZ. Many of the errors will be mitigated by a separate update to the redirect links (https://github.com/timescale/web-documentation/pull/202), but there are still valid errors in these documentation files. There will be a few more once we let all of this run it's course one more time, but these seem to be the most egregious right now.

Aiming to get below 10 4xx errors that we have control over by late next week. ;-) 

# Version

Which documentation version does this PR apply to?

- [ ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
