### PR TITLE
Update  pg_restore limitations

### DIFF
--- a/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
+++ b/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
@@ -48,6 +48,11 @@ database and restore the data.
 
 </procedure>
 
+<highlight type="warning">
+Do not use the `pg_restore` command with -j option. This option does not 
+correctly restore the Timescale catalogs.
+</highlight>
+
 ## Back up individual hypertables [](backup-hypertable)
 The `pg_dump` command provides flags that allow you to specify tables or schemas
 to back up. However, using these flags means that the dump lacks necessary


### PR DESCRIPTION
# Description
pg_restore with -j option does not work for timescaledb extension

# Version
All

Which documentation version does this PR apply to?

- [x ] Latest (Default)
any older version of the docs that we still maintain.
This is an old problem that has not been documented.

# Links

Fixes https://github.com/timescale/timescaledb/issues/4101
