### PR TITLE
add "what is toolkit?" on install page

### DIFF
--- a/timescaledb/how-to-guides/install-timescaledb-toolkit.md
+++ b/timescaledb/how-to-guides/install-timescaledb-toolkit.md
@@ -24,7 +24,7 @@ are available under the [Timescale Community Edition license](ts-license).
 Functionality within the TimescaleDB Toolkit extension is separated into two categories: experimental and stable.
 
 <highlight type="warning">
-Experimental APIs are still under active development, may not handle edge cases, and their performance will vary. They are subject to change across releases, which will lead to the dropping of objects you've created using these experimental features. Experimental functions and features are found in the toolkit_experimental schema.
+Toolkit experimental APIs are still under active development, may not handle edge cases, and their performance will vary. They are subject to change across releases, which will lead to the dropping of objects you've created using these experimental features. Experimental functions and features are found in the toolkit_experimental schema.
 </highlight>
 
 <highlight type="important">

--- a/timescaledb/how-to-guides/install-timescaledb-toolkit.md
+++ b/timescaledb/how-to-guides/install-timescaledb-toolkit.md
@@ -1,4 +1,4 @@
-# Install TimescaleDB Toolkit
+# Installing TimescaleDB Toolkit
 
 In order to use functions from the TimescaleDB Toolkit, you'll need to install
 it. If you are using [Timescale Forge][] to host your database, the Toolkit is already

--- a/timescaledb/how-to-guides/install-timescaledb-toolkit.md
+++ b/timescaledb/how-to-guides/install-timescaledb-toolkit.md
@@ -18,8 +18,8 @@ from source][install-source].
 
 ## What is TimescaleDB Toolkit?
 
-TimescaleDB Toolkit is an extension for TimescaleDB that gives users access to several unique "hyperfunctions" - SQL functions designed to make manipulation and analysis of time-series data in PostgreSQL simple and efficient. Hyperfunctions work on TimescaleDB hypertables, as well as regular PostgreSQL tables. All TimescaleDB Toolkit hyperfunctions
-are available under the Timescale Community Edition license.
+TimescaleDB Toolkit is an extension for TimescaleDB that gives users access to several unique "hyperfunctions" - SQL functions designed to make manipulation and analysis of time-series data in PostgreSQL simple and efficient. Hyperfunctions work on data in TimescaleDB hypertables, as well as data in regular PostgreSQL tables. All TimescaleDB Toolkit hyperfunctions
+are available under the [Timescale Community Edition license](ts-license).
 
 Functionality within the TimescaleDB Toolkit extension is separated into three categories: experimental, stable and deprecated.
 
