### PR TITLE
Remove redundant nav item in Cloud section

### DIFF
--- a/cloud/page-index/page-index.js
+++ b/cloud/page-index/page-index.js
@@ -25,10 +25,6 @@ module.exports = [
         ],
       },
       {
-        title: "Scale a service",
-        href: "scaling-a-service",
-      },
-      {
         title: "Customize configuration",
         href: "customize-configuration",
       },


### PR DESCRIPTION
# Description

"Scale a service" appears twice in the Cloud nav, linking to the same page each time. This PR removes one of them.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
