### PR TITLE
Document the required and optional arguments of time_bucket_ng()

### DIFF
--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -30,6 +30,30 @@ it is the first day of the month and the year. This works better with monthly
 or annual aggregates.
 </highlight>
 
+### Required Arguments
+
+|Name|Type|Description|
+|---|---|---|
+| `bucket_width` | INTERVAL | A PostgreSQL time interval for how long each bucket is |
+| `ts` | DATE, TIMESTAMP or TIMESTAMPTZ | The timestamp to bucket |
+
+### Optional Arguments
+
+|Name|Type|Description|
+|---|---|---|
+| `origin` | Should be the same as `ts` | Buckets are aligned relative to this timestamp |
+| `timezone` | TEXT | The name of the timezone. The argument can be specified only if the type of `ts` is TIMESTAMPTZ |
+
+For backward compatibility with `time_bucket()` the `timezone` argument is
+optional. Note that if you call the TIMESTAMPTZ-version of the function
+without the `timezone` argument, the timezone defaults to the session's
+timezone and so the function can't be used with continuous aggregates.
+
+### Return value
+
+The function returns the bucket's start time. The return value type is the
+same as `ts`.
+
 ### Sample Usage
 
 In this example, `time_bucket_ng()` is used to create bucket data in three month


### PR DESCRIPTION
# Description

This PR adds the documentation of required and optional arguments of time_bucket_ng().

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

None.
