### PR TITLE
Update install instructions

### DIFF
--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -26,7 +26,7 @@ which will download any required dependencies from the PostgreSQL repository:
 ```bash
 # Add our repository
 sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc |  sudo gpg --dearmor > /usr/share/keyrings/postgresql.keyring
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor > /usr/share/keyrings/postgresql.keyring
 sudo apt-get update
 
 # Now install appropriate package for PG version

--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -26,7 +26,7 @@ which will download any required dependencies from the PostgreSQL repository:
 ```bash
 # Add our repository
 sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc |  gpg --dearmor > /usr/share/keyrings/postgresql.keyring
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc |  sudo gpg --dearmor > /usr/share/keyrings/postgresql.keyring
 sudo apt-get update
 
 # Now install appropriate package for PG version

--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -13,7 +13,7 @@ non-obsolete releases.
 #### Build and install
 
 <highlight type="warning">
- If you have another PostgreSQL installation not via `apt`,
+If you have another PostgreSQL installation not via `apt`,
 this will likely cause problems.
 
 If you wish to maintain your current version of PostgreSQL outside
@@ -25,7 +25,7 @@ Add TimescaleDB's third party repository and install TimescaleDB,
 which will download any required dependencies from the PostgreSQL repository:
 ```bash
 # Add our repository
-echo "deb [signed-by=/usr/share/keyrings/postgresql.keyring] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc |  gpg --dearmor > /usr/share/keyrings/postgresql.keyring
 sudo apt-get update
 

--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -30,8 +30,8 @@ sudo sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
 Add the TimescaleDB third party repository and install TimescaleDB. This command
 downloads any required dependencies from the PostgreSQL repository:
 ```bash
-sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
-wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo gpg -o --dearmor > /usr/share/keyrings/timescale.keyring
+sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/timescale.keyring] https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main' > /etc/apt/sources.list.d/timescaledb.list"
+wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/timescale.keyring
 sudo apt-get update
 
 # Now install appropriate package for PG version

--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -26,7 +26,7 @@ which will download any required dependencies from the PostgreSQL repository:
 ```bash
 # Add our repository
 sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
-wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo gpg --dearmor > /usr/share/keyrings/postgresql.keyring
+wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo gpg -o --dearmor > /usr/share/keyrings/timescale.keyring
 sudo apt-get update
 
 # Now install appropriate package for PG version

--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -26,7 +26,7 @@ which will download any required dependencies from the PostgreSQL repository:
 ```bash
 # Add our repository
 sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor > /usr/share/keyrings/postgresql.keyring
+wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo gpg --dearmor > /usr/share/keyrings/postgresql.keyring
 sudo apt-get update
 
 # Now install appropriate package for PG version

--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -21,10 +21,15 @@ of `apt`, we recommend installing from source.  Otherwise, please be
 sure to remove non-`apt` installations before using this method.
 </highlight>
 
-Add TimescaleDB's third party repository and install TimescaleDB,
-which will download any required dependencies from the PostgreSQL repository:
+Add the PostgreSQL third party repository to get the latest PostgreSQL packages:
 ```bash
-# Add our repository
+sudo apt install postgresql-common
+sudo sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+```
+
+Add the TimescaleDB third party repository and install TimescaleDB. This command
+downloads any required dependencies from the PostgreSQL repository:
+```bash
 sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
 wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo gpg -o --dearmor > /usr/share/keyrings/timescale.keyring
 sudo apt-get update

--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-ubuntu.md
@@ -21,31 +21,21 @@ of `apt`, we recommend installing from source.  Otherwise, please be
 sure to remove non-`apt` installations before using this method.
 </highlight>
 
-**If you don't already have PostgreSQL installed**, add PostgreSQL's third
-party repository to get the latest PostgreSQL packages (if you are using Ubuntu older than 19.04):
-```bash
-# `lsb_release -c -s` should return the correct codename of your OS
-echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-sudo apt-get update
-```
-
 Add TimescaleDB's third party repository and install TimescaleDB,
-which will download any dependencies it needs from the PostgreSQL repo:
-<highlight type="tip">
-Users coming from previous versions that have installed the PPA,
-need to add the new Ubuntu package repository for the release of TimescaleDB 2.4.
-</highlight>
-
+which will download any required dependencies from the PostgreSQL repository:
 ```bash
 # Add our repository
-sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
-wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
+echo "deb [signed-by=/usr/share/keyrings/postgresql.keyring] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc |  gpg --dearmor > /usr/share/keyrings/postgresql.keyring
 sudo apt-get update
 
 # Now install appropriate package for PG version
 sudo apt install timescaledb-2-postgresql-13
 ```
+<highlight type="tip">
+Users coming from previous versions that have installed the PPA need to add the
+new Ubuntu package repository for the release of TimescaleDB 2.4.
+</highlight>
 
 #### Upgrading from TimescaleDB 1.x
 If you are upgrading from TimescaleDB 1.x, the `apt` package will first


### PR DESCRIPTION
# Description

Updates install instructions to avoid deprecated apt-key command.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/350