### PR TITLE
Add the toolkit as a pre-req to the tutorial.

### DIFF
--- a/timescaledb/tutorials/nfl-analytics/index.md
+++ b/timescaledb/tutorials/nfl-analytics/index.md
@@ -1,23 +1,22 @@
-# Analyze data using TimescaleDB continuous aggregates and hyperfunctions 
-
-This tutorial is a step-by-step guide on how to use TimescaleDB for analyzing time-series data. We will show you how to utilize TimescaleDB's continuous aggregates and hyperfunctions for faster and more efficient queries. 
+# Analyze data using TimescaleDB continuous aggregates and hyperfunctions
+This tutorial is a step-by-step guide on how to use TimescaleDB for analyzing time-series data. We will show you how to utilize TimescaleDB's continuous aggregates and hyperfunctions for faster and more efficient queries.
 We will also take advantage of a unique capability of TimescaleDB: the ability to
 join time-series data with relational data.
 
-The dataset that we're using is provided by the National Football League (NFL) 
-and contains player and tracking data for all the passing plays of the 2018 NFL 
-season. We're going to ingest this dataset with Python into TimescaleDB and start 
-exploring it to uncover insights about players and teams. 
+The dataset that we're using is provided by the National Football League (NFL)
+and contains player and tracking data for all the passing plays of the 2018 NFL
+season. We're going to ingest this dataset with Python into TimescaleDB and start
+exploring it to uncover insights about players and teams.
 
 If you happen to be a NFL fantasy football player, using
 some of this analysis on past data could be helpful in selecting the most effective
 players for the upcoming year. And, as the NFL releases new data throughout the
-upcoming season, you can ingest that data to help you make better decisions from 
+upcoming season, you can ingest that data to help you make better decisions from
 week to week.
 
 Even if you aren't an NFL fan, this tutorial provides a great example
 of how to ingest time-series data into TimescaleDB (even when it doesn't _seem_ like
-time-series data), how you can use plain SQL and TimescaleDB hyperfunctions to do 
+time-series data), how you can use plain SQL and TimescaleDB hyperfunctions to do
 powerful data analysis, and also visualize the data with Python.
 
 This tutorial has a few sections to help you on your journey:
@@ -34,18 +33,18 @@ This tutorial has a few sections to help you on your journey:
 4. [Visualize time-series play-by-play data](/tutorials/nfl-analytics/play-visualization/)
 
     For a little extra fun, create images that plot the movement of every player on the field for any play using Python and MatPlotlib.
-   
+
 ## Prerequisites
 
 * Python 3
-* TimescaleDB (see [installation options][install-timescale]) 
+* TimescaleDB (see [installation options][install-timescale])
 * [Psql][psql-install] or any other PostgreSQL client (e.g. DBeaver)
+* The [Timescale toolkit][toolkit]
 
 ## Download the dataset
 
 * [The NFL dataset is available for download on Kaggle.][kaggle-download]
 * [Additional stadium and scores dataset (.zip) (source: wikipedia.com).][extra-download]
-
 
 ## Resources
 
@@ -54,5 +53,6 @@ This tutorial has a few sections to help you on your journey:
 
 [install-timescale]: /how-to-guides/install-timescaledb/
 [psql-install]: /how-to-guides/connecting/psql
+[toolkit]: /how-to-guides/toolkit/
 [kaggle-download]: https://www.kaggle.com/c/nfl-big-data-bowl-2021/data
 [extra-download]: https://assets.timescale.com/docs/downloads/nfl_2018.zip

--- a/timescaledb/tutorials/nfl-analytics/index.md
+++ b/timescaledb/tutorials/nfl-analytics/index.md
@@ -53,6 +53,6 @@ This tutorial has a few sections to help you on your journey:
 
 [install-timescale]: /how-to-guides/install-timescaledb/
 [psql-install]: /how-to-guides/connecting/psql
-[toolkit]: /how-to-guides/toolkit/
+[toolkit]: /how-to-guides/install-timescaledb-toolkit
 [kaggle-download]: https://www.kaggle.com/c/nfl-big-data-bowl-2021/data
 [extra-download]: https://assets.timescale.com/docs/downloads/nfl_2018.zip

--- a/timescaledb/tutorials/nfl-analytics/ingest-and-query.md
+++ b/timescaledb/tutorials/nfl-analytics/ingest-and-query.md
@@ -215,7 +215,7 @@ contains multiple rows per player for each play (because the data is sampled
 multiple times per second during each play)
 
 <highlight type="important">
-These queries are examples of hyperfunctions. To access hyperfunctions, you need to have installed the  [Timescale toolkit][toolkit] before you begin.
+These queries are examples of hyperfunctions. To access hyperfunctions, you need to have installed the  [Timescale toolkit](/how-to-guides/toolkit/) before you begin.
 </highlight>
 
 ### Number of yards run in game for passing plays, by player and game
@@ -287,4 +287,3 @@ as you try to answer even more questions with TimescaleDB.
 [kaggle-download]: https://www.kaggle.com/c/nfl-big-data-bowl-2021/data
 [extra-download]: https://assets.timescale.com/docs/downloads/nfl_2018.zip
 [cagg]: /how-to-guides/continuous-aggregates/
-[toolkit]: /how-to-guides/toolkit/

--- a/timescaledb/tutorials/nfl-analytics/ingest-and-query.md
+++ b/timescaledb/tutorials/nfl-analytics/ingest-and-query.md
@@ -215,7 +215,7 @@ contains multiple rows per player for each play (because the data is sampled
 multiple times per second during each play)
 
 <highlight type="important">
-These queries are examples of hyperfunctions. To access hyperfunctions, you need to have installed the  [Timescale toolkit](/how-to-guides/install-timescaledb-toolkit) before you begin.
+These queries are examples of hyperfunctions. To access hyperfunctions, you need to have installed the  [Timescale toolkit](https://docs.timescale.com/timescaledb/latest/how-to-guides/install-timescaledb-toolkit) before you begin.
 </highlight>
 
 ### Number of yards run in game for passing plays, by player and game

--- a/timescaledb/tutorials/nfl-analytics/ingest-and-query.md
+++ b/timescaledb/tutorials/nfl-analytics/ingest-and-query.md
@@ -215,7 +215,7 @@ contains multiple rows per player for each play (because the data is sampled
 multiple times per second during each play)
 
 <highlight type="important">
-These queries are examples of hyperfunctions. To access hyperfunctions, you need to have installed the  [Timescale toolkit](/how-to-guides/toolkit/) before you begin.
+These queries are examples of hyperfunctions. To access hyperfunctions, you need to have installed the  [Timescale toolkit](/how-to-guides/install-timescaledb-toolkit) before you begin.
 </highlight>
 
 ### Number of yards run in game for passing plays, by player and game


### PR DESCRIPTION
# Description

The NFL tutorial did not include toolkit as a pre-req. This includes it in the index, and adds an admonition at the start of the queries section.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

- Fixes https://github.com/timescale/timescaledb/issues/3513
- Fixes https://github.com/timescale/docs/issues/347