### PR TITLE
Update time_bucket_ng() docs for the upcoming 2.6.0 release

### DIFF
--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -6,8 +6,10 @@ supports years and months in addition to small units of time.
 
 <highlight type="warning">
 Experimental features could have bugs! They might not be backwards compatible,
-and could be removed in future releases. Use these features at your own risk, and
-do not use any experimental features in production.
+and could be removed in future releases. It will be necessary to delete and
+re-build a CAGG that uses an experimental function when this function will be
+graduated from the experimental schema. Use these features at your own risk,
+and do not use any experimental features in production.
 </highlight>
 
 Functionality | time_bucket() | time_bucket_ng()
@@ -186,7 +188,7 @@ This table shows which `time_bucket_ng()` functions can be used in a continuous 
 |Function|Available in continuous aggregate|TimescaleDB version|
 |-|-|-|
 |Buckets by seconds, minutes, hours, days, and weeks|✅|2.4.0 and later|
-|Buckets by months and years|❌|Expected in 2.6.0 or later|
+|Buckets by months and years|✅|2.6.0 or later|
 |Specify custom origin|❌|To be determined|
 |Timezones support|❌|To be determined|
 

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -6,10 +6,10 @@ supports years and months in addition to small units of time.
 
 <highlight type="warning">
 Experimental features could have bugs! They might not be backwards compatible,
-and could be removed in future releases. It will be necessary to delete and
-re-build a CAGG that uses an experimental function when this function will be
-graduated from the experimental schema. Use these features at your own risk,
-and do not use any experimental features in production.
+and could be removed in future releases. When this function is no longer 
+experimental, you need to delete and rebuild any continuous aggregate 
+that uses it. Use experimental features at your own risk, and do not use 
+any experimental features in production.
 </highlight>
 
 Functionality | time_bucket() | time_bucket_ng()

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -6,10 +6,10 @@ supports years and months in addition to small units of time.
 
 <highlight type="warning">
 Experimental features could have bugs! They might not be backwards compatible,
-and could be removed in future releases. When this function is no longer 
-experimental, you need to delete and rebuild any continuous aggregate 
-that uses it. Use experimental features at your own risk, and do not use 
-any experimental features in production.
+and could be removed in future releases. When this function is no longer experimental, 
+you will need to delete and rebuild any continuous aggregate that uses it. 
+Use experimental features at your own risk and we do not recommend to use 
+any experimental feature in a production environment.
 </highlight>
 
 Functionality | time_bucket() | time_bucket_ng()


### PR DESCRIPTION
# Description

- State that monthly buckets in CAGGs are going to be available since 2.6.0
- Explicitly state that CAGG that uses an experimental function should be dropped and replaced in the feature

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

This PR adds the documentation for https://github.com/timescale/timescaledb/pull/3753
