### PR TITLE
Clarify go install method

### DIFF
--- a/timescaledb/how-to-guides/backup-and-restore/timescaledb-backup.md
+++ b/timescaledb/how-to-guides/backup-and-restore/timescaledb-backup.md
@@ -27,9 +27,26 @@ get`, or download a binary from
     *   `pg_dump`
     *   `pg_dumpall`
     *   `pg_restore`
-1.  Install `timescaledb-backup`:
+1.  Download `timescaledb-backup`:
     ```bash
-    $ go get github.com/timescale/timescaledb-backup/
+    $ go get -d github.com/timescale/timescaledb-backup/
+    # Ignore any can't load packages errors, if any.
+    ```
+1. Build the binaries:
+   ```bash
+   $ cd ~/go/src/github.com/timescale/timescaledb-backup/
+   $ go install ./cmd/...
+   ```
+   The binaries will be available on your GOPATH.
+    Find it with:
+    ```bash
+    $ go env
+    ```
+1. (Optional) Make the binaries available on your path:
+     * Debian/Ubuntu:
+     ```bash
+   $ cd ~/go/bin/ # or whatever you GOPATH is
+   $ sudo mv {ts-dump,ts-restore} /usr/bin/
     ```
 
 </procedure>

--- a/timescaledb/how-to-guides/backup-and-restore/timescaledb-backup.md
+++ b/timescaledb/how-to-guides/backup-and-restore/timescaledb-backup.md
@@ -37,8 +37,7 @@ get`, or download a binary from
    $ cd ~/go/src/github.com/timescale/timescaledb-backup/
    $ go install ./cmd/...
    ```
-   The binaries will be available on your GOPATH.
-    Find it with:
+1.  The binaries are available on your `GOPATH`. You can find them with this command:
     ```bash
     $ go env
     ```

--- a/timescaledb/how-to-guides/backup-and-restore/timescaledb-backup.md
+++ b/timescaledb/how-to-guides/backup-and-restore/timescaledb-backup.md
@@ -27,7 +27,8 @@ get`, or download a binary from
     *   `pg_dump`
     *   `pg_dumpall`
     *   `pg_restore`
-1.  Download `timescaledb-backup`:
+1.  Download `timescaledb-backup`. If you see an error about 
+     not being able to load packages, you can safely ignore them:
     ```bash
     $ go get -d github.com/timescale/timescaledb-backup/
     # Ignore any can't load packages errors, if any.


### PR DESCRIPTION
Go get can only download the source files, as it stands. There is no one-liner go command that downloads and installs, to my knowledge and testing.
This procedure should get Go beginners setup with the ts-dump and ts-restore tools. This method is only two command longer than downloading the prebuilt binaries.
Tested on Ubuntu 20.04 only.

# Description

I think the Go install method description is too short. This will guide users once the go get command either appears to do nothing or appears to error out.

# Version

Which documentation version does this PR apply to?

- [* ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #629 
