### PR TITLE
Update screenshots for new branding - Timescale Cloud section

### DIFF
--- a/cloud/cloud-multi-node.md
+++ b/cloud/cloud-multi-node.md
@@ -112,7 +112,7 @@ local connection information that is used when setting up Service-to-Service,
 multi-node connections. Copy this hostname to use in the `add_data_node` command
 below.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-internal-dns.png" alt="Timescale Forge multi-node connection information"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-multinode-info.png" alt="Timescale Cloud multi-node connection information"/>
 
 Once you have the **password** and **internal, Multi-node** hostname for each
 data node Service, connect to the access node using the `tsdbadmin` user.

--- a/cloud/create-a-service.md
+++ b/cloud/create-a-service.md
@@ -8,7 +8,7 @@ account and completing your first tutorial project.
 Sign up for Timescale Cloud by visiting [console.cloud.timescale.com][cloud-signup].
 Provide your full name, email address, and a strong password to start:
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-signup-page.png" alt="Sign up for Timescale Forge"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-signup.png" alt="Sign up for Timescale Cloud"/>
 
 You need to confirm your account by clicking the link you receive by email.
 If you do not receive this link, check your spam folder first, then
@@ -20,32 +20,21 @@ When you have completed account verification, visit the
 
 To begin, click `Create service`.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/forge_create-db.png" alt="Set up a Timescale Forge service"/>
-
-1.  Supply your service name (for example, `acmecorp-test` or `acmecorp-dev`).
-1.  Choose your CPU and memory configuration, from 0.25&nbsp;CPU and 1&nbsp;GB
-    RAM, to 32&nbsp;CPU and 128&nbsp;GB RAM.
-1.  Select your storage requirements, from 10&nbsp;GB to 1&nbsp;TB.  Note that
-    with TimescaleDB compression, this is typically equivalent to 170&nbsp;GB
-    to 67&nbsp;TB or more of uncompressed storage (although compression rates can vary based on your data).
-1.  Note the estimated cost of running your chosen configuration. Feel free to
-    [contact us][contact-timescale] if you would like to discuss pricing and
-    configuration options best suited for your use case.
-1.  Click `Create service` when your configuration is complete.
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-createdb.png" alt="Set up a Timescale Cloud service"/>
 
 <highlight type="tip">
 Don't worry too much about the size settings that you choose initially.
 With Timescale Cloud, it's easy to modify both the compute (CPU/Memory) and
 storage associated with the service that you just created. As you get to know
-TimescaleDB and how your data processing needs vary, it's easy to [right-size
-your service with a few clicks](/cloud/latest/scaling-a-service/)!
+TimescaleDB and how your data processing needs vary, it's easy to
+[right-size your service with a few clicks](/cloud/latest/scaling-a-service/)!
 </highlight>
 
 After you select `Create service`, you will see confirmation of your service
 account and password information. You should save the information in this
 confirmation screen in a safe place:
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/forge_build-service.png" alt="View Timescale Forge service information"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-build-service.png" alt="View Timescale Cloud service information"/>
 
 <highlight type="warning">
 If you forget your password, you can reset it from the `Operations` menu in the service dashboard.
@@ -55,7 +44,7 @@ It takes a couple minutes for your service to be provisioned. When your
 database is ready for connection, a green `Running` label shows above
 the service in the service dashboard.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/forge_service-dash.png" alt="View all Timescale Forge services"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-service-dashboard.png" alt="View all Timescale Cloud services"/>
 
 Select any service to view *service details*. You can obtain connection,
 configuration, and utilization information. In addition, you can reset the
@@ -63,7 +52,7 @@ password for your service, power down or power up any service (which stops
 or starts your compute, although your storage persists), or delete
 a service altogether.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/forge_running-service.png" alt="View Timescale Forge service information"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-running-service.png" alt="View Timescale Cloud service information"/>
 
 ### Complete your first tutorial
 Congratulations! You are now up and running with Timescale Cloud. To

--- a/cloud/customize-configuration.md
+++ b/cloud/customize-configuration.md
@@ -23,7 +23,7 @@ To modify configuration parameters, first select the Service that you want to
 modify. This displays the `service details`, with these tabs across the top:
 Overview, Operations, Metrics, Logs, and Settings. Select `Settings`.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-basic.png" alt="View Timescale Forge service operational information"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-settings.png" alt="View Timescale Cloud service settings"/>
 
 ### Modify basic parameters
 Under the Settings tab, you can modify a limited set of the parameters that
@@ -32,7 +32,7 @@ configured value, click the value that you would like to change. This reveals
 an editable field to apply your change. Clicking anywhere outside of that field
 will save the value to be applied.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-modify.png" alt="View Timescale Forge service settings modification"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-settings-change.png" alt="Change Timescale Cloud configuration parameters"/>
 
 ### Apply configuration changes
 When you have modified the configuration parameters that you would
@@ -40,25 +40,23 @@ like to change, click `Apply Changes`. For some changes, such as
 `timescaledb.max_background_workers` (pictured below), the Service needs to be
 restarted. In this case, the button reads `Restart and apply changes`.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-apply.png" alt="View Timescale Forge service apply settings parameter changes"/>
