### PR TITLE
Improve documentation for copy/move chunk

### DIFF
--- a/api/cleanup_copy_chunk_operation_experimental.md
+++ b/api/cleanup_copy_chunk_operation_experimental.md
@@ -1,0 +1,40 @@
+## cleanup_copy_chunk_operation() <tag type="community">Community</tag> <tag type="experimental">Experimental</tag>
+You can [copy][copy_chunk] or [move][move_chunk] a
+chunk to a new location within a multi-node environment. The
+operation happens over multiple transactions so, if it fails, it 
+is manually cleaned up using this function. Without cleanup,
+the failed operation might hold a replication slot open, which in turn
+prevents storage from being reclaimed. The operation ID is logged in
+case of a failed copy or move operation and is required as input to
+the cleanup function.
+
+<highlight type="warning">
+Experimental features could have bugs! They might not be backwards compatible,
+and could be removed in future releases. Use these features at your own risk, and
+do not use any experimental features in production.
+</highlight>
+
+### Required arguments
+
+|Name|Type|Description|
+|-|-|-|
+|`operation_id`|NAME|ID of the failed operation|
+
+### Sample usage
+
+Clean up a failed operation:
+
+```sql
+CALL timescaledb_experimental.cleanup_copy_chunk_operation('ts_copy_1_31');
+```
+
+Get a list of running copy or move operations:
+
+```sql
+SELECT * FROM _timescaledb_catalog.chunk_copy_operation;
+```
+
+
+[copy_chunk]: /api/:currentVersion:/distributed-hypertables/copy_chunk_experimental
+[move_chunk]: /api/:currentVersion:/distributed-hypertables/move_chunk_experimental
+

--- a/api/copy_chunk_experimental.md
+++ b/api/copy_chunk_experimental.md
@@ -18,8 +18,29 @@ do not use any experimental features in production.
 |`source_node`|NAME|Data node where the chunk currently resides|
 |`destination_node`|NAME|Data node where the chunk is to be copied|
 
+### Required settings
+When copying a chunk, the destination data node needs a way to
+authenticate with the data node that holds the source chunk. It is
+currently recommended to use a [password file][password-config] on the
+data node.
+
+The `wal_level` setting must also be set to `logical` or higher on
+data nodes from which chunks are copied. If you are copying or moving
+many chunks in parallel, you can increase `max_wal_senders` and
+`max_replication_slots`.
+
+### Failures
+When a copy operation fails, it sometimes creates objects and metadata on 
+the destination data node. It can also hold a replication slot open on the
+source data node. To clean up these objects and metadata, use
+[`cleanup_copy_chunk_operation`][cleanup_copy_chunk].
+
+
 ### Sample usage
 
 ``` sql
 CALL timescaledb_experimental.copy_chunk(‘_timescaledb_internal._dist_hyper_1_1_chunk’, ‘data_node_2’, ‘data_node_3’);
 ```
+
+[password-config]: /timescaledb/:currentVersion:/how-to-guides/multi-node-setup/node-communication#v1-set-the-password-encryption-method-for-access-node-and-data-nodes
+[cleanup_copy_chunk]: /api/:currentVersion:/distributed-hypertables/cleanup_copy_chunk_operation_experimental

--- a/api/move_chunk_experimental.md
+++ b/api/move_chunk_experimental.md
@@ -1,9 +1,8 @@
+
 ## move_chunk() <tag type="community">Community</tag> <tag type="experimental">Experimental</tag>
-TimescaleDB allows you to move chunks to other data nodes. This can be used
-when new data nodes are added to a cluster and you want to rebalance the storage
-across more nodes. It is also helpful when a node needs to be removed from the
-cluster, which can only happen once all chunks are replicated on other data
-nodes.
+TimescaleDB allows you to move chunks to other data nodes. Moving
+chunks is useful in order to rebalance a multi-node cluster or remove
+a data node from the cluster.
 
 <highlight type="warning">
 Experimental features could have bugs! They might not be backwards compatible,
@@ -19,14 +18,29 @@ do not use any experimental features in production.
 |`source_node`|NAME|Data node where the chunk currently resides|
 |`destination_node`|NAME|Data node where the chunk is to be copied|
 
+### Required settings
+When moving a chunk, the destination data node needs a way to
+authenticate with the data node that holds the source chunk. It is
+currently recommended to use a [password file][password-config] on the
+data node.
+
+The `wal_level` setting must also be set to `logical` or higher on
+data nodes from which chunks are moved. If you are copying or moving
+many chunks in parallel, you can increase `max_wal_senders` and
+`max_replication_slots`.
+
+### Failures
+When a move operation fails, it sometimes creates objects and metadata on 
+the destination data node. It can also hold a replication slot open on the
+source data node. To clean up these objects and metadata, use
+[`cleanup_copy_chunk_operation`][cleanup_copy_chunk].
 
 ### Sample usage
 
 ``` sql
 CALL timescaledb_experimental.move_chunk(‘_timescaledb_internal._dist_hyper_1_1_chunk’, ‘data_node_2’, ‘data_node_3’);
 ```
-```
 
-[postgres-cluster]: https://www.postgresql.org/docs/current/sql-cluster.html
-[postgres-altertable]: https://www.postgresql.org/docs/13/sql-altertable.html
-[using-data-tiering]: timescaledb/how-to-guides/data-tiering/
+[password-config]: /timescaledb/:currentVersion:/how-to-guides/multi-node-setup/node-communication#v1-set-the-password-encryption-method-for-access-node-and-data-nodes
+[cleanup_copy_chunk]: /api/:currentVersion:/distributed-hypertables/cleanup_copy_chunk_operation_experimental
+

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -138,6 +138,10 @@ module.exports = [
             title: 'move_chunk',
             href: 'move_chunk_experimental',
           },
+          {
+            title: 'cleanup_copy_chunk_operation',
+            href: 'cleanup_copy_chunk_operation_experimental',
+          },
         ],
       },
       {

--- a/timescaledb/how-to-guides/multi-node-setup/required-configuration.md
+++ b/timescaledb/how-to-guides/multi-node-setup/required-configuration.md
@@ -16,6 +16,10 @@ data nodes (if not already set, `150` is recommended).
   through the access node configuration if desired. This setting is disabled
   by default in PostgreSQL, but may be worth verifying in your specific
   environment.
+* Set the `wal_level` to `logical` or higher on data nodes to 
+  [move][move_chunk] or [copy][copy_chunk] chunks between
+  data nodes. If you are moving many chunks in parallel, consider 
+  increasing `max_wal_senders` and `max_replication_slots`.
 * For consistency, if the transaction isolation level is set to `READ COMMITTED` it is
   automatically upgraded to `REPEATABLE READ` whenever a distributed operation
   takes place. If the isolation level is `SERIALIZABLE`, it is not changed.
@@ -36,3 +40,5 @@ pg_ctl reload
 ```
 
 [configuration]: /how-to-guides/configuration
+[copy_chunk]: /api/:currentVersion:/distributed-hypertables/copy_chunk_experimental
+[move_chunk]: /api/:currentVersion:/distributed-hypertables/move_chunk_experimental


### PR DESCRIPTION
# Description

* Add `cleanup_copy_chunk_operation` to the API docs. This function
  deals with cleaning up failed copy or move operations.
* Add a note about required `wal_level` to the experimental API
  documentation for `copy_chunk` and `move_chunk`.
* Add references across the different sections for easier navigation.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
