### PR TITLE
Toolkit - hyperloglog content

### DIFF
--- a/api/distinct_count.md
+++ b/api/distinct_count.md
@@ -1,4 +1,4 @@
-# distinct_count() <tag type="experimental">Experimental</tag>
+# distinct_count()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
 The `distinct_count` function gets the number of distinct values from a
 hyperloglog.
 

--- a/api/distinct_count.md
+++ b/api/distinct_count.md
@@ -1,0 +1,42 @@
+# distinct_count() <tag type="experimental">Experimental</tag>
+The `distinct_count` function gets the number of distinct values from a
+hyperloglog.
+
+For more information about hyperloglog(), see the
+[Toolkit documentation][toolkit-hyperloglog].
+
+<!---
+<highlight type="note"
+Use a highlight for any important information. Choose `note`, `important`, or `warning`.
+</highlight>
+-->
+
+## Required Arguments
+
+|Name|Type|Description|
+|-|-|-|
+|hyperloglog|Hyperloglog|The hyperloglog to extract the count from.|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|distinct_count|BIGINT|The number of distinct elements counted by the hyperloglog.|
+
+<!---Any special notes about the returns-->
+
+## Sample Usage
+This example retrieves the distinct values from a hyperloglog
+called `hyperloglog`:
+
+``` sql
+SELECT toolkit_experimental.distinct_count(toolkit_experimental.hyperloglog(64, data))
+FROM generate_series(1, 100) data
+
+ distinct_count
+----------------
+            114
+```
+
+
+[toolkit-hyperloglog]: timescaledb/:currentVersion:/how-to-guides/toolkit/hyperloglog/

--- a/api/hyperloglog-functions.md
+++ b/api/hyperloglog-functions.md
@@ -1,0 +1,13 @@
+# hyperloglog() <tag type="experimental">Experimental</tag>
+TimescaleDB Toolkit provides an implementation of the hyperloglog estimator for
+`COUNT DISTINCT` approximations of any type that has a hash function.
+Timescale's hyperLogLog is implemented as an aggregate function in PostgreSQL.
+It does not support moving-aggregate mode, and are not ordered-set aggregates.
+It is restricted to values that have an extended hash function. They are
+parallelizable and are good candidates for continuous aggregation.
+
+For more information about hyperloglog(), see the
+[Toolkit documentation][toolkit-hyperloglog].
+
+
+[toolkit-hyperloglog]: timescaledb/:currentVersion:/how-to-guides/toolkit/hyperloglog/

--- a/api/hyperloglog-functions.md
+++ b/api/hyperloglog-functions.md
@@ -1,4 +1,4 @@
-# hyperloglog() <tag type="experimental">Experimental</tag>
+# hyperloglog()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
 TimescaleDB Toolkit provides an implementation of the hyperloglog estimator for
 `COUNT DISTINCT` approximations of any type that has a hash function.
 Timescale's hyperLogLog is implemented as an aggregate function in PostgreSQL.

--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -1,8 +1,6 @@
 # hyperloglog() <tag type="experimental">Experimental</tag>
-The `hyperloglog` function constructs and returns a Hyperloglog with at least
+The `hyperloglog` function constructs and returns a hyperloglog with at least
 the specified number of buckets over the given values.
-
-<!---Any special notes about the API call-->
 
 For more information about hyperloglog(), see the
 [Toolkit documentation][toolkit-hyperloglog].

