### PR TITLE
[Update] Fixed the 404 link for docs-standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,4 +149,4 @@ Timescale is in the process of creating comprehensive writing and style standard
 *   Ted Sczelecki <https://github.com/tedsczelecki>
 
 
-[docs-standards]: timescaledb/latest/contribute-to-docs
+[docs-standards]: timescaledb/:currentVersion:/contribute-to-docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,4 +149,4 @@ Timescale is in the process of creating comprehensive writing and style standard
 *   Ted Sczelecki <https://github.com/tedsczelecki>
 
 
-[docs-standards]: timescaledb/contribute-to-docs
+[docs-standards]: timescaledb/latest/contribute-to-docs


### PR DESCRIPTION
# Description

Fixed the 404 link for docs-standards
# Version

Which documentation version does this PR apply to?

- [ ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
