### PR TITLE
Fix typo in update-timescaledb how to guide

### DIFF
--- a/timescaledb/how-to-guides/update-timescaledb/index.md
+++ b/timescaledb/how-to-guides/update-timescaledb/index.md
@@ -1,6 +1,6 @@
 # Updating TimescaleDB versions [](update)
 
-The instructions below all you to update TimescaleDB within the same major release
+The instructions below allow you to update TimescaleDB within the same major release
 version (for example, from TimescaleDB 2.1 to 2.2, or from 1.7 to 1.7.4). If you need
 to upgrade between TimescaleDB 1.x and 2.x, see our [separate upgrade document][update-tsdb-2]
 for detailed instructions.


### PR DESCRIPTION
# Description

Typo

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
