### PR TITLE
Remove warning about backups on multi-node

### DIFF
--- a/timescaledb/overview/core-concepts/backup-restore.md
+++ b/timescaledb/overview/core-concepts/backup-restore.md
@@ -7,15 +7,14 @@ or logical backups with [`pg_dump`][pg_dump] and [`pg_restore`][pg_restore].
 Physical backups may also be used with Write-Ahead Log (WAL) archiving to
 achieve an ongoing backup.
 
-<highlight type="warning">
-TimescaleDB currently does not natively support a consistent restore point for
-multi-node environments. Care should be taken to ensure third-party solutions
-properly quiesce the environment before backing up, so that the backup point used
-across nodes does not have outstanding transactions.
-</highlight>
-
+If you have a multi-node deployment, make sure you can restore to a 
+point that ensures consistency across all nodes. You can create a 
+restore point with the
+[`create_distributed_restore_point`][create_distributed_restore_point] 
+function, and use it later when you restore from a physical backup.
 
 
 [postgres-pg_basebackup]: https://www.postgresql.org/docs/current/app-pgbasebackup.html
 [pg_dump]: https://www.postgresql.org/docs/current/static/app-pgdump.html
 [pg_restore]: https://www.postgresql.org/docs/current/static/app-pgrestore.html
+[create_distributed_restore_point]: /api/:currentVersion:/distributed-hypertables/create_distributed_restore_point/


### PR DESCRIPTION
# Description

Remove a warning that says that multi-node doesn't support a
consistent restore point. This hasn't been true for some time since we
have `create_distributed_restore_point`.

# Version

Which documentation version does this PR apply to?

- [ x] Latest (Default)


