### PR TITLE
Fix the argument name in time_bucket() documentation

### DIFF
--- a/api/time_bucket.md
+++ b/api/time_bucket.md
@@ -24,7 +24,7 @@ or 1 hour.
 |Name|Type|Description|
 |---|---|---|
 | `bucket_width` | INTERVAL | A PostgreSQL time interval for how long each bucket is |
-| `time` | TIMESTAMP | The timestamp to bucket |
+| `ts` | TIMESTAMP | The timestamp to bucket |
 
 ### Optional Arguments
 
@@ -40,7 +40,7 @@ or 1 hour.
 |Name|Type|Description|
 |---|---|---|
 | `bucket_width` | INTEGER | The bucket width |
-| `time` | INTEGER | The timestamp to bucket |
+| `ts` | INTEGER | The timestamp to bucket |
 
 ### Optional Arguments
 
@@ -117,3 +117,4 @@ to the server's timezone setting.
  multi-day calls to time_bucket. The old behavior can be reproduced by passing
  2000-01-01 as the origin parameter to time_bucket.
 </highlight>
+


### PR DESCRIPTION
# Description

The documentation claims that the argument name of time_bucket() is `time` while in fact, it's name is `ts`.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

None