--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -1,0 +1,51 @@
+# hyperloglog() <tag type="experimental">Experimental</tag>
+The `hyperloglog` function constructs and returns a Hyperloglog with at least
+the specified number of buckets over the given values.
+
+<!---Any special notes about the API call-->
+
+For more information about hyperloglog(), see the
+[Toolkit documentation][toolkit-hyperloglog].
+
+<!---
+<highlight type="note"
+Use a highlight for any important information. Choose `note`, `important`, or `warning`.
+</highlight>
+-->
+
+## Required Arguments
+
+|Name|Type|Description|
+|-|-|-|
+|buckets|integer|Number of buckets in the digest. Rounded up to the next power of 2, must be between 16 and 2^18.|
+|value|AnyElement| Column to count distinct elements. The type must have an extended, 64-bit, hash function.|
+
+Increasing the `buckets` argument usually provides more accuracy at the expense
+of more storage.
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|hyperloglog|hyperloglog|A hyperloglog object which can be passed to other hyperloglog APIs.|
+
+<!---Any special notes about the returns-->
+
+## Sample Usage
+This examples assumes you have a table called `samples`, that contains a column
+called `weights` that holds DOUBLE PRECISION values. This command returns a
+digest over that column:
+
+``` sql
+SELECT toolkit_experimental.hyperloglog(64, weights) FROM samples;
+```
+
+Alternatively, you can build a view from the aggregate that you can pass to
+other `tdigest` functions:
+
+``` sql
+CREATE VIEW digest AS SELECT toolkit_experimental.hyperloglog(64, data) FROM samples;
+```
+
+
+[toolkit-hyperloglog]: timescaledb/:currentVersion:/how-to-guides/toolkit/hyperloglog/

--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -1,4 +1,4 @@
-# hyperloglog() <tag type="experimental">Experimental</tag>
+# hyperloglog()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
 The `hyperloglog` function constructs and returns a hyperloglog with at least
 the specified number of buckets over the given values.
 

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -388,6 +388,10 @@ module.exports = [
                 title: 'distinct_count',
                 href: 'distinct_count',
               },
+              {
+                title: 'stderror',
+                href: 'stderror',
+              },
             ],
           },
         ],

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -371,6 +371,25 @@ module.exports = [
               },
             ],
           },
