### PR TITLE
Add note about timezone required for buckets less than one day + edits

### DIFF
--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -47,8 +47,7 @@ or annual aggregates.
 | `timezone` | TEXT | The name of the timezone. The argument can be specified only if the type of `ts` is TIMESTAMPTZ |
 
 For backward compatibility with `time_bucket()` the `timezone` argument is
-optional. However, it is required for time buckets that are less than twenty
-four hours.
+optional. However, it is required for time buckets that are less than 24 hours.
 
 If you call the TIMESTAMPTZ-version of the function without the `timezone`
 argument, the timezone defaults to the session's timezone and so the function

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -48,11 +48,12 @@ or annual aggregates.
 
 For backward compatibility with `time_bucket()` the `timezone` argument is
 optional. However, it is required for time buckets that are less than twenty
-four hours. 
+four hours.
 
 If you call the TIMESTAMPTZ-version of the function without the `timezone`
 argument, the timezone defaults to the session's timezone and so the function
-can't be used with continuous aggregates.
+can't be used with continuous aggregates. Best practice is to use
+`time_bucket_ng(interval, timestamptz, text)` and specify the timezone.
 
 ### Return value
 

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -1,22 +1,22 @@
 ## timescaledb_experimental.time_bucket_ng() <tag type="experimental">Experimental</tag>
 The `time_bucket_ng()` (next generation) experimental function is an updated
 version of  the original [`time_bucket()`][time_bucket] function. While
-`time_bucket` works only with small units of time,  `time_bucket_ng()` 
+`time_bucket` works only with small units of time,  `time_bucket_ng()`
 supports years and months in addition to small units of time.
 
 <highlight type="warning">
 Experimental features could have bugs! They might not be backwards compatible,
-and could be removed in future releases. When this function is no longer experimental, 
-you will need to delete and rebuild any continuous aggregate that uses it. 
-Use experimental features at your own risk and we do not recommend to use 
+and could be removed in future releases. When this function is no longer experimental,
+you will need to delete and rebuild any continuous aggregate that uses it.
+Use experimental features at your own risk and we do not recommend to use
 any experimental feature in a production environment.
 </highlight>
 
-Functionality | time_bucket() | time_bucket_ng()
---------------|---------------|-----------------
-Buckets by seconds, minutes, hours, days and weeks | YES | YES
-Buckets by months and years | NO | YES
-Timezones support | NO | YES
+|Functionality|time_bucket()|time_bucket_ng()|
+|-|-|-|
+|Buckets by seconds, minutes, hours, days and weeks|YES|YES|
+|Buckets by months and years|NO|YES|
+|Timezones support|NO|YES|
 
 <highlight type="warning">
 The `time_bucket()` and `time_bucket_ng()` functions are similar, but not
@@ -47,9 +47,12 @@ or annual aggregates.
 | `timezone` | TEXT | The name of the timezone. The argument can be specified only if the type of `ts` is TIMESTAMPTZ |
 
 For backward compatibility with `time_bucket()` the `timezone` argument is
-optional. Note that if you call the TIMESTAMPTZ-version of the function
-without the `timezone` argument, the timezone defaults to the session's
-timezone and so the function can't be used with continuous aggregates.
+optional. However, it is required for time buckets that are less than twenty
+four hours. 
+
+If you call the TIMESTAMPTZ-version of the function without the `timezone`
+argument, the timezone defaults to the session's timezone and so the function
+can't be used with continuous aggregates.
 
 ### Return value
 
@@ -178,9 +181,9 @@ ORDER BY bucket;
 For more information, see the [continuous aggregates documentation][caggs].
 
 <highlight type="important">
-While `time_bucket_ng()` supports months and timezones, 
-continuous aggregates cannot always be used with monthly 
-buckets or buckets with timezones. 
+While `time_bucket_ng()` supports months and timezones,
+continuous aggregates cannot always be used with monthly
+buckets or buckets with timezones.
 </highlight>
 
 This table shows which `time_bucket_ng()` functions can be used in a continuous aggregate:


### PR DESCRIPTION
# Description

Added clarification that timezone param is required for buckets that are less than a day. Also fixed the formatting of the first table.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/792
