### PR TITLE
Fix broken link in index

### DIFF
--- a/timescaledb/tutorials/page-index/page-index.js
+++ b/timescaledb/tutorials/page-index/page-index.js
@@ -133,7 +133,7 @@ module.exports = [
       },
       {
         title: 'Monitor Timescale Cloud with Prometheus',
-        href: 'setting-up-timescale-cloud-endpoint-for-prometheus',
+        href: 'monitor-mst-with-prometheus',
         tags: ['prometheus', 'monitor', 'learn', 'timescaledb'],
         keywords: ['Promscale', 'Prometheus', 'tutorial', 'TimescaleDB'],
         excerpt: 'Monitor Timescale Cloud with Prometheus',


### PR DESCRIPTION
# Description

The rebranding created a broken link in the index for the Prometheus tutorial. This PR updates the index file with the correct href.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
