### PR TITLE
Small line edits to time_bucket_ng API

### DIFF
--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -1,9 +1,9 @@
 ## timescaledb_experimental.time_bucket_ng() <tag type="experimental">Experimental</tag>
-
-The `time_bucket_ng()` (next generation) experimental function is
-similar to [`time_bucket()`][time_bucket], but works with years and
-months. It is expected that the feature will also support timezones
-in a future release.
+The `time_bucket_ng()` (next generation) experimental function is an updated
+version of  the original [`time_bucket()`][time_bucket] function. While
+`time_bucket` works with small units of time, the `time_bucket_ng()` function
+uses years and months. The `time_bucket_ng()` function does not, at this stage,
+support timezones.
 
 <highlight type="warning">
 Experimental features could have bugs! They might not be backwards compatible,
@@ -32,8 +32,8 @@ SELECT timescaledb_experimental.time_bucket_ng('1 year', date '2021-08-01');
 (1 row)
 ```
 
-To split time into buckets we use a starting point in time called `origin`. The
-default origin is '2000-01-01'. `time_bucket_ng` can't work with timestamps
+To split time into buckets, use a starting point in time called `origin`. The
+default origin is `2000-01-01`. `time_bucket_ng` cannot use timestamps
 earlier than `origin`:
 
 ```
@@ -41,15 +41,12 @@ SELECT timescaledb_experimental.time_bucket_ng('100 years', timestamp '1988-05-0
 ERROR:  origin must be before the given date
 ```
 
-Going back in time from `origin` isn't possible in general case, especially
-when you consider time zones and DST. We could partially support it
-depending on the arguments, but it seems to be a bad user experience.
+Going back in time from `origin` isn't usually possible, especially when you
+consider timezones and daylight savings time (DST). Note also that there is no
+reasonable way to split time in variable-sized buckets (such as months) from an
+arbitrary `origin`, so `origin` defaults to the first day of the month.
 
-Note also that there is no reasonable way to split time in
-variable-sized buckets (e.g. months) from an arbitrary `origin`. For this
-reason the default `origin` is the first day of the month.
-
-To bypass named limitations it's possible to override the default `origin`:
+To bypass named limitations, you can override the default `origin`:
 
 ```
 -- working with timestamps before 2000-01-01
@@ -65,8 +62,8 @@ SELECT timescaledb_experimental.time_bucket_ng('1 week', timestamp '2021-08-26',
  2021-08-23 00:00:00
 ```
 
-You can use `time_bucket_ng()` with continuous aggregates.
-This example tracks the temperature in Moscow over seven day intervals:
+You can use `time_bucket_ng()` with continuous aggregates. This example tracks
+the temperature in Moscow over seven day intervals:
 
 ```
 CREATE TABLE conditions(

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -32,9 +32,9 @@ SELECT timescaledb_experimental.time_bucket_ng('1 year', date '2021-08-01');
 (1 row)
 ```
 
-To split time into buckets, use a starting point in time called `origin`. The
-default origin is `2000-01-01`. `time_bucket_ng` cannot use timestamps
-earlier than `origin`:
+To split time into buckets, `time_bucket_ng()` uses a starting point in time
+called `origin`. The default origin is `2000-01-01`. `time_bucket_ng` cannot use
+timestamps earlier than `origin`:
 
 ```
 SELECT timescaledb_experimental.time_bucket_ng('100 years', timestamp '1988-05-08');


### PR DESCRIPTION
# Description

Just some general tidy up.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Related to: https://github.com/timescale/docs/pull/308
