### PR TITLE
Update the docs for CAGGs with TZ support

### DIFF
--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -189,8 +189,8 @@ This table shows which `time_bucket_ng()` functions can be used in a continuous 
 |-|-|-|
 |Buckets by seconds, minutes, hours, days, and weeks|✅|2.4.0 and later|
 |Buckets by months and years|✅|2.6.0 or later|
+|Timezones support|✅|2.6.0 or later|
 |Specify custom origin|❌|To be determined|
-|Timezones support|❌|To be determined|
 
 [time_bucket]: /hyperfunctions/time_bucket/
 [caggs]: /timescaledb/:currentVersion:/overview/core-concepts/continuous-aggregates/


### PR DESCRIPTION
## CAGGs with timezones support will be delivered in TimescaleDB 2.6.0.
Update the documentation accordingly.

# Description

[Short summary of why you created this PR]

# Version

Which documentation version does this PR apply to?

- [x] TimescaleDB 2.6
- [ ] Version 1.7
- [ ] Older [specify]

# Links

None