+          {
+            title: 'Hyperloglog Functions',
+            type: 'directory',
+            href: 'hyperloglog-functions',
+            children: [
+              {
+                title: 'hyperloglog',
+                href: 'hyperloglog',
+              },
+              {
+                title: 'rollup',
+                href: 'rollup-hyperloglog',
+              },
+              {
+                title: 'distinct_count',
+                href: 'distinct_count',
+              },
+            ],
+          },
         ],
       },
       {

--- a/api/rollup-hyperloglog.md
+++ b/api/rollup-hyperloglog.md
@@ -1,4 +1,4 @@
-## rollup()
+## rollup()  <tag type="toolkit">Toolkit</tag>
 
 ```SQL
 rollup(

--- a/api/rollup-hyperloglog.md
+++ b/api/rollup-hyperloglog.md
@@ -1,0 +1,39 @@
+## rollup()
+
+```SQL
+rollup(
+    log hyperloglog
+) RETURNS Hyperloglog
+```
+
+Returns a hyperloglog by aggregating over the union of the input elements.
+
+For more information about hyperloglog(), see the
+[Toolkit documentation][toolkit-hyperloglog].
+
+### Required arguments
+
+|Name| Type |Description|
+|---|---|---|
+|`log`|`Hyperloglog`|Column of Hyperloglogs to be united.|
+
+### Returns
+
+|Column|Type|Description|
+|---|---|---|
+|`hyperloglog`|`Hyperloglog`|A hyperloglog containing the count of the union of the input hyperloglogs.|
+
+
+### Sample usage
+
+```SQL
+SELECT toolkit_experimental.distinct_count(toolkit_experimental.rollup(logs))
+FROM (
+    (SELECT toolkit_experimental.hyperloglog(32, v::text) logs FROM generate_series(1, 100) v)
+    UNION ALL
+    (SELECT toolkit_experimental.hyperloglog(32, v::text) FROM generate_series(50, 150) v)
+) hll;
+ count
+-------
+   152
+```

--- a/api/stderror.md
+++ b/api/stderror.md
@@ -1,0 +1,59 @@
+# stderror() <tag type="experimental">Experimental</tag>
+The `stderror` function returns an estimate of the relative standard error of the hyperloglog, based on the hyperloglog error formula. Approximate results are:
+
+|precision|registers|error|bytes|
+|-|-|-|-|
+|4|16|0.2600|12|
+|5|32|0.1838|24|
+|6|64|0.1300|48|
+|7|128|0.0919|96|
+|8|256|0.0650|192|
+|9|512|0.0460|384|
+|10|1024|0.0325|768|
+|11|2048|0.0230||1536|
+|12|4096|0.0163|3072|
+|13|8192|0.0115|6144|
+|14|16384|0.0081|12288|
+|15|32768|0.0057|24576|
+|16|65536|0.0041|49152|
+|17|131072|0.0029|98304|
+|18|262144|0.0020|196608|
+
+For more information about hyperloglog(), see the
+[Toolkit documentation][toolkit-hyperloglog].
+
+<!---
+<highlight type="note"
+Use a highlight for any important information. Choose `note`, `important`, or `warning`.
+</highlight>
+-->
+
+## Required Arguments
+
+|Name|Type|Description|
+|-|-|-|
+|hyperloglog|Hyperloglog|The hyperloglog to extract the count from.|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|stderror|BIGINT|The number of distinct elements counted by the hyperloglog.|
+
+<!---Any special notes about the returns-->
+
+## Sample Usage
+This examples retrieves the standard error from a hyperloglog called `hyperloglog`:
+
+``` sql
+SELECT toolkit_experimental.stderror(toolkit_experimental.hyperloglog(64, data))
+FROM generate_series(1, 100) data
+
+ stderror
+----------
+     0.13
+
+```
+
+
+[toolkit-hyperloglog]: timescaledb/:currentVersion:/how-to-guides/toolkit/hyperloglog/

--- a/api/stderror.md
+++ b/api/stderror.md
@@ -1,4 +1,4 @@
-# stderror() <tag type="experimental">Experimental</tag>
+# stderror()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
 The `stderror` function returns an estimate of the relative standard error of the hyperloglog, based on the hyperloglog error formula. Approximate results are:
 
 |precision|registers|error|bytes|

--- a/timescaledb/how-to-guides/toolkit/about-toolkit.md
+++ b/timescaledb/how-to-guides/toolkit/about-toolkit.md
@@ -40,12 +40,17 @@ Toolkit queries, when you are used to it, you can use it to construct more and
 more complicated queries.
 
 ## Toolkit features
-Timescale Toolkit features are developed in the open. As features are developed they are categorized as experimental, beta, stable, or deprecated. The documentation on this page will focus on the stable features, but more information on our experimental features in development can be found in the [Toolkit repository][gh-docs].
+Timescale Toolkit features are developed in the open. As features are developed
+they are categorized as experimental, beta, stable, or deprecated. The
+documentation on this page focusses on the stable features, but more
+information on our experimental features in development can be found in the
+[Toolkit repository][gh-docs].
 
 |Feature|Notes|More information|
 |-------|-----|----------------|
 |Percentile Approximation|Efficient approximation of percentiles|[Percentile Approximation documentation][approx-percentile]|
 |Time-weighted averages|Average that weights each value based on duration|[Time-weighted average documentation][time-weighted-avg]|
+|Hyperloglog|Approximates any type that has a hash function|[Hyperloglog documentation][hyperloglog]|
 
 ## Contribute to Timescale Toolkit
 We want and need your feedback! What are the frustrating parts of analyzing
@@ -59,9 +64,9 @@ community-wide problems and incorporate as much feedback as possible.
 *   Add your own [feature request][gh-newissue].
 
 [gh-docs]: https://github.com/timescale/timescale-analytics/tree/main/docs
-[approx-percentile]: /how-to-guides/toolkit/approximate_percentile.md
-[time-weighted-avg]: /how-to-guides/toolkit/time-weighted-averages.md
-[doc-promscale]: /tutorials/promscale
+[approx-percentile]: /how-to-guides/toolkit/approximate_percentile
+[time-weighted-avg]: /how-to-guides/toolkit/time-weighted-averages
+[hyperloglog]: /how-to-guides/toolkit/hyperloglog
 [gh-discussions]: https://github.com/timescale/timescale-analytics/discussions
 [gh-proposed]: https://github.com/timescale/timescale-analytics/labels/proposed-feature
 [gh-requests]: https://github.com/timescale/timescale-analytics/labels/feature-request

--- a/timescaledb/how-to-guides/toolkit/hyperloglog.md
+++ b/timescaledb/how-to-guides/toolkit/hyperloglog.md
@@ -1,0 +1,36 @@
+# Hyperloglog
+Credibly coordinate user-centric quality vectors without dynamic platforms. Globally administrate alternative vortals and prospective interfaces. Dynamically negotiate synergistic solutions rather than enterprise infrastructures. Progressively reconceptualize parallel e-markets via progressive content. Enthusiastically transition scalable web-readiness rather than accurate mindshare.
+
+Holisticly exploit an expanded array of meta-services rather than progressive methodologies. Competently seize stand-alone ROI via open-source products. Enthusiastically benchmark extensible synergy rather than enterprise content. Objectively aggregate high standards in technology rather than interoperable methodologies. Authoritatively synthesize e-business relationships with 2.0 networks.
+
+## Run a hyperloglog query
+In this procedure, we are using an example table called `response_times` that contains information about how long a server takes to respond to API calls.
+
+### Procedure: Running a hyperloglog query
+1.  At the `psql` prompt, create a continuous aggregate that computes the daily aggregates:
+    ```sql
+    CREATE MATERIALIZED VIEW response_times_daily
+    WITH (timescaledb.continuous)
+    AS SELECT
+      time_bucket('1 day'::interval, ts) as bucket,
+      percentile_agg(response_time_ms)
+    FROM response_times
+    GROUP BY 1;
+    ```
+1.  Re-aggregate the aggregate to get the last 30 days, and look for the 95th percentile:
+    ```sql
+    SELECT approx_percentile(0.95, percentile_agg(percentile_agg)) as threshold
+    FROM response_times_daily
+    WHERE bucket >= time_bucket('1 day'::interval, now() - '30 days'::interval);
+    ```
+1.  You can also create an alert:
+    ```sql
+    WITH t as (SELECT approx_percentile(0.95, percentile_agg(percentile_agg)) as threshold
+    FROM response_times_daily
+    WHERE bucket >= time_bucket('1 day'::interval, now() - '30 days'::interval))
+
+    SELECT count(*)
+    FROM response_times
+    WHERE ts > now()- '1 minute'::interval
+    AND response_time_ms > (SELECT threshold FROM t);
+    ```

--- a/timescaledb/how-to-guides/toolkit/hyperloglog.md
+++ b/timescaledb/how-to-guides/toolkit/hyperloglog.md
@@ -1,7 +1,23 @@
 # Hyperloglog
-Credibly coordinate user-centric quality vectors without dynamic platforms. Globally administrate alternative vortals and prospective interfaces. Dynamically negotiate synergistic solutions rather than enterprise infrastructures. Progressively reconceptualize parallel e-markets via progressive content. Enthusiastically transition scalable web-readiness rather than accurate mindshare.
+Hyperloglog is used to find the cardinality of very large datasets. If you want
+to find the number of unique values, or cardinality, in a dataset, the time it
+takes to process this query is proportional to how large the dataset is. So if
+you wanted to find the cardinality of a dataset that contained only 20 entries,
+the calculation would be very fast. Finding the cardinality of a dataset that
+contains 20,000 or 20 million entries, however, can take a significant amount of
+time and compute resources.
 
-Holisticly exploit an expanded array of meta-services rather than progressive methodologies. Competently seize stand-alone ROI via open-source products. Enthusiastically benchmark extensible synergy rather than enterprise content. Objectively aggregate high standards in technology rather than interoperable methodologies. Authoritatively synthesize e-business relationships with 2.0 networks.
+Hyperloglog does not calculate the exact cardinality of a dataset, but rather
+estimates the number of unique values. It does this by converting the original
+data into a hash of random numbers that represents the cardinality of the
+dataset. This is not a perfect calculation of the cardinality, but it is usually
+within a margin of error of 2%.
+
+The benefit of hyperloglog on time-series data, is that it can continue to
+calculate the approximate cardinality of a dataset as it changes over time, by
+adding an entry to the hyperloglog hash as new data is retrieved, rather than
+recalculating the result for the entire dataset every time it is needed. This
+makes it an ideal candidate for using with continuous aggregates.
 
 ## Run a hyperloglog query
 In this procedure, we are using an example table called `response_times` that contains information about how long a server takes to respond to API calls.


### PR DESCRIPTION
# Description

Adds hyperloglog Toolkit content

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Partial: https://github.com/timescale/docs/issues/447
