### PR TITLE
Remove old default interval references

### DIFF
--- a/api/create_distributed_hypertable.md
+++ b/api/create_distributed_hypertable.md
@@ -19,7 +19,7 @@ when creating distributed hypertables.
 | `number_partitions` | INTEGER | Number of hash partitions to use for `partitioning_column`. Must be > 0. Default is the number of `data_nodes`. |
 | `associated_schema_name` | TEXT | Name of the schema for internal hypertable tables. Default is "_timescaledb_internal". |
 | `associated_table_prefix` | TEXT | Prefix for internal hypertable chunk names. Default is "_hyper". |
-| `chunk_time_interval` | INTERVAL | Interval in event time that each chunk covers. Must be > 0. As of TimescaleDB v0.11.0, default is 7 days, unless adaptive chunking (DEPRECATED)  is enabled, in which case the interval starts at 1 day. For previous versions, default is 1 month. |
+| `chunk_time_interval` | INTERVAL | Interval in event time that each chunk covers. Must be > 0. Default is 7 days. |
 | `create_default_indexes` | BOOLEAN | Boolean whether to create default indexes on time/partitioning columns. Default is TRUE. |
 | `if_not_exists` | BOOLEAN | Boolean whether to print warning if table already converted to hypertable or raise exception. Default is FALSE. |
 | `partitioning_func` | REGCLASS | The function to use for calculating a value's partition.|

--- a/api/create_hypertable.md
+++ b/api/create_hypertable.md
@@ -25,7 +25,7 @@ still work on the resulting hypertable.
 |---|---|---|
 | `partitioning_column` | REGCLASS | Name of an additional column to partition by. If provided, the `number_partitions` argument must also be provided. |
 | `number_partitions` | INTEGER | Number of [hash partitions][] to use for `partitioning_column`. Must be > 0. |
-| `chunk_time_interval` | INTERVAL | Event time that each chunk covers. Must be > 0. As of TimescaleDB v0.11.0, default is 7 days. For previous versions, default is 1 month. |
+| `chunk_time_interval` | INTERVAL | Event time that each chunk covers. Must be > 0. Default is 7 days. |
 | `create_default_indexes` | BOOLEAN | Whether to create default indexes on time/partitioning columns. Default is TRUE. |
 | `if_not_exists` | BOOLEAN | Whether to print warning if table already converted to hypertable or raise exception. Default is FALSE. |
 | `partitioning_func` | REGCLASS | The function to use for calculating a value's partition.|

--- a/timescaledb/how-to-guides/hypertables/best-practices.md
+++ b/timescaledb/how-to-guides/hypertables/best-practices.md
@@ -6,13 +6,13 @@ Users of TimescaleDB often have two common questions:
 1. Should I use space partitioning, and how many space partitions should I use?
 
 ## Time intervals:
-Users can use the default time interval, which is 7 days starting in v0.11.0
-and 1 month prior to v0.11.0. Alternatively, users can explicitly configure time
-intervals by setting `chunk_time_interval` when creating a hypertable. After the
-hypertable has been created, the interval used for new chunks can be changed by
-calling [`set_chunk_time_interval`][set_chunk_time_interval].
+The default time interval is 7 days. You can explicitly configure time
+intervals when you create a hypertable, using the `chunk_time_interval` setting.
+After the hypertable is created, you can change the interval for new chunks 
+with [`set_chunk_time_interval`][set_chunk_time_interval].
 
-The key property of choosing the time interval is that the chunk (including indexes) belonging to the most recent interval (or chunks if using space
+The key property of choosing the time interval is that the chunk (including indexes)
+belonging to the most recent interval (or chunks if using space
 partitions) fit into memory.  As such, we typically recommend setting
 the interval so that these chunk(s) comprise no more than 25% of main
 memory.


### PR DESCRIPTION
# Description

There are references to the old default time interval (from `v0.11.0`) which don't apply anymore

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
