### PR TITLE
Fix command error in Node code quick start

### DIFF
--- a/timescaledb/quick-start/node.md
+++ b/timescaledb/quick-start/node.md
@@ -227,7 +227,7 @@ Now you're ready to create the `node_test` database. From the command line, type
 the following:
 
 ```bash
-npx sequelize db:create node_test
+npx sequelize db:create
 ```
 
 You should get this result:


### PR DESCRIPTION
# Description

npx command was incorrect.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/731
