### PR TITLE
Adding a link to the sample dataset

### DIFF
--- a/timescaledb/getting-started/create-hypertable.md
+++ b/timescaledb/getting-started/create-hypertable.md
@@ -83,4 +83,4 @@ data-stores become more efficient.
 See the [Hypertable How To](/how-to-guides/hypertables) to learn more about
 hypertables and best practices for configuring chunks.
 
-Next, ingest some sample data into TimescaleDB.
+Next, ingest some sample data into TimescaleDB. You can also use this [sample dataset](/getting-started/add-data/#accessing-the-dataset) to populate the table you just created. 

--- a/timescaledb/getting-started/create-hypertable.md
+++ b/timescaledb/getting-started/create-hypertable.md
@@ -83,4 +83,6 @@ data-stores become more efficient.
 See the [Hypertable How To](/how-to-guides/hypertables) to learn more about
 hypertables and best practices for configuring chunks.
 
-Next, ingest some sample data into TimescaleDB. You can also use this [sample dataset](/getting-started/add-data/#accessing-the-dataset) to populate the table you just created. 
+Next, ingest some sample data into TimescaleDB. You can also use this 
+[sample dataset](/getting-started/add-data/#accessing-the-dataset) to 
+populate the table you just created. 


### PR DESCRIPTION
When reaching the end of [this page](https://docs.timescale.com/timescaledb/latest/getting-started/create-hypertable/#learn-more-about-hypertables-and-chunks), the user is left with an empty table. We have the instructions in the getting started to populate the table with sample data. We should add the link to those instructions.

# Description

Adding a link to the sample dataset to help users in their learning process.

# Version

Which documentation version does this PR apply to?

- [X] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

N/A