### PR TITLE
Add command to install timescaledb-tools

### DIFF
--- a/timescaledb/how-to-guides/install-timescaledb/installation-apt-debian.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-apt-debian.md
@@ -72,6 +72,7 @@ file to include our library in the parameter `shared_preload_libraries`.
 The easiest way to get started is to run `timescaledb-tune`, which is
 installed by default when using `apt`:
 ```bash
+sudo apt install timescaledb-tools
 sudo timescaledb-tune
 ```
 


### PR DESCRIPTION
# Description

Adds the command to install the timescaledb-tools package before using timescaledb-tune.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/317
