### PR TITLE
add space between quick and starts

### DIFF
--- a/timescaledb/quick-start/index.md
+++ b/timescaledb/quick-start/index.md
@@ -1,6 +1,6 @@
 # Language quick starts
 
-Here is a collection of quick starts on your favorite language.
+Here is a collection of quick starts for your favorite language.
 
 <highlight type="warning">
 If you didn't find a quick start with your beloved language,

--- a/timescaledb/quick-start/index.md
+++ b/timescaledb/quick-start/index.md
@@ -1,6 +1,6 @@
 # Language quick starts
 
-Here is a collection of quickstarts on your favorite language.
+Here is a collection of quick starts on your favorite language.
 
 <highlight type="warning">
 If you didn't find a quick start with your beloved language,


### PR DESCRIPTION
# Description
"Quickstarts" as a term appears to be used in the industry, but we specifically use "quick start" several other places. For consistency, recommending this space.

@jproman1 request 