### PR TITLE
Clarify when chunk_compression_stats is updated.

### DIFF
--- a/api/chunk_compression_stats.md
+++ b/api/chunk_compression_stats.md
@@ -3,6 +3,12 @@
 Get chunk-specific statistics related to hypertable compression.
 All sizes are in bytes.
 
+This view shows the cached size of chunks. The cached sizes are computed 
+when `compress_chunk` is executed, or when a compression policy touches 
+the chunk. An insert into a compressed chunk does not update the cached 
+sizes. For more information about how to compute exact sizes, rather than 
+cached sizes, see the `chunks_detailed_size` section.
+
 ### Required Arguments
 
 |Name|Type|Description|


### PR DESCRIPTION
# Description

Clarify when chunk_compression_stats view is updated

# Version

2.x all versions (from the introduction of chunk_compression_stats view).
- [ ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Addresses:  https://github.com/timescale/timescaledb/issues/3982