### PR TITLE
Move experimental features

### DIFF
--- a/api/copy_chunk_experimental.md
+++ b/api/copy_chunk_experimental.md
@@ -1,8 +1,14 @@
-## copy_chunk() <tag type="community">Community</tag>
+## copy_chunk() <tag type="community">Community</tag> <tag type="experimental">Experimental</tag>
 TimescaleDB allows you to copy existing chunks to a new location within a
 multi-node environment. This allows each data node to work both as a primary for
 some chunks and backup for others. If a data node fails, its chunks already
 exist on other nodes that can take over the responsibility of serving them.
+
+<highlight type="warning">
+Experimental features could have bugs! They might not be backwards compatible,
+and could be removed in future releases. Use these features at your own risk, and
+do not use any experimental features in production.
+</highlight>
 
 ### Required arguments
 

--- a/api/move_chunk_experimental.md
+++ b/api/move_chunk_experimental.md
@@ -1,9 +1,15 @@
-## move_chunk() <tag type="community">Community</tag>
+## move_chunk() <tag type="community">Community</tag> <tag type="experimental">Experimental</tag>
 TimescaleDB allows you to move chunks to other data nodes. This can be used
 when new data nodes are added to a cluster and you want to rebalance the storage
-across more nodes. It is also helpful when a node needs to be removed from the 
+across more nodes. It is also helpful when a node needs to be removed from the
 cluster, which can only happen once all chunks are replicated on other data
 nodes.
+
+<highlight type="warning">
+Experimental features could have bugs! They might not be backwards compatible,
+and could be removed in future releases. Use these features at your own risk, and
+do not use any experimental features in production.
+</highlight>
 
 ### Required arguments
 

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -126,6 +126,14 @@ module.exports = [
           {
             title: "set_replication_factor",
             href: "set_replication_factor"
+          },
+          {
+            title: "copy_chunk",
+            href: "copy_chunk_experimental"
+          },
+          {
+            title: "move_chunk",
+            href: "move_chunk_experimental"
           }
         ]
       },
@@ -274,6 +282,10 @@ module.exports = [
               {
                 title: "interpolate",
                 href: "interpolate"
+              },
+              {
+                title: "time_bucket_ng",
+                href: "time_bucket_ng"
               }
             ]
           },
@@ -422,25 +434,6 @@ module.exports = [
           }
         ]
       },
-      {
-        title: "Experimental",
-        type: 'directory',
-        href: "experimental",
-        children: [
-          {
-            title: "time_bucket_ng",
-            href: "time_bucket_ng"
-          },
-          {
-            title: "copy_chunk",
-            href: "copy_chunk_experimental"
-          },
-          {
-            title: "move_chunk",
-            href: "move_chunk_experimental"
-          }
-        ]
-      }
     ],
   }
 ]

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -267,6 +267,10 @@ module.exports = [
             href: "time_bucket"
           },
           {
+            title: "time_bucket_ng",
+            href: "time_bucket_ng"
+          },
+          {
             title: "Gapfilling and interpolation",
             type: 'directory',
             href: "gapfilling-interpolation",
@@ -282,10 +286,6 @@ module.exports = [
               {
                 title: "interpolate",
                 href: "interpolate"
-              },
-              {
-                title: "time_bucket_ng",
-                href: "time_bucket_ng"
               }
             ]
           },

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -1,4 +1,4 @@
-## timescaledb_experimental.time_bucket_ng()
+## timescaledb_experimental.time_bucket_ng() <tag type="experimental">Experimental</tag>
 
 The `time_bucket_ng()` (next generation) experimental function is
 similar to [`time_bucket()`][time_bucket], but works with years and
@@ -11,8 +11,8 @@ and could be removed in future releases. Use these features at your own risk, an
 do not use any experimental features in production.
 </highlight>
 
-In this example, `time_bucket_ng()` is used to create bucket data in three month 
-intervals: 
+In this example, `time_bucket_ng()` is used to create bucket data in three month
+intervals:
 
 ```
 SELECT timescaledb_experimental.time_bucket_ng('3 month', date '2021-08-01');
@@ -33,7 +33,7 @@ SELECT timescaledb_experimental.time_bucket_ng('1 year', date '2021-08-01');
 ```
 
 You can also use `time_bucket_ng()` with continuous aggregates.
-This example tracks the temperature in Moscow over seven day intervals: 
+This example tracks the temperature in Moscow over seven day intervals:
 
 ```
 CREATE TABLE conditions(


### PR DESCRIPTION
# Description

Move experimental features out of the 'experimental' directory, to their correct locations. Add the `experimental` tag (https://github.com/timescale/web-documentation/pull/220) and admonitions.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
