### PR TITLE
update grafana install doc and change old cloud login links

### DIFF
--- a/api/create_distributed_hypertable.md
+++ b/api/create_distributed_hypertable.md
@@ -25,7 +25,7 @@ when creating distributed hypertables.
 | `partitioning_func` | REGCLASS | The function to use for calculating a value's partition.|
 | `migrate_data` | BOOLEAN | Set to TRUE to migrate any existing data from the `relation` table to chunks in the new hypertable. A non-empty table will generate an error without this option. Large tables may take significant time to migrate. Default is FALSE. |
 | `time_partitioning_func` | REGCLASS | Function to convert incompatible primary time column values to compatible ones. The function must be `IMMUTABLE`. |
-| `replication_factor` | INTEGER | The number of data nodes to which the same data is written to. This is done by creating chunk copies on this amount of data nodes.  Must be >= 1; default is 1.  Read [the best practices](/distributed-hypertables/create_distributed_hypertable-best-practices) before changing the default. |
+| `replication_factor` | INTEGER | The number of data nodes to which the same data is written to. This is done by creating chunk copies on this amount of data nodes.  Must be >= 1; default is 1.  Read [the best practices](/timescaledb/latest/how-to-guides/hypertables/best-practices/) before changing the default. |
 | `data_nodes` | ARRAY | The set of data nodes used for the distributed hypertable.  If not present, defaults to all data nodes known by the access node (the node on which the distributed hypertable is created). |
 
 ### Returns

--- a/api/percentile-aggregation-methods.md
+++ b/api/percentile-aggregation-methods.md
@@ -1,5 +1,5 @@
 # Advanced percentile aggregation <tag type="toolkit">Toolkit</tag>
-While the simple [`Percentile_agg()`](/hyperfunctions/percentile-approximation/aggregation-methods/percentile_agg)
+While the simple [`Percentile_agg()`](/hyperfunctions/percentile-approximation/percentile_agg)
 interface will be sufficient for many users, we do provide more specific APIs for
 advanced users who want more control of how their percentile approximation is
 computed and how much space the intermediate representation uses.  We currently

--- a/cloud/vpc-peering-aws/migrate.md
+++ b/cloud/vpc-peering-aws/migrate.md
@@ -1,6 +1,6 @@
 # Migrating a service between networks
 
-Timescale Forge services may be migrated between VPCs within a Cloud project, and may also
+Timescale Cloud services may be migrated between VPCs within a Cloud project, and may also
 be migrated to and from the public network. Typically, once you have attached your service
 to a VPC, it should remain attached to ensure that your applications running in your AWS
 VPC will have continued connectivity to your service.

--- a/mst/create-a-service.md
+++ b/mst/create-a-service.md
@@ -68,7 +68,7 @@ Now you have your service up and running, you can try your
 
 
 [sign-up]: https://www.timescale.com/cloud-signup
-[mst-login]: https://portal.timescale.cloud/login
+[mst-login]: https://portal.managed.timescale.com
 [timescale-mst-portal]: https://portal.managed.timescale.com
 [timescale-pricing]: https://www.timescale.com/products
 [contact]: https://www.timescale.com/contact

--- a/mst/metrics-datadog.md
+++ b/mst/metrics-datadog.md
@@ -66,5 +66,5 @@ Datadog dashboard editor to configure your visualizations. See the
 
 
 [datadog-login]: https://app.datadoghq.com/
-[mst-login]: https://portal.timescale.cloud/login
+[mst-login]: https://portal.managed.timescale.com
 [datadog-dashboard-docs]: https://docs.datadoghq.com/dashboards/

--- a/mst/user-management.md
+++ b/mst/user-management.md
@@ -50,4 +50,4 @@ Your service must be running before you can manage users.
 <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/mst-serviceuser.png" alt="Add a new MST service user"/>
 
 
-[mst-login]: https://portal.timescale.cloud/login
+[mst-login]: https://portal.managed.timescale.com

--- a/mst/viewing-service-logs.md
+++ b/mst/viewing-service-logs.md
@@ -17,6 +17,6 @@ output, in case programmatic access is needed.
 
 Service logs included on the normal service price are stored only for a few days. Unless you are using logs integration to another service, older logs are not accessible.
 
-[mst-portal]: https://portal.timescale.cloud/
+[mst-portal]: https://portal.managed.timescale.com
 [Command-line client]: https://github.com/aiven/aiven-client
 [REST API]: https://kb.timescale.cloud/en/articles/2949775-rest-api

