### PR TITLE
Change phrasing on 'manage services' to make the meaning clearer

### DIFF
--- a/mst/user-management.md
+++ b/mst/user-management.md
@@ -7,12 +7,16 @@ service.
 You can invite new users to join your project as project members. There are
 several roles available for project members:
 
-|Role|Invite more users|Modify billing information|Manage services|Start and stop services|View service information|
+|Role|Invite more users|Modify billing information|Manage existing services|Start and stop services|View service information|
 |-|-|-|-|-|-|
 |Admin|✅|✅|✅|✅|✅|
 |Operator|❌|❌|✅|✅|✅|
 |Developer|✅|❌|✅|❌|✅|
 |Read-only|❌|❌|❌|❌|✅|
+
+Users who can manage existing services can create databases and connect to them,
+on a service that already exists. To create a new service, users need the start
+and stop services permission.
 
 <procedure>
 


### PR DESCRIPTION
# Description

Some of the nuance on the user management page was lost in the transition from the Kbase. This clarifies what is meant by 'manage services' by changing the column heading, and including a note.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

- Fixes https://github.com/timescale/docs/issues/711
- Original PR with the content migration from Kbase: https://github.com/timescale/docs/pull/225
