### PR TITLE
Add admon about pg v12 or higher for on prem installs

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -22,6 +22,11 @@ head over to [Managed Service for TimescaleDB][mst-install]. This option allows
 you more flexibility in choosing where your installation is hosted, from more
 than 75 regions on Amazon Web Services, Azure, or Google Cloud Platform.
 
+<highlight type="important">
+Before you begin installing TimescaleDB, make sure you have installed PostgreSQL
+version 12 or higher.
+</highlight>
+
 *   Start using the [Timescale Cloud][tsc-install] hosted service.
 *   Install self-hosted TimescaleDB on [your own server hardware][self-hosted-install].
 *   Install self-hosted TimescaleDB [from source][self-hosted-source].

--- a/install/installation-debian.md
+++ b/install/installation-debian.md
@@ -10,6 +10,11 @@ instructions use the `apt` package manager on these distributions:
 *   Ubuntu 21.04 Hirsute Hippo
 *   Ubuntu 21.10 Impish Indri
 
+<highlight type="important">
+Before you begin installing TimescaleDB, make sure you have installed PostgreSQL
+version 12 or higher.
+</highlight>
+
 <highlight type="warning">
 If you have already installed PostgreSQL using a method other than the `apt`
 package manager, you could encounter errors following these instructions. It is

--- a/install/installation-macos.md
+++ b/install/installation-macos.md
@@ -5,6 +5,11 @@ These instructions use a Homebrew installer on these versions:
 *   Apple macOS 11 Big Sur
 *   Apple macOS 12 Monterey
 
+<highlight type="important">
+Before you begin installing TimescaleDB, make sure you have installed PostgreSQL
+version 12 or higher.
+</highlight>
+
 <highlight type="warning">
 If you have already installed PostgreSQL using a method other than Homebrew, you
 could encounter errors following these instructions. It is safest to remove any

--- a/install/installation-redhat.md
+++ b/install/installation-redhat.md
@@ -10,6 +10,10 @@ distributions:
 *   Fedora 34
 *   Fedora 35
 
+<highlight type="important">
+Before you begin installing TimescaleDB, make sure you have installed PostgreSQL
+version 12 or higher.
+</highlight>
 
 <highlight type="warning">
 If you have already installed PostgreSQL using a method other than the `yum` or

--- a/install/installation-ubuntu-ami.md
+++ b/install/installation-ubuntu-ami.md
@@ -1,5 +1,4 @@
 ## Installing from an Amazon AMI (Ubuntu) [](installation-ubuntu-ami)
-
 TimescaleDB is currently available as an Ubuntu 18.04 Amazon EBS-backed AMI. AMIs are
 distributed by region, and our AMI is currently available in US and EU
 regions. Note that this image is built to use an EBS attached volume

--- a/install/installation-windows.md
+++ b/install/installation-windows.md
@@ -5,6 +5,11 @@ These instructions use a `zip` installer on these versions:
 *   Microsoft Windows 11
 *   Microsoft Windows Server 2019
 
+<highlight type="important">
+Before you begin installing TimescaleDB, make sure you have installed PostgreSQL
+version 12 or higher.
+</highlight>
+
 <highlight type="warning">
 If you have already installed PostgreSQL using a method other than the `zip`
 installer provided here, you could encounter errors following these


### PR DESCRIPTION
# Description

Adds an admonition about having pg 12 or higher before you install TimescaleDB on-prem

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/811
