### PR TITLE
Update Windows download links to 2.4.1

### DIFF
--- a/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-windows.md
@@ -50,8 +50,8 @@ to `bootstrap`.
 
 [c_plus]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 [pg_config]: https://www.postgresql.org/docs/10/static/app-pgconfig.html
-[windows-dl-12]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-12_2.3.0-windows-amd64.zip
-[windows-dl-13]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-13_2.3.0-windows-amd64.zip
+[windows-dl-12]: https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-12_2.4.1-windows-amd64.zip
+[windows-dl-13]: https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-13_2.4.1-windows-amd64.zip
 [config]: /how-to-guides/configuration/
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/


### PR DESCRIPTION
# Description

The Windows download links were outdated, this PR updates them to 2.4.1

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Partial https://github.com/timescale/docs/issues/316
