### PR TITLE
Make dataset one word for consistency across docs

### DIFF
--- a/timescaledb/tutorials/index.md
+++ b/timescaledb/tutorials/index.md
@@ -35,8 +35,8 @@ data analysis and make forecasts on your data.
 
 ### Additional resources
 
-- **[Sample data sets][sample-data-sets]**: And if you want to explore on your own
-with some sample data, we have some ready-made data sets for you to explore.
+- **[Sample datasets][sample-data-sets]**: And if you want to explore on your own
+with some sample data, we have some ready-made datasets for you to explore.
 - **[Simulate IoT sensor data][simul-iot-data]**: Simulate a basic IoT sensor dataset
 on PostgreSQL or TimescaleDB.
 - **[psql installation][psql]**: `psql` is a terminal-based front-end for PostgreSQL.


### PR DESCRIPTION
# Description

Make spelling of "dataset" consistent across pages

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #777
