### PR TITLE
fix windows-install configuration link

### DIFF
--- a/install/installation-windows.md
+++ b/install/installation-windows.md
@@ -123,7 +123,7 @@ You can always [contact us][contact] if you need help working something out, or
 if you want to have a chat.
 
 
-[config]: /how-to-guides/configuration/
+[config]: timescaledb/:currentVersion:/how-to-guides/configuration/
 [contact]: https://www.timescale.com/contact
 [install-psql]: timescaledb/:currentVersion:/how-to-guides/connecting/psql/
 [tsdb-docs]: timescaledb/:currentVersion:/index/


### PR DESCRIPTION
# Description

Fix 404 on configuration link.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
