### PR TITLE
Fix mistyped TimescaleDB name

### DIFF
--- a/install/installation-cloud-image.md
+++ b/install/installation-cloud-image.md
@@ -54,7 +54,7 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the TimeascaleDB extension
+## Set up the TimescaleDB extension
 When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't
@@ -142,6 +142,6 @@ if you want to have a chat.
 [aws-instance-config]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html
 [contact]: https://www.timescale.com/contact
 [install-psql]: /how-to-guides/connecting/psql/
-[tsdb-docs]: timeascaledb/:currentVersion:/index/
+[tsdb-docs]: timescaledb/:currentVersion:/index/
 [tutorials]: /timescaledb/:currentVersion:/tutorials/
 [config]: /how-to-guides/configuration/

--- a/install/installation-debian.md
+++ b/install/installation-debian.md
@@ -74,7 +74,7 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the TimeascaleDB extension
+## Set up the TimescaleDB extension
 When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't

--- a/install/installation-macos.md
+++ b/install/installation-macos.md
@@ -43,7 +43,7 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the TimeascaleDB extension
+## Set up the TimescaleDB extension
 When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't
@@ -128,7 +128,7 @@ if you want to have a chat.
 
 [contact]: https://www.timescale.com/contact
 [install-psql]: /how-to-guides/connecting/psql/
-[tsdb-docs]: timeascaledb/:currentVersion:/index/
+[tsdb-docs]: timescaledb/:currentVersion:/index/
 [tutorials]: /timescaledb/:currentVersion:/tutorials/
 [config]: /how-to-guides/configuration/
 [homebrew]: https://docs.brew.sh/Installation

--- a/install/installation-redhat.md
+++ b/install/installation-redhat.md
@@ -130,7 +130,7 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the TimeascaleDB extension
+## Set up the TimescaleDB extension
 When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't

--- a/install/installation-source.md
+++ b/install/installation-source.md
@@ -149,7 +149,7 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the TimeascaleDB extension
+## Set up the TimescaleDB extension
 When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't

--- a/install/installation-windows.md
+++ b/install/installation-windows.md
@@ -40,7 +40,7 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the TimeascaleDB extension
+## Set up the TimescaleDB extension
 When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't
@@ -126,7 +126,7 @@ if you want to have a chat.
 [config]: /how-to-guides/configuration/
 [contact]: https://www.timescale.com/contact
 [install-psql]: /how-to-guides/connecting/psql/
-[tsdb-docs]: timeascaledb/:currentVersion:/index/
+[tsdb-docs]: timescaledb/:currentVersion:/index/
 [tutorials]: /timescaledb/:currentVersion:/tutorials/
 [ms-download]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 [pg-download]: https://www.postgresql.org/download/windows/

--- a/timescaledb/overview/release-notes/changes-in-timescaledb-2.md
+++ b/timescaledb/overview/release-notes/changes-in-timescaledb-2.md
@@ -374,7 +374,7 @@ could potentially force the next job to start all over again.
 
 To prevent this, the `ignore_invalidation_older_than` setting could be used to ignore backfill data older than
 a specified interval (e.g., ignore backfill older than 1 week), preventing the materializer from restarting if
-hypertable data was modified beyond this interval boundary. However, this would also stop TimescalDB 1.x from
+hypertable data was modified beyond this interval boundary. However, this would also stop TimescaleDB 1.x from
 tracking changes in the underlying data beyond the `ignore_invalidation_older_than` threshold too. This meant
 that it was not possible to revert this setting later to a larger interval (e.g., 1 month) without potentially
 having a mismatch between the raw data and the aggregated data in the continuous aggregate.


### PR DESCRIPTION
Fixes a couple typos

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
