### PR TITLE
Clarify what functionality of time_bucket_ng() is supported by CAGGs

### DIFF
--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -175,10 +175,13 @@ ORDER BY bucket;
 
 For more information, see the [continuous aggregates documentation][caggs].
 
-Note that although `time_bucket_ng()` supports months and timezones, it doesn't
-necessarily mean that monthly buckets or buckets with timezones are supported
-by continuous aggregates. The following table shows what functionality of
-`time_bucket_ng()` is currently supported on the continuous aggregates side:
+<highlight type="important">
+While `time_bucket_ng()` supports months and timezones, 
+continuous aggregates cannot always be used with monthly 
+buckets or buckets with timezones. 
+</highlight>
+
+This table shows which `time_bucket_ng()` functions can be used in a continuous aggregate:
 
 |Function|Available in continuous aggregate|TimescaleDB version|
 |-|-|-|

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -180,12 +180,12 @@ necessarily mean that monthly buckets or buckets with timezones are supported
 by continuous aggregates. The following table shows what functionality of
 `time_bucket_ng()` is currently supported on the continuous aggregates side:
 
-Functionality | Supported
---------------|----------
-Buckets by seconds, minutes, hours, days and weeks | YES, since 2.4.0
-Buckets by months and years | NO (expected in 2.6.0)
-Specifying custom origin | NO
-Timezones support | NO
+|Function|Available in continuous aggregate|TimescaleDB version|
+|-|-|-|
+|Buckets by seconds, minutes, hours, days, and weeks|✅|2.4.0 and later|
+|Buckets by months and years|❌|Expected in 2.6.0 or later|
+|Specify custom origin|❌|To be determined|
+|Timezones support|❌|To be determined|
 
 [time_bucket]: /hyperfunctions/time_bucket/
 [caggs]: /timescaledb/:currentVersion:/overview/core-concepts/continuous-aggregates/

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -175,5 +175,17 @@ ORDER BY bucket;
 
 For more information, see the [continuous aggregates documentation][caggs].
 
+Note that although `time_bucket_ng()` supports months and timezones, it doesn't
+necessarily mean that monthly buckets or buckets with timezones are supported
+by continuous aggregates. The following table shows what functionality of
+`time_bucket_ng()` is currently supported on the continuous aggregates side:
+
+Functionality | Supported
+--------------|----------
+Buckets by seconds, minutes, hours, days and weeks | YES, since 2.4.0
+Buckets by months and years | NO (expected in 2.6.0)
+Specifying custom origin | NO
+Timezones support | NO
+
 [time_bucket]: /hyperfunctions/time_bucket/
 [caggs]: /timescaledb/:currentVersion:/overview/core-concepts/continuous-aggregates/


### PR DESCRIPTION
# Description

Several users expected that since time_bucket_ng() supports months and timezones, this functionality is also supported in CAGGs. It's not clear from the documentation that it's not true. The proposed patch clarifies what is currently supported on the CAGGs side.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

https://github.com/timescale/timescaledb/issues/414#issuecomment-954480123
Also, Slack.