-
 Regardless of whether the Service needs to be restarted or not, a confirmation
 dialog is displayed which lists the parameters that are being modified. Click
 `Confirm` to apply the changes (and restart if necessary).
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-confirm.png" alt="View Timescale Forge service configuration changes confirmation dialog"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-settings-confirm.png" alt="Confirm Timescale Cloud configuration changes"/>
 
 ## Configuring advanced parameters
 It is also possible to configure a wide variety of Service database parameters
 by toggling `Show advanced parameters` in the upper-right corner of the
 `Settings` tab.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-advanced.png" alt="View Timescale Forge service configuration changes confirmation dialog"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-settings-advanced.png" alt="View Timescale Cloud advanced configuration parameters"/>
 
 Once toggled, a scrollable (and searchable) list of configurable parameters is
 displayed.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-advanced-search.png" alt="View Timescale Forge service configuration changes confirmation dialog"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-settings-search.png" alt="Search Timescale Cloud configuration parameters"/>
 
 As with the basic database configuration parameters, any changes are highlighted
 and the `Apply changes` (or `Restart and apply changes`) button is available to

--- a/cloud/disk-management.md
+++ b/cloud/disk-management.md
@@ -18,7 +18,7 @@ database services. You can check your health data by navigating to the `metrics`
 tab in your service dashboard. These metrics are also monitored by the Timescale
 operations team.
 
-<img class="main-content__illustration" src="https://assets.timescale.com/images/diagrams/forge_metrics.png" alt="Timescale Forge metrics dashboard"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-disk-metrics.png" alt="Timescale Cloud metrics dashboard"/>
 
 If your database exceeds a storage threshold of available resources, some
 automated actions are triggered, including notifications, and preventative
@@ -59,7 +59,7 @@ You can increase your storage size in the Timescale Cloud console.
 
 <highlight type="warning">
 You can only increase your service's storage once every six hours, and you cannot
-currently decrease your storage size once set. 
+currently decrease your storage size once set.
 </highlight>
 
 ### Procedure: Increasing service resources
@@ -76,7 +76,7 @@ complete, your database is immediately available on the new resources. If your
 database is in read-only mode, the read-only protection is automatically removed,
 and you can begin writing data immediately.
 
-<img class="main-content__illustration" src="https://assets.timescale.com/images/diagrams/forge_resources.png" alt="Timescale Forge change resources"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-resources-changed.png" alt="Timescale Cloud change resources"/>
 
 ## Storage recovery
 

--- a/cloud/maintenance.md
+++ b/cloud/maintenance.md
@@ -46,6 +46,8 @@ system during the upgrade.
     same maintenance window settings for all of your Timescale Cloud services.
 1.  Click `Apply Changes`.
 
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-maintenance-change.png" alt="Timescale Cloud change maintenance window"/>
+
 ## Critical updates
 Critical upgrades and security fixes are installed outside normal maintenance
 windows when necessary, and sometimes require a short outage.

--- a/cloud/scaling-a-service.md
+++ b/cloud/scaling-a-service.md
@@ -26,7 +26,7 @@ To modify the compute or storage of your Service, first select the Service that
 you want to modify. This displays the `service details`, which list four tabs
 across the top: Overview, Operations, Metrics, and Logs. Select `Operations`.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-operations.png" alt="View Timescale Forge service operational information"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-service-operations.png" alt="View Timescale Cloud service operational information"/>
 
 ## Display the current service resources
 Under the Operations tab, you can perform the same basic operations as before
@@ -34,7 +34,7 @@ Under the Operations tab, you can perform the same basic operations as before
 section on the left labeled `Resources`. Selecting this option displays the
 current resource settings for the Service.
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-resources-4tb.png" alt="View Timescale Forge service resource information"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-resources-unchanged.png" alt="View Timescale Cloud service resource information"/>
 
 ## Modify service resources
 Once you have navigated to the current Service resources, it's easy to modify
@@ -49,7 +49,8 @@ and you can increase disk size once every six (6) hours.
 When you're satisfied with the changes, click `Apply` (storage resizes only) or
 `Apply and Restart` (when modifying compute resources).
 
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-restart-4tb.png" alt="View Timescale Forge service apply resize"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-resources-changed.png" alt="View Timescale Cloud service apply resize"/>
+
 # Compute resources and disk size
 You can use the Timescale Cloud console to change how much CPU and memory
 resources your service has available, as well as change the disk size for your
@@ -82,7 +83,7 @@ plan for this before you begin!
 1.  Review the new allocations and costs in the comparison chart.
 1.  Click `Apply` to save your changes. If you have changed the CPU and memory
     allocation, your service will go down briefly while the changes are applied.
-    <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-resources-configure.png" alt="Configure resource allocations"/>
+    <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-resources-changed-apply.png" alt="Configure resource allocations"/>
 
 ## Configure autoscaling for disk size
 Disk size autoscaling is enabled by default on most services. When you consume
