### PR TITLE
Adds an (unlinked) API template

### DIFF
--- a/api/_template.md
+++ b/api/_template.md
@@ -3,9 +3,13 @@
 
 <!---Any special notes about the API call-->
 
-<!--For more information about api_call(), see the [FIXME docs][link_ref]-->
+<!---For more information about api_call(), see the [FIXME docs][link_ref]-->
 
-<!---Admonitions-->
+<!---
+<highlight type="note"
+Use a highlight for any important information. Choose `note`, `important`, or `warning`.
+</highlight>
+-->
 
 ## Required Arguments
 

--- a/api/_template.md
+++ b/api/_template.md
@@ -1,0 +1,48 @@
+# api_call() <tag type="FIXME" content="FIXME" />
+<!---Single sentence description of the API call-->
+
+<!---Any special notes about the API call-->
+
+<!--For more information about api_call(), see the [FIXME docs][link_ref]-->
+
+<!---Admonitions-->
+
+## Required Arguments
+
+|Name|Type|Description|
+|-|-|-|
+|<FIXME>|<FIXME>|<FIXME>|
+
+<!---Any special notes about the required arguments-->
+
+### Optional Arguments
+
+|Name|Type|Description|
+|-|-|-|
+|<FIXME>|<FIXME>|<FIXME>|
+
+<!---Any special notes about the optional arguments-->
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|<FIXME>|<FIXME>|<FIXME>|
+
+<!---Any special notes about the returns-->
+
+## Sample Usage
+<!---Single sentence description of what this example does-->
+
+``` sql
+<FIXME>
+```
+
+<!---Single sentence description of what this example does-->
+
+``` sql
+<FIXME>
+```
+
+
+[link_ref]: timescaledb/:currentVersion:/how-to-guides/<FIXME>/


### PR DESCRIPTION
# Description

Our API docs are pretty inconsistent. This PR adds an API doc template at `api/_template.md` to help contributors stay consistent when they are writing new API docs.

Thanks to @gayyappan for the idea!

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
