### PR TITLE
Fix apt installation instructions

### DIFF
--- a/install/installation-debian.md
+++ b/install/installation-debian.md
@@ -33,6 +33,7 @@ instead.
     /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
     ```
 1.  Add the TimescaleDB third party repository:
+
     <terminal>
 
     <tab label='Debian'>
@@ -52,6 +53,7 @@ instead.
     </tab>
 
     </terminal>
+    
 1.  Install Timescale GPG key
     ```bash
     wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -

--- a/install/installation-debian.md
+++ b/install/installation-debian.md
@@ -26,7 +26,7 @@ instead.
 1.  At the command prompt, as root, add the PostgreSQL third party repository
     to get the latest PostgreSQL packages:
     ```bash
-    apt install gnupg postgresql-common
+    apt install gnupg postgresql-common apt-transport-https lsb-release wget
     ```
 1.  Run the PostgreSQL repository setup script:
     ```bash
@@ -52,6 +52,10 @@ instead.
     </tab>
 
     </terminal>
+1.  Install Timescale GPG key
+    ```bash
+    wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -
+    ```
 1.  Update your local repository list:
     ```bash
     apt update


### PR DESCRIPTION
While individual packages in the apt repository are not signed the package list still is though. So we need to install our GPG key for package list verification. This PR adds this missing command and also adds lsb-release,  apt-transport-https and wget to the list of packages to install cause they are used in the instructions but might not be installed by default on some installations.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

Fixes #715 