### PR TITLE
Small edit to multinode docs

### DIFF
--- a/timescaledb/how-to-guides/multi-node-setup/required-configuration.md
+++ b/timescaledb/how-to-guides/multi-node-setup/required-configuration.md
@@ -18,7 +18,7 @@ data nodes (if not already set, `150` is recommended).
   environment.
 * For consistency, if the transaction isolation level is set to `READ COMMITTED` it is
   automatically upgraded to `REPEATABLE READ` whenever a distributed operation
-  takes place. If the isolation level is `READ COMMITTED` or `SERIALIZABLE`, it is not changed.
+  takes place. If the isolation level is `SERIALIZABLE`, it is not changed.
 
 Each of the above settings parameters can be configured for the
 instance in `postgresql.conf`, typically located in the data


### PR DESCRIPTION
# Description

Remove 'repeatable' isolation level from multinode docs

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/329