### PR TITLE
Typo in path fixed

### DIFF
--- a/install/installation-windows.md
+++ b/install/installation-windows.md
@@ -26,7 +26,7 @@ instead.
     click `Environment Variables...`. Locate the `Path` variable and
     click `Edit...`. In the `Edit environment variable` dialog, click `New` and
     type the path to your PostgreSQL `pg_config` file. It should
-    be `C:\Program Files\PostreSQL\14\bin\`. Click `OK` to save your changes.
+    be `C:\Program Files\PostgreSQL\14\bin\`. Click `OK` to save your changes.
 1.  Download the TimescaleDB installation `.zip` file from our
     [Windows releases page][windows-releases].
 1.  Locate the downloaded file on your local file system, and extract the files.


### PR DESCRIPTION
Reported by community member Stefan (thank you) there was a 'g' missing in the path to the bin folder. This PR addresses the issue.

# Description

To fix the typo in a path (which can be inconvenient). 

# Version

Which documentation version does this PR apply to?

- [ x] Latest (Default)
- [ ] Version 1.7. _not sure_
- [ ] Older [specify] _not sure_

# Links

N/A
