### PR TITLE
Fix misspell on postgres-config.md page

### DIFF
--- a/timescaledb/how-to-guides/configuration/postgres-config.md
+++ b/timescaledb/how-to-guides/configuration/postgres-config.md
@@ -21,7 +21,7 @@ and you can use a `#` symbol at the beginning of a line to denote a comment.
 
 When you have made changes to the configuration file, the new configuration is
 not applied immediately. The configuration file is reloaded whenever the server
-receives a `SIGHUP` sugnal, or you can manually reload the file uses the
+receives a `SIGHUP` signal, or you can manually reload the file uses the
 `pg_ctl` command.
 
 ## Setting parameters at the command prompt


### PR DESCRIPTION
# Description

Fix misspell in signal word on postgres-config.md page

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
