### PR TITLE
Update migration docs

### DIFF
--- a/cloud/migrate-to-cloud/entire-database.md
+++ b/cloud/migrate-to-cloud/entire-database.md
@@ -132,7 +132,7 @@ pg_restore: warning: errors ignored on restore: 1
 [install-timescale-cloud]: /install/:currentVersion:/installation-cloud/
 [migrate-separately]: migrate-to-cloud/schema-then-data/
 [pg_dump]: https://www.postgresql.org/docs/current/app-pgdump.html
-[pg_restore]: https://www.postgresql.org/docs/9.2/app-pgrestore.html
+[pg_restore]: https://www.postgresql.org/docs/current/app-pgrestore.html
 [psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
 [timescaledb_pre_restore]: /api/:currentVersion:/administration/timescaledb_pre_restore/
 [timescaledb_post_restore]: /api/:currentVersion:/administration/timescaledb_post_restore/

--- a/cloud/migrate-to-cloud/schema-then-data.md
+++ b/cloud/migrate-to-cloud/schema-then-data.md
@@ -355,7 +355,7 @@ ANALYZE;
 [extensions]: /customize-configuration/#postgresql-extensions
 [install-timescale-cloud]: /install/:currentVersion:/installation-cloud/
 [pg_dump]: https://www.postgresql.org/docs/current/app-pgdump.html
-[pg_restore]: https://www.postgresql.org/docs/9.2/app-pgrestore.html
+[pg_restore]: https://www.postgresql.org/docs/current/app-pgrestore.html
 [psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
 [retention-policy]: /how-to-guides/data-retention/create-a-retention-policy/
 [reorder-policy]: /api/:currentVersion:/hypertable/add_reorder_policy/


### PR DESCRIPTION
# Description

- Fix outdated link in cloud migration docs
- Edit instructions for migrating from different database and add link to new cloud migration guide so readers can find more detailed instructions

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