@@ -40,3 +40,5 @@ For more on TimescaleDB Toolkit functions, explore the [API Reference documentat
 [timescale forge]: /timescale-forge/:currentVersion:/
 [timescale cloud]: /timescale-cloud/:currentVersion:/
 [install-source]: https://github.com/timescale/timescaledb-toolkit#-installing-from-source
+[ts-license]: /timescaledb/:currentVersion:/timescale-license-comparison/
+

--- a/timescaledb/how-to-guides/install-timescaledb-toolkit.md
+++ b/timescaledb/how-to-guides/install-timescaledb-toolkit.md
@@ -24,7 +24,7 @@ are available under the [Timescale Community Edition license](ts-license).
 Functionality within the TimescaleDB Toolkit extension is separated into two categories: experimental and stable.
 
 <highlight type="warning">
-Toolkit experimental APIs are still under active development, may not handle edge cases, and their performance will vary. They are subject to change across releases, which will lead to the dropping of objects you've created using these experimental features. Experimental functions and features are found in the toolkit_experimental schema.
+[Toolkit experimental APIs](#toolkit-experimental) are still under active development, may not handle edge cases, and their performance will vary. They are subject to change across releases, which will lead to the dropping of objects you've created using these experimental features. Experimental functions and features are found in the toolkit_experimental schema.
 </highlight>
 
 <highlight type="important">

--- a/timescaledb/how-to-guides/install-timescaledb-toolkit.md
+++ b/timescaledb/how-to-guides/install-timescaledb-toolkit.md
@@ -1,20 +1,42 @@
-# Installing TimescaleDB Toolkit
+# Install TimescaleDB Toolkit
 
-In order to use functions from the TimescaleDB Toolkit, you'll need to install 
+In order to use functions from the TimescaleDB Toolkit, you'll need to install
 it. If you are using [Timescale Forge][] to host your database, the Toolkit is already
-installed. 
+installed.
 
-On [Timescale Cloud][] you may need to run `CREATE EXTENSION timescaledb_toolkit;` 
-in each database that you need to use the functions with. 
+On [Timescale Cloud][] you may need to run `CREATE EXTENSION timescaledb_toolkit;`
+in each database that you need to use the functions with.
 
-If you already have it installed and are updating to the latest version, run 
+If you already have it installed and are updating to the latest version, run
 `ALTER EXTENSION timescaledb_toolkit UPDATE;`.
 
 ## Self-hosted install
+
 If you are hosting your own TimescaleDB database and need to install the TimescaleDB
 Toolkit first, follow the instructions provided at the GitHub repo to [install it
 from source][install-source].
 
-[Timescale Forge]: /timescale-forge/:currentVersion:/
-[Timescale Cloud]: /timescale-cloud/:currentVersion:/
+## What is TimescaleDB Toolkit?
+
+TimescaleDB Toolkit is an extension for TimescaleDB that gives users access to several unique "hyperfunctions" - SQL functions designed to make manipulation and analysis of time-series data in PostgreSQL simple and efficient. Hyperfunctions work on TimescaleDB hypertables, as well as regular PostgreSQL tables. All TimescaleDB Toolkit hyperfunctions
+are available under the Timescale Community Edition license.
+
+Functionality within the TimescaleDB Toolkit extension is separated into three categories: experimental, stable and deprecated.
+
+<highlight type="warning">
+Experimental APIs are still under active development, may not handle edge cases, and their performance will vary. They are subject to change across releases, which will lead to the dropping of objects you've created using these experimental features. Experimental functions and features are found in the toolkit_experimental schema.
+</highlight>
+
+<highlight type="important">
+Toolkit functions labeled as deprecated are removed from future releases and are no longer supported. Currently, there are no deprecated Toolkit functions.
+</highlight>
+
+<highlight type="note">
+Toolkit functions not labeled otherwise are stable - in this state, functionality is correct and performant. Stable APIs are found in releases and won't break in future releases.
+</highlight>
+
+For more on TimescaleDB Toolkit functions, explore the [API Reference documentation on hyperfunctions](/api/:currentVersion:/hyperfunctions/).
+
+[timescale forge]: /timescale-forge/:currentVersion:/
+[timescale cloud]: /timescale-cloud/:currentVersion:/
 [install-source]: https://github.com/timescale/timescaledb-toolkit#-installing-from-source

--- a/timescaledb/how-to-guides/install-timescaledb-toolkit.md
+++ b/timescaledb/how-to-guides/install-timescaledb-toolkit.md
@@ -21,17 +21,13 @@ from source][install-source].
 TimescaleDB Toolkit is an extension for TimescaleDB that gives users access to several unique "hyperfunctions" - SQL functions designed to make manipulation and analysis of time-series data in PostgreSQL simple and efficient. Hyperfunctions work on data in TimescaleDB hypertables, as well as data in regular PostgreSQL tables. All TimescaleDB Toolkit hyperfunctions
 are available under the [Timescale Community Edition license](ts-license).
 
-Functionality within the TimescaleDB Toolkit extension is separated into three categories: experimental, stable and deprecated.
+Functionality within the TimescaleDB Toolkit extension is separated into two categories: experimental and stable.
 
 <highlight type="warning">
 Experimental APIs are still under active development, may not handle edge cases, and their performance will vary. They are subject to change across releases, which will lead to the dropping of objects you've created using these experimental features. Experimental functions and features are found in the toolkit_experimental schema.
 </highlight>
 
 <highlight type="important">
-Toolkit functions labeled as deprecated are removed from future releases and are no longer supported. Currently, there are no deprecated Toolkit functions.
-</highlight>
-
-<highlight type="note">
 Toolkit functions not labeled otherwise are stable - in this state, functionality is correct and performant. Stable APIs are found in releases and won't break in future releases.
 </highlight>
 

--- a/timescaledb/how-to-guides/install-timescaledb-toolkit.md
+++ b/timescaledb/how-to-guides/install-timescaledb-toolkit.md
@@ -1,10 +1,10 @@
 # Installing TimescaleDB Toolkit
 
 In order to use functions from the TimescaleDB Toolkit, you'll need to install
-it. If you are using [Timescale Forge][] to host your database, the Toolkit is already
+it. If you are using [Timescale Cloud][cloud] to host your database, the Toolkit is already
 installed.
 
-On [Timescale Cloud][] you may need to run `CREATE EXTENSION timescaledb_toolkit;`
+On [Managed Service for TimescaleDB][mst] you may need to run `CREATE EXTENSION timescaledb_toolkit;`
 in each database that you need to use the functions with.
 
 If you already have it installed and are updating to the latest version, run
@@ -33,8 +33,8 @@ Toolkit functions not labeled experimental are stable - in this state, functiona
 
 For more on TimescaleDB Toolkit functions, explore the [API Reference documentation on hyperfunctions](/api/:currentVersion:/hyperfunctions/).
 
-[timescale forge]: /timescale-forge/:currentVersion:/
-[timescale cloud]: /timescale-cloud/:currentVersion:/
+[cloud]: /cloud/:currentVersion:/
+[mst]: /mst/:currentVersion:/
 [install-source]: https://github.com/timescale/timescaledb-toolkit#-installing-from-source
 [ts-license]: https://www.timescale.com/legal/licenses
 

--- a/timescaledb/how-to-guides/install-timescaledb-toolkit.md
+++ b/timescaledb/how-to-guides/install-timescaledb-toolkit.md
@@ -40,5 +40,5 @@ For more on TimescaleDB Toolkit functions, explore the [API Reference documentat
 [timescale forge]: /timescale-forge/:currentVersion:/
 [timescale cloud]: /timescale-cloud/:currentVersion:/
 [install-source]: https://github.com/timescale/timescaledb-toolkit#-installing-from-source
-[ts-license]: /timescaledb/:currentVersion:/timescale-license-comparison/
+[ts-license]: https://www.timescale.com/legal/licenses
 

--- a/timescaledb/how-to-guides/install-timescaledb-toolkit.md
+++ b/timescaledb/how-to-guides/install-timescaledb-toolkit.md
@@ -28,7 +28,7 @@ Functionality within the TimescaleDB Toolkit extension is separated into two cat
 </highlight>
 
 <highlight type="important">
-Toolkit functions not labeled otherwise are stable - in this state, functionality is correct and performant. Stable APIs are found in releases and won't break in future releases.
+Toolkit functions not labeled experimental are stable - in this state, functionality is correct and performant. Stable APIs are found in releases and won't break in future releases.
 </highlight>
 
 For more on TimescaleDB Toolkit functions, explore the [API Reference documentation on hyperfunctions](/api/:currentVersion:/hyperfunctions/).


### PR DESCRIPTION
# Description

Add what is TimescaleDB Toolkit section, as well as tagging breakdown, to Install TimescaleDB Toolkit page.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links
https://github.com/timescale/docs/issues/487