--- a/timescaledb/how-to-guides/install-timescaledb/installation-mst.md
+++ b/timescaledb/how-to-guides/install-timescaledb/installation-mst.md
@@ -24,7 +24,7 @@ Now that your database account is setup, it's time to
 ---
 
 [sign-up]: https://www.timescale.com/cloud-signup
-[portal]: http://portal.timescale.cloud
+[portal]: https://portal.managed.timescale.com
 [timescale-features]: https://www.timescale.com/products
 [mst-setup]: /mst/:currentVersion:/create-a-service
 [intercom]: https://kb.timescale.cloud/

--- a/timescaledb/how-to-guides/install-timescaledb/managed-service-for-timescaledb.md
+++ b/timescaledb/how-to-guides/install-timescaledb/managed-service-for-timescaledb.md
@@ -168,7 +168,7 @@ account when securing your data. To learn more about security options within man
 visit the [managed service for TimescaleDB Knowledge Base][mst-kb].
 
 
-[mst-install]: /how-to-guides/install-timescaledb//mst/installation-mst
+[mst-install]: /how-to-guides/install-timescaledb/mst/installation-mst
 [cidr-wiki]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
 [cidr-tool]: http://www.subnet-calculator.com/cidr.php
 [mst-kb]: https://kb.timescale.cloud/en/collections/1600092-security

--- a/timescaledb/how-to-guides/install-timescaledb/managed-service-for-timescaledb.md
+++ b/timescaledb/how-to-guides/install-timescaledb/managed-service-for-timescaledb.md
@@ -172,7 +172,7 @@ visit the [managed service for TimescaleDB Knowledge Base][mst-kb].
 [cidr-wiki]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
 [cidr-tool]: http://www.subnet-calculator.com/cidr.php
 [mst-kb]: https://kb.timescale.cloud/en/collections/1600092-security
-[mst-portal]: http://portal.timescale.cloud
+[mst-portal]: https://portal.managed.timescale.com
 [sign-up]: https://www.timescale.com/cloud-signup
 [timescale-features]: https://www.timescale.com/products
 [timescale-pricing]: https://www.timescale.com/products#cloud-pricing

--- a/timescaledb/tutorials/grafana/installation.md
+++ b/timescaledb/tutorials/grafana/installation.md
@@ -1,13 +1,13 @@
 # Set up TimescaleDB and Grafana
-This tutorial uses Timescale Cloud to set up your database, and
+This tutorial uses Managed Service for TimescaleDB (MST) to set up your database, and
 to set up Grafana. You can [create a free account][mst-login] to try it out.
 
 ## Create a new service for Grafana
-You need to sign in to your Timescale Cloud account to create a
+You need to sign in to your MST account to create a
 new service to run Grafana.
 
 ### Procedure: Creating a new service for Grafana
-1.  [Log in to your Timescale Cloud account][mst-login]. By default, you start in the
+1.  [Log in to your Managed Service for TimescaleDB account][mst-login]. By default, you start in the
     `Services` view, showing any services you currently have in your project.
 1.  Click `Create a new service`.
 1.  In the `Select your service` section, click `TimescaleDB Grafana - Metrics
@@ -28,11 +28,11 @@ new service to run Grafana.
     the list to see more information and make changes.
     <img class="main-content__illustration" src="https://assets.timescale.com/docs/images/mst-buildservice-grafana.png" alt="Building the Grafana service"/>
 
-## Log in to your Timescale Cloud Grafana service
+## Log in to your MST Grafana service
 When your service is built, you can log and set up your data services.
 
-### Logging in to your Timescale Cloud Grafana service
-1.  In the [Timescale Cloud account][mst-login] `Services` view, click the name of your new
+### Logging in to your MST Grafana service
+1.  In the [MST account][mst-login] `Services` view, click the name of your new
     Grafana service.
 1.  On the service details page, take a note of the user name and password for
     your service, and click the link in the `Service URI` field to open Grafana:
@@ -64,4 +64,4 @@ connect to your TimescaleDB instance.
 1.  Click `Save & Test`. You can confirm your data source is working by clicking
     `Back`, and checking that your service is listed correctly.
 
-[mst-login]: https://portal.timescale.cloud
+[mst-login]: https://portal.managed.timescale.com


### PR DESCRIPTION
# Description

Update grafana install docs from cloud -> mst and change old cloud portal links

# Version

Which documentation version does this PR apply to?

- [x ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

https://github.com/timescale/docs/issues/500
