### PR TITLE
Add links to data model index page

### DIFF
--- a/timescaledb/overview/data-model-flexibility/index.md
+++ b/timescaledb/overview/data-model-flexibility/index.md
@@ -29,7 +29,7 @@ timestamp | device_id | cpu_1m_avg | free_mem | temperature | location_id | dev_
 2017-01-01 01:03:42 | ghi789 | 100 | 100MB | 56 |  77 | roof
 
 
-Now, let's look at various ways to model this data:
+Now you can look at various ways to model this data:
 
 - [Wide data model][wide-data-model]
 - [Narrow data model][narrow-data-model]

--- a/timescaledb/overview/data-model-flexibility/index.md
+++ b/timescaledb/overview/data-model-flexibility/index.md
@@ -29,4 +29,10 @@ timestamp | device_id | cpu_1m_avg | free_mem | temperature | location_id | dev_
 2017-01-01 01:03:42 | ghi789 | 100 | 100MB | 56 |  77 | roof
 
 
-Now, let's look at various ways to model this data.
+Now, let's look at various ways to model this data:
+
+- [Wide data model][wide-data-model]
+- [Narrow data model][narrow-data-model]
+
+[wide-data-model]: /overview/data-model-flexibility/wide-data-model/
+[narrow-data-model]: /overview/data-model-flexibility/narrow-data-model/


### PR DESCRIPTION
# Description

Ending of page is a bit abrupt since the "next page" button isn't immediately obvious

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
