### PR TITLE
Reference new path of Homebrew prefix

### DIFF
--- a/timescaledb/how-to-guides/connecting/psql.md
+++ b/timescaledb/how-to-guides/connecting/psql.md
@@ -26,8 +26,9 @@ brew update
 brew install libpq
 ```
 
-Finally, create a symbolic link to `psql` (and other `libpq` tools) into `/usr/local/bin`
-so that you can reach it from any command on the macOS Terminal.
+Finally, create a symbolic link to `psql` (and other `libpq` tools) into `/usr/local/bin` on
+Intel or `/opt/homebrew/bin` on Apple Silicon chips so that you can reach it from any
+command on the macOS Terminal.
 
 ```bash
 brew link --force libpq ail

--- a/timescaledb/how-to-guides/connecting/psql.md
+++ b/timescaledb/how-to-guides/connecting/psql.md
@@ -27,7 +27,7 @@ brew install libpq
 ```
 
 Finally, create a symbolic link to `psql` (and other `libpq` tools) into `/usr/local/bin` on
-Intel or `/opt/homebrew/bin` on Apple Silicon chips so that you can reach it from any
+Intel, or `/opt/homebrew/bin` on Apple Silicon chips so that you can reach it from any
 command on the macOS Terminal.
 
 ```bash


### PR DESCRIPTION
# Description

Homebrew on Apple Silicon uses a new path for the prefix /opt/homebrew/bin whereas Intel installations still utilize /usr/local/bin.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

N/A