@@ -110,4 +111,4 @@ to 10&nbsp;TB in size.
 1.  Review the new allocations and costs in the comparison chart.
 1.  Click `Apply` to save your changes. The new disk size generally becomes
     available within a few seconds.
-    <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-autoscale-configure.png" alt="Configure autoscaling disk size"/>
+    <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-autoscaling.png" alt="Configure autoscaling disk size"/>

--- a/cloud/vpc-peering-aws/create.md
+++ b/cloud/vpc-peering-aws/create.md
@@ -1,14 +1,15 @@
 # Create and connect a Timescale Cloud VPC with AWS
 
 ## Setup
-Before you begin, log in to the [Timescale Cloud console](https://console.cloud.timescale.com/).
+Before you begin, log in to the
+[Timescale Cloud console](https://console.cloud.timescale.com/).
 
 ## Create a new VPC
 In the Timescale Cloud console, click `VPC` in the left navigation bar to go to the VPC
 dashboard. You can add new VPCs here for your Timescale Cloud services to attach to.
 The VPCs created here are peered with your own VPC as part of the setup process.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/timescale-forge/vpc-dashboard.png" alt="Navigate to the VPC dashboard in the console"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-vpc-novpc.png" alt="The Timescale Cloud VPC dashboard"/>
 
 Click `Create VPC`, type a name for your new VPC, and provide an IPv4 CIDR block
 (E.G., `10.0.0.0/16` or `192.168.0.0/24`). Make sure that the CIDR block you
@@ -16,7 +17,7 @@ choose for your Timescale Cloud VPC does not overlap with the AWS VPC you are us
 a peering connection. If the CIDR blocks overlap, the peering process will fail.
 You can always find the CIDR block of your AWS VPC from the AWS console.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/timescale-forge/create-vpc.png" alt="Create a new Forge VPC"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-vpc-create.png" alt="Create a new Timescale Cloud VPC"/>
 
 <highlight type="tip">
 VPC peering can be enabled for free during your Timescale Cloud trial, but you will be
@@ -29,7 +30,7 @@ When you have created a Timescale Cloud VPC, you are ready to create a peering c
 between your Cloud VPC and your cloud VPC. To do this, click the `Add` text in
 the `VPC Peering` column for the Cloud VPC that you would like to connect.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/timescale-forge/create-peering-connection.png" alt="Expand the VPC Peering dropdown menu and enter info"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-vpc-addpeering.png" alt="Expand the VPC Peering dropdown menu and enter info"/>
 
 In the form that is displayed, enter the AWS Account ID, AWS VPC ID, and AWS region of your
 cloud VPC for the new peering connection. When you have entered the correct
@@ -48,7 +49,7 @@ accept the request.
 Make note of the peering connection ID (starting with `pcx-`) as it is used in the next step.
 </highlight>
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/timescale-forge/aws-accept-peering-connection.png" alt="Accept peering connection in AWS console after verifying requestor account number"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/aws-vpc-peering.png" alt="Peering information in AWS"/>
 
 ## Network routing and security in AWS
 Once you have accepted the peering connection, the two VPCs will now be peered;
@@ -62,7 +63,7 @@ Within the AWS console, navigate to the
 dashboard. Select the route table corresponding to your VPC. From the detail menu, select
 the `Routes` tab and click the `Edit routes` button.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/timescale-forge/aws-route-table-routes.png" alt="The AWS Route Tables dashboard with Routes tab expanded"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/aws-vpc-routetable.png" alt="Route table on AWS"/>
 
 From this view, click `Add route`. In the `Destination` column of the new row,
 enter the CIDR block of the Timescale Cloud VPC for which the peering connection
@@ -75,7 +76,7 @@ No other configuration is needed here, so click `Save routes`. This
 configuration allows network traffic to flow from your VPC, across the peering
 connection, and over to the Timescale Cloud VPC where your TimescaleDB services reside.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/timescale-forge/aws-edit-routes.png" alt="Adding a new route table entry for our peering connection"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/aws-vpc-editroutes.png" alt="Edit routes on AWS"/>
 
 ### Security groups
 Within the AWS console, navigate to the
@@ -87,7 +88,7 @@ If you need to, you can use another security group which already exists in your 
 however, for simplicity we will assume the creation of a new security group.
 </highlight>
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/timescale-forge/aws-create-security-group.png" alt="The AWS Security Groups dashboard"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/aws-vpc-securitygroup.png" alt="The AWS Security Groups dashboard"/>
 
 From the `Create security group` view, enter a name for your security group. Add whatever
 content you would like to the description field. For the `VPC` field, select the VPC
@@ -122,4 +123,4 @@ Click `Create Service`, and Timescale Cloud will create your new service. Due to
 selecting a VPC during setup, your new service will be created with an attachment to
 your selected VPC.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/timescale-forge/create-service-with-vpc.png" alt="Create new service with VPC attachment"/>
+<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-vpc-select.png" alt="Create new service with VPC attachment"/>


### PR DESCRIPTION
# Description

This updates the screenshots for all pages under the Timescale Cloud section: https://docs.timescale.com/cloud/latest/

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]

# Notes for reviewers

Please click through the pages on the preview to make sure all images are rendering OK