### PR TITLE
Adding experimental toolkit downsample APIs

### DIFF
--- a/api/asap.md
+++ b/api/asap.md
@@ -1,0 +1,50 @@
+# asap_smooth()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
+The [ASAP smoothing alogrithm](https://arxiv.org/pdf/1703.00983.pdf) is designed create human readable graphs which preserve the rough shape and larger trends of the input data while minimizing the local variance between points.  The `asap_smooth` hyperfunction provides an implementation of this algorithm which takes `(timestamptz, double precision)` data and returns an ASAP smoothed [`timevector`][hyperfunctions-timevectors].
+
+## Required Arguments
+|Name| Type |Description|
+|---|---|---|
+| `ts` | `TIMESTAMPTZ` | Column of timestamps corresponding to the values to aggregate |
+| `value` | `DOUBLE PRECISION` |  Column to aggregate. |
+| `resolution` | `INT` |  Approximate number of points to return.  Intended to represent the horizontal resolution in which the aggregate will be graphed
+
+## Returns
+
+|Column|Type|Description|
+|---|---|---|
+| `normalizedtimevector` | `NormalizedTimevector` | A object representing a series of values occurring at set intervals from a starting time.  It can be unpacked via `unnest` |
+
+## Sample Usage
+For this examples assume we have a table 'metrics' with columns 'date' and 'reading' which contains some interesting measurment we've accumulated over a large interval.  The following example would take that data and give us a smoothed representation of approximately 10 points which would still show any anomolous readings:
+
+```SQL
+SET TIME ZONE 'UTC';
+CREATE TABLE metrics(date TIMESTAMPTZ, reading DOUBLE PRECISION);
+INSERT INTO metrics
+SELECT
+    '2020-1-1 UTC'::timestamptz + make_interval(hours=>foo),
+    (5 + 5 * sin(foo / 12.0 * PI()))
+    FROM generate_series(1,168) foo;
+
+```
+
+```SQL
+SELECT * FROM toolkit_experimental.unnest(
+    (SELECT toolkit_experimental.asap_smooth(date, reading, 8)
+     FROM metrics));
+```
+```output
+          time          |        value
+------------------------+---------------------
+ 2020-01-01 01:00:00+00 | 5.3664814565722665
+ 2020-01-01 21:00:00+00 |  5.949469264090644
+ 2020-01-02 17:00:00+00 |  5.582987807518377
+ 2020-01-03 13:00:00+00 |  4.633518543427733
+ 2020-01-04 09:00:00+00 |  4.050530735909357
+ 2020-01-05 05:00:00+00 |  4.417012192481623
+ 2020-01-06 01:00:00+00 |  5.366481456572268
+ 2020-01-06 21:00:00+00 |  5.949469264090643
+```
+
+
+[hyperfunctions-timevectors]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/function-pipelines/#timevectors

--- a/api/distinct_count.md
+++ b/api/distinct_count.md
@@ -1,4 +1,4 @@
-# distinct_count()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
+# distinct_count()  <tag type="toolkit">Toolkit</tag>
 The `distinct_count` function gets the number of distinct values from a
 hyperloglog.
 

--- a/api/downsample.md
+++ b/api/downsample.md
@@ -1,0 +1,16 @@
+# Downsample
+This section deals with functions used to downsample data.  Downsampling
+is used to replace a set of values with a much smaller set that is highly
+representative of the original data.  This is particularly useful for
+graphing applications.
+
+Some hyperfunctions are included in the default TimescaleDB product. For
+additional hyperfunctions, you need to install the
+[Timescale Toolkit][install-toolkit] PostgreSQL extension.
+
+|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
+|-|-|-|-|-|
+|Downsample|ASAP|[`asap_smooth`](hyperfunctions/downsample/asap/)|❌|✅|
+|Downsample|LTTB|[`lttb`](hyperfunctions/downsample/lttb/)|❌|✅|
+
+[install-toolkit]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -1,4 +1,4 @@
-# hyperloglog()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
+# hyperloglog()  <tag type="toolkit">Toolkit</tag>
 The `hyperloglog` function constructs and returns a hyperloglog with at least
 the specified number of buckets over the given values.
 

--- a/api/lttb.md
+++ b/api/lttb.md
@@ -1,0 +1,39 @@
+# lttb()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
+[Largest Triangle Three Buckets](https://github.com/sveinn-steinarsson/flot-downsample)
+is a downsampling method that tries to retain visual similarity between the
+downsampled data and the original dataset. TimescaleDB Toolkit provides an
+implementation of this which takes `(timestamp, value)` pairs, sorts them if
+needed, and downsamples them.
+
+## Required Arguments
+|Name| Type |Description|
+|---|---|---|
+| `time` | `TIMESTAMPTZ` | Time (x) value for the data point. |
+| `value` | `DOUBLE PRECISION` |  Data (y) value for the data point. |
+| `resolution` | `INTEGER` | Number of points the output should have. |
+
+## Returns
+
+|Column|Type|Description|
+|---|---|---|
+| `sortedtimevector` | `SortedTimevector` | A [`timevector`][hyperfunctions-timevectors] object containing the downsampled points.  It can be unpacked via `unnest` |
+
+## Sample Usage
+This example gets a dramatically downsampled data set from a `sample_data` table.
+
+```SQL
+SELECT time, value
+FROM toolkit_experimental.unnest((
+    SELECT toolkit_experimental.lttb(time, val, 4)
+    FROM sample_data))
+```
+```output
+          time          |       value
+------------------------+--------------------
+ 2020-01-11 00:00:00+00 |   12.7015115293407
+ 2020-02-01 00:00:00+00 |  5.004324248633603
+ 2020-03-03 00:00:00+00 | 14.982710485116087
+ 2020-04-20 00:00:00+00 | 10.022128489940254
+```
+
+[hyperfunctions-timevectors]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/function-pipelines/#timevectors

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -488,6 +488,21 @@ module.exports = [
               },
             ],
           },
+          {
+            title: 'Downsample',
+            type: 'directory',
+            href: 'downsample',
+            children: [
+              {
+                title: 'asap',
+                href: 'asap',
+              },
+              {
+                title: 'lttb',
+                href: 'lttb',
+              },
+            ],
+          },
         ],
       },
       {

--- a/api/stderror.md
+++ b/api/stderror.md
@@ -1,4 +1,4 @@
-# stderror()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
+# stderror()  <tag type="toolkit">Toolkit</tag>
 The `stderror` function returns an estimate of the relative standard error of the hyperloglog, based on the hyperloglog error formula. Approximate results are:
 
 |precision|registers|error|bytes|


### PR DESCRIPTION
# Description

This provides documentation for some experimental APIs that are in the current version of toolkit.  Specifically this covers the `asap_smooth` and `lttb` functions.

Additionally this removes a few experimental tags from `hyperloglog` functions which are now stable.

# Version

Which documentation version does this PR apply to?

- [ x ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

