### PR TITLE
Add link to developer docs on GH

### DIFF
--- a/promscale/index.md
+++ b/promscale/index.md
@@ -24,8 +24,10 @@ data from TimescaleDB. SQL queries can be directed to TimescaleDB directly.
 
 <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/promscale-arch.png" alt="Promscale architecture diagram"/>
 
-For a detailed description of this architecture, see our [design
-document][design-doc].
+For a detailed description of this architecture, see our
+[design document][design-doc].
+
+For more documentation, see our [developer documentation][promscale-gh-docs].
 
 
 [promscale-blog]: https://blog.timescale.com/blog/promscale-analytical-platform-long-term-store-for-prometheus-combined-sql-promql-postgresql/
@@ -33,3 +35,4 @@ document][design-doc].
 [slack]: https://slack.timescale.com/
 [promlabs]: https://promlabs.com/promql-compliance-test-results/2020-12-01/promscale
 [design-doc]: https://docs.google.com/document/d/1e3mAN3eHUpQ2JHDvnmkmn_9rFyqyYisIgdtgd3D1MHA/edit?usp=sharing
+[promscale-gh-docs]: https://github.com/timescale/promscale/tree/master/docs

--- a/promscale/install-promscale.md
+++ b/promscale/install-promscale.md
@@ -68,6 +68,7 @@ You can configure the Promscale Connector using flags at the command prompt, env
 All environment variables are prefixed with `PROMSCALE`.
 
 For more information about configuring Promscale, see the [Promscale CLI documentation][promscale-cli-github], or use the `promscale -h` command.
+For more documentation, see our [developer documentation][promscale-gh-docs].
 
 
 [tobs-demo]: https://youtu.be/MSvBsXOI1ks
@@ -78,3 +79,4 @@ For more information about configuring Promscale, see the [Promscale CLI documen
 [promscale-releases-github]: https://github.com/timescale/promscale/releases
 [promscale-config-github]: https://github.com/timescale/promscale/blob/master/docs/configuring_prometheus.md
 [promscale-cli-github]: https://github.com/timescale/promscale/blob/master/docs/cli.md
+[promscale-gh-docs]: https://github.com/timescale/promscale/tree/master/docs


### PR DESCRIPTION
# Description

Add link to Promscale developer docs on GitHub

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/389
