### PR TITLE
Fix Promscale command

### DIFF
--- a/promscale/installation/source.md
+++ b/promscale/installation/source.md
@@ -42,7 +42,7 @@ In this procedure, you download the Promscale binaries and run them.
 1.  Run Promscale by providing the connection details for your TimescaleDB
     service:
     ```bash
-    ./promscale --db-name <DBNAME> --db-password <DBPASSWORD> --db-ssl-mode allow
+    ./promscale --db-host <DB_HOSTNAME> --db-port <DB_PORT> --db-name <DBNAME> --db-password <DBPASSWORD> --db-ssl-mode allow
     ```
 
     <highlight type="note">


### PR DESCRIPTION
# Description

Add parameters for host and database which are needed for folks that don't run Promscale and. the database on the same host (the majority).

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

