### PR TITLE
Fix typo in macOS Homebrew install docs

### DIFF
--- a/install/installation-macos.md
+++ b/install/installation-macos.md
@@ -10,8 +10,6 @@ If you have already installed PostgreSQL using a method other than Homebrew, you
 could encounter errors following these instructions. It is safest to remove any
 existing PostgreSQL installations before you begin. If you want to keep your
 current PostgreSQL installation, do not install TimescaleDB using this method.
-using this method.
-TimescaleDB using this method.
 [Install from source](/install/latest/self-hosted/installation-source/)
 instead.
 </highlight>


### PR DESCRIPTION
# Description

Removes some duplicated copy from a warning in the macOS Homebrew install docs.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
