### PR TITLE
Add step to add GPG key for apt install.

### DIFF
--- a/install/installation-debian.md
+++ b/install/installation-debian.md
@@ -32,6 +32,10 @@ instead.
     ```bash
     /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
     ```
+1.  Add the Timescale GPG key:
+    ```bash
+    curl -L https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
+    ```
 1.  Add the TimescaleDB third party repository:
 
     <terminal>
@@ -53,7 +57,7 @@ instead.
     </tab>
 
     </terminal>
-    
+
 1.  Install Timescale GPG key
     ```bash
     wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -


### PR DESCRIPTION
# Description

Add step to apt install instructions to add the Timescale GPG key.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/705