### PR TITLE
Emphasise unsupported, and add lcof tshooting

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
@@ -45,15 +45,16 @@ dataset, and automatically updates the view in the background. This does not add
 any maintenance burden to your database, and does not slow down `INSERT`
 operations.
 
+## Unsupported functions
 Continuous aggregates are supported for most aggregate functions that can be
 [parallelized by PostgreSQL][postgres-parallel-agg], including the standard
 aggregates like `SUM` and `AVG`. You can also use more complex expressions on
 top of the aggregate functions, for example `max(temperature)-min(temperature)`.
 
 However, aggregates using `ORDER BY` and `DISTINCT` cannot be used with
-continuous aggregates since they are not possible to parallelize with PostgreSQL.
-TimescaleDB does not currently support the `FILTER` clause, or window functions
-in continuous aggregates. 
+continuous aggregates since they are not possible to parallelize with
+PostgreSQL. TimescaleDB does not currently support `FILTER` or `JOIN` clauses,
+or window functions in continuous aggregates.
 
 To test out continuous aggregates, follow
 the [continuous aggregate tutorial][tutorial-caggs].

--- a/timescaledb/how-to-guides/continuous-aggregates/troubleshooting.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/troubleshooting.md
@@ -25,9 +25,26 @@ aggregates like `SUM` and `AVG`. You can also use more complex expressions on
 top of the aggregate functions, for example `max(temperature)-min(temperature)`.
 
 However, aggregates using `ORDER BY` and `DISTINCT` cannot be used with
-continuous aggregates since they are not possible to parallelize with PostgreSQL.
-TimescaleDB does not currently support the `FILTER` clause, or window functions
-in continuous aggregates.
-
+continuous aggregates since they are not possible to parallelize with
+PostgreSQL. TimescaleDB does not currently support `FILTER` or `JOIN` clauses,
+or window functions in continuous aggregates.
 
 [postgres-parallel-agg]: https://www.postgresql.org/docs/current/parallel-plans.html#PARALLEL-AGGREGATION
+
+## Queries using locf() do not return NULL values
+When you have a query that uses a last observation carried forward (locf)
+function, the query carries forward NULL values by default. If you want the
+function to ignore NULL values instead, you can set `treat_null_as_missing=TRUE`
+as the second parameter in the query. For example:
+```sql
+dev=# select * FROM (select time_bucket_gapfill(4, time,-5,13), locf(avg(v)::int,treat_null_as_missing:=true) FROM (VALUES (0,0),(8,NULL)) v(time, v) WHERE time BETWEEN 0 AND 10 GROUP BY 1) i ORDER BY 1 DESC;
+ time_bucket_gapfill | locf
+---------------------+------
+                  12 |    0
+                   8 |    0
+                   4 |    0
+                   0 |    0
+                  -4 |
+                  -8 |
+(6 rows)
+```


### PR DESCRIPTION
# Description

Moves limitations under its own heading, and adds `JOIN` as explicitly unsupported. Updates caggs tshooting section to include `JOIN` as unsupported, and adds a new section to troubleshoot lcof and NULL values.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

- Fixes https://github.com/timescale/timescaledb/issues/1466
- Fixes https://github.com/timescale/docs/issues/415
