### PR TITLE
Use a fully qualified hypertable name in an example

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/materialized-hypertables.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/materialized-hypertables.md
@@ -4,8 +4,8 @@ and store the intermediate state in a materialization hypertable. You can modify
 this materialized hypertable in the same way as any other hypertable.
 
 ## Discover the name of a materialized hypertable
-To change a materialized hypertable, you need to discover the name of it. To do
-this, use the
+To change a materialized hypertable, you need to discover the fully qualified
+name of it. To do this, use the
 [timescaledb_information.continuous_aggregates view][api-continuous-aggregates-info]).
 You can then use the name to modify it in the same way as any other hypertable.
 
@@ -14,7 +14,8 @@ You can then use the name to modify it in the same way as any other hypertable.
 ### Discovering the name of a materialized hypertable
 1.  At the `psql`prompt, query `timescaledb_information.continuous_aggregates`:
     ```sql
-    SELECT view_name, <materialization_hypertable_name>
+    SELECT view_name, format('%I.%I', materialization_hypertable_schema,
+            materialization_hypertable_name) AS materialization_hypertable
         FROM timescaledb_information.continuous_aggregates;
     ```
 1.  Locate the name of the hypertable you want to adjust in the results of the

--- a/timescaledb/how-to-guides/continuous-aggregates/materialized-hypertables.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/materialized-hypertables.md
@@ -4,8 +4,8 @@ and store the intermediate state in a materialization hypertable. You can modify
 this materialized hypertable in the same way as any other hypertable.
 
 ## Discover the name of a materialized hypertable
-To change a materialized hypertable, you need to discover the fully qualified
-name of it. To do this, use the
+To change a materialized hypertable, you need to use its fully qualified
+name. To find the correct name, use the
 [timescaledb_information.continuous_aggregates view][api-continuous-aggregates-info]).
 You can then use the name to modify it in the same way as any other hypertable.
 


### PR DESCRIPTION
# Description

In an example, use the fully qualified name of the materialization hypertable, because it doesn't work otherwise.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)

# Links

Fixes https://github.com/timescale/timescaledb/issues/4002
