### PR TITLE
Fix typo 'primarily' > 'primary'

### DIFF
--- a/timescaledb/overview/core-concepts/hypertables-and-chunks.md
+++ b/timescaledb/overview/core-concepts/hypertables-and-chunks.md
@@ -1,7 +1,7 @@
 # Hypertables
 
 From a user's perspective, TimescaleDB exposes what look like singular tables,
-called **hypertables**. A hypertable is the primarily point of interaction
+called **hypertables**. A hypertable is the primary point of interaction
 with your data, as it provides the standard table abstraction that you can query
 via standard SQL.  [Creating a hypertable][create-hypertable] in TimescaleDB takes two
 SQL commands: `CREATE TABLE` (with standard SQL syntax),


### PR DESCRIPTION
# Description

Fixing a typo to use an adjective where there used to (incorrectly) be an adverb

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
