### PR TITLE
Change URL to point to current pg docs

### DIFF
--- a/timescaledb/how-to-guides/replication-and-ha/replication.md
+++ b/timescaledb/how-to-guides/replication-and-ha/replication.md
@@ -389,13 +389,8 @@ high availability solution with automatic failover functionality.
 [timescale-streamrep-docker]: https://github.com/timescale/streaming-replication-docker
 [postgres-rslots-docs]: https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS
 [postgres-archive-docs]: https://www.postgresql.org/docs/current/static/continuous-archiving.html
-[postgres-wal-docs]: https://www.postgresql.org/docs/current/static/wal-intro.html
 [postgres-synchronous-commit-docs]: https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT
-[postgres-scram-docs]: https://www.postgresql.org/docs/current/static/sasl-authentication.html#SASL-SCRAM-SHA-256
-[hba-docs]: https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html
-[postgres-pgpass-docs]: https://www.postgresql.org/docs/current/static/libpq-pgpass.html
 [postgres-recovery-docs]: https://www.postgresql.org/docs/current/static/recovery-config.html
-[postgres-pgpass-docs]: https://www.postgresql.org/docs/current/static/libpq-pgpass.html
 [timescale-setup-docs]: /how-to-guides/install-timescaledb/post-install-setup/
 [postgres-pg-stat-replication-docs]: https://www.postgresql.org/docs/10/static/monitoring-stats.html#PG-STAT-REPLICATION-VIEW
 [pgctl-docs]: https://www.postgresql.org/docs/current/static/app-pg-ctl.html

--- a/timescaledb/how-to-guides/replication-and-ha/replication.md
+++ b/timescaledb/how-to-guides/replication-and-ha/replication.md
@@ -382,7 +382,7 @@ documentation][failover-docs]). [patroni][patroni-github] offers a configurable
 high availability solution with automatic failover functionality.
 
 [postgres-streaming-replication-docs]: https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION
-[postgres-partition-limitations]: https://www.postgresql.org/docs/10/static/logical-replication-restrictions.html
+[postgres-partition-limitations]: https://www.postgresql.org/docs/current/static/logical-replication-restrictions.html
 [postgres-logrep-docs]: https://www.postgresql.org/docs/current/static/logical-replication.html
 [timescale-docker]: https://github.com/timescale/timescaledb-docker
 [docker-postgres-scripts]: https://docs.docker.com/samples/library/postgres/#how-to-extend-this-image


### PR DESCRIPTION
# Description

Updates link to Postgres docs to use the most recent docs, instead of a specific version.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/454
