### PR TITLE
Fix typo in JSON docs

### DIFF
--- a/timescaledb/how-to-guides/schema-management/json.md
+++ b/timescaledb/how-to-guides/schema-management/json.md
@@ -20,7 +20,7 @@ efficient on table columns than inside of JSONB structures. Storage is also more
 efficient.
 
 2. We use the JSONB data type (that is, JSON stored in a binary format) and not the JSON data type. JSONB data types are
-are more efficient in both storage overhead and lookup performance.
+more efficient in both storage overhead and lookup performance.
 
 <highlight type="tip">
 Often, people use JSON for sparse data as opposed


### PR DESCRIPTION
# Description

Fix typo (double _are_) in [JSON support for semi-structured data](https://docs.timescale.com/timescaledb/latest/how-to-guides/schema-management/json/#indexing-json-fields).

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #440
