### PR TITLE
Update time_bucket_ng() docs; custom origin support will be available since 2.7.0

### DIFF
--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -193,7 +193,7 @@ This table shows which `time_bucket_ng()` functions can be used in a continuous 
 |Buckets by seconds, minutes, hours, days, and weeks|✅|2.4.0 and later|
 |Buckets by months and years|✅|2.6.0 or later|
 |Timezones support|✅|2.6.0 or later|
-|Specify custom origin|❌|To be determined|
+|Specify custom origin|✅|2.7.0 or later|
 
 [time_bucket]: /hyperfunctions/time_bucket/
 [caggs]: /timescaledb/:currentVersion:/overview/core-concepts/continuous-aggregates/


### PR DESCRIPTION
# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Docs for https://github.com/timescale/timescaledb/pull/4045
