### PR TITLE
Add link to GH releases page

### DIFF
--- a/promscale/installation/source.md
+++ b/promscale/installation/source.md
@@ -31,7 +31,7 @@ In this procedure, you download the Promscale binaries and run them.
 
 ### Installing Promscale from source
 1.  At the command prompt, as root, download the appropriate source files for
-    your operating system (get the url from the [GitHub repository releases page][releases]):
+    your operating system (get the URL from the [GitHub repository releases page][releases]):
     ```bash
     curl -L -o promscale https://github.com/timescale/promscale/releases/download/<VERSION>/<PROMSCALE_DISTRIBUTION>
     ```

--- a/promscale/installation/source.md
+++ b/promscale/installation/source.md
@@ -31,7 +31,7 @@ In this procedure, you download the Promscale binaries and run them.
 
 ### Installing Promscale from source
 1.  At the command prompt, as root, download the appropriate source files for
-    your operating system:
+    your operating system (get the url from the [GitHub repository releases page][releases]):
     ```bash
     curl -L -o promscale https://github.com/timescale/promscale/releases/download/<VERSION>/<PROMSCALE_DISTRIBUTION>
     ```
@@ -59,3 +59,4 @@ In this procedure, you download the Promscale binaries and run them.
 [go-install]: https://golang.org/dl/
 [prometheus-config-tips]: https://github.com/timescale/promscale/blob/master/docs/configuring_prometheus.md
 [promscale-extension]: https://github.com/timescale/promscale_extension#promscale-extension
+[releases]: https://github.com/timescale/promscale/releases/


### PR DESCRIPTION
# Description

Add link to GH releases page so the user knows how to get the url to the binary file

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
