### PR TITLE
Make sure window functions are listed as unsupported

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
@@ -47,11 +47,13 @@ operations.
 
 Continuous aggregates are supported for most aggregate functions that can be
 [parallelized by PostgreSQL][postgres-parallel-agg], including the standard
-aggregates like `SUM` and `AVG`. However, aggregates using `ORDER BY` and
-`DISTINCT` cannot be used with continuous aggregates since they are not possible
-to parallelize by PostgreSQL. TimescaleDB does not currently support the
-`FILTER` clause. You can also use more complex expressions on top of the
-aggregate functions, for example `max(temperature)-min(temperature)`.
+aggregates like `SUM` and `AVG`. You can also use more complex expressions on
+top of the aggregate functions, for example `max(temperature)-min(temperature)`.
+
+However, aggregates using `ORDER BY` and `DISTINCT` cannot be used with
+continuous aggregates since they are not possible to parallelize with PostgreSQL.
+TimescaleDB does not currently support the `FILTER` clause, or window functions
+in continuous aggregates. 
 
 To test out continuous aggregates, follow
 the [continuous aggregate tutorial][tutorial-caggs].

--- a/timescaledb/how-to-guides/continuous-aggregates/create-a-continuous-aggregate.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/create-a-continuous-aggregate.md
@@ -39,12 +39,15 @@ hypertable. Additionally, all functions and their arguments included in
 	     schedule_interval => INTERVAL '1 hour');
     ```
 
-Continuous aggregates are supported for most aggregate functions that can
-be [parallelized by PostgreSQL][postgres-parallel-agg], including the standard
-aggregates like `SUM` and `AVG`. However, aggregates using `ORDER BY` and
-`DISTINCT` cannot be used with continuous aggregates since they are not possible
-to parallelize by PostgreSQL. TimescaleDB does not currently support the
-`FILTER` clause.
+Continuous aggregates are supported for most aggregate functions that can be
+[parallelized by PostgreSQL][postgres-parallel-agg], including the standard
+aggregates like `SUM` and `AVG`. You can also use more complex expressions on
+top of the aggregate functions, for example `max(temperature)-min(temperature)`.
+
+However, aggregates using `ORDER BY` and `DISTINCT` cannot be used with
+continuous aggregates since they are not possible to parallelize with PostgreSQL.
+TimescaleDB does not currently support the `FILTER` clause, or window functions
+in continuous aggregates.
 
 ## Choosing an appropriate bucket interval
 Continuous aggregates require a `time_bucket` on the time partitioning column of

--- a/timescaledb/how-to-guides/continuous-aggregates/troubleshooting.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/troubleshooting.md
@@ -19,11 +19,15 @@ that continuous aggregates do not support, you see an error like this:
 ERROR:  invalid continuous aggregate view
 SQL state: 0A000
 ```
-Continuous aggregates are supported for most aggregate functions that can
-be [parallelized by PostgreSQL][postgres-parallel-agg], including the standard
-aggregates like `SUM` and `AVG`. However, aggregates using `ORDER BY` and
-`DISTINCT` cannot be used with continuous aggregates since they are not possible
-to parallelize by PostgreSQL. TimescaleDB does not currently support the
-`FILTER` clause.
+Continuous aggregates are supported for most aggregate functions that can be
+[parallelized by PostgreSQL][postgres-parallel-agg], including the standard
+aggregates like `SUM` and `AVG`. You can also use more complex expressions on
+top of the aggregate functions, for example `max(temperature)-min(temperature)`.
+
+However, aggregates using `ORDER BY` and `DISTINCT` cannot be used with
+continuous aggregates since they are not possible to parallelize with PostgreSQL.
+TimescaleDB does not currently support the `FILTER` clause, or window functions
+in continuous aggregates.
+
 
 [postgres-parallel-agg]: https://www.postgresql.org/docs/current/parallel-plans.html#PARALLEL-AGGREGATION


### PR DESCRIPTION
# Description

Reworded the relevant sections to make it clear that window functions are not supported.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/154
