### PR TITLE
Add instructions for installing Toolkit from package

### DIFF
--- a/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
+++ b/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
@@ -21,13 +21,16 @@ ALTER EXTENSION timescaledb_toolkit UPDATE;
 If you're hosting your own TimescaleDB database, you can install Toolkit as an
 RPM, Debian, or Ubuntu package. You can also build Toolkit from source.
 
-<procedure>
+### Install Toolkit on Red Hat-based systems
 
-### Installing Toolkit on Red Hat-based systems
 These instructions use the `dnf` package manager on RHEL, CentOS, and Fedora.
 
+<procedure>
+
+#### Installing Toolkit on Red Hat-based systems
+
 1.  Make sure you have installed TimescaleDB and created a TimescaleDB
-    repository in your `yum` `repo.d` directory. For more information, see [the installation
+    repository in your `yum` `repo.d` directory. For more information, see [the
     instructions for Red Hat-based systems][red-hat-install].
 1.  Update your local repository list:
     ```bash
@@ -45,14 +48,17 @@ These instructions use the `dnf` package manager on RHEL, CentOS, and Fedora.
 
 </procedure>
 
-<procedure>
+### Install Toolkit on Debian-based systems
 
-### Installing Toolkit on Debian-based systems
 These instructions use the `apt` package manager on Debian and Ubuntu.
 
+<procedure>
+
+#### Installing Toolkit on Debian-based systems
+
 1.  Make sure you have installed TimescaleDB and added the TimescaleDB
-    repository and GPG key. For more information, see [the installation
-    instructions for Debian-based systems][debian-install].
+    repository and GPG key. For more information, see [the instructions for
+    Debian-based systems][debian-install].
 1.  Update your local repository list:
     ```bash
     apt update
@@ -69,9 +75,14 @@ These instructions use the `apt` package manager on Debian and Ubuntu.
 
 </procedure>
 
+### Build Toolkit from source
+
+You can build Toolkit from source. For more information, see the [Toolkit
+developer documentation][toolkit-gh-docs] .
+
 <procedure>
 
-### Building Toolkit from source
+#### Building Toolkit from source
 1.  The extension requires `rust`, `rustfmt`, `clang`, and `pgx` packages, as
     well as the PostgreSQL headers for your installed version of PostgreSQL.
     Install these using your native package manager. For instructions on how to
@@ -93,9 +104,6 @@ These instructions use the `apt` package manager on Debian and Ubuntu.
     ```
 
 </procedure>
-
-For more information about installing Toolkit from source, see the
-[developer documentation][toolkit-gh-docs] .
 
 [cloud]: /cloud/:currentVersion:/
 [debian-install]: /install/:currentVersion:/self-hosted/installation-debian/

--- a/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
+++ b/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
@@ -27,7 +27,7 @@ RPM, Debian, or Ubuntu package. You can also build Toolkit from source.
 These instructions use the `dnf` package manager on RHEL, CentOS, and Fedora.
 
 1.  Make sure you have installed TimescaleDB and created a TimescaleDB
-    repository in your `yum` repos. For more information, see [the installation
+    repository in your `yum` `repo.d` directory. For more information, see [the installation
     instructions for Red Hat-based systems][red-hat-install].
 1.  Update your local repository list:
     ```bash

--- a/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
+++ b/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
@@ -1,12 +1,13 @@
 # Install TimescaleDB Toolkit
 Some hyperfunctions are included in the default TimescaleDB product. For
-additional hyperfunctions, you need to install the Timescale Toolkit PostgreSQL
+additional hyperfunctions, you need to install the TimescaleDB Toolkit PostgreSQL
 extension.
 
-If you are using [Timescale Cloud][], the Toolkit is already installed.
+If you're using [Timescale Cloud][cloud], the Toolkit is already installed.
 
-On [Managed TimescaleDB][], run this command on each database you want to use
-the Toolkit with:
+## Install Toolkit on Managed Service for TimescaleDB
+On [Managed Service for TimescaleDB][mst], run this command on each database you
+want to use the Toolkit with:
 ```sql
 CREATE EXTENSION timescaledb_toolkit;
 ```
@@ -17,12 +18,60 @@ ALTER EXTENSION timescaledb_toolkit UPDATE;
 ```
 
 ## Install Toolkit on self-hosted TimescaleDB
-If you are hosting your own TimescaleDB database you install the Toolkit
-extension from the command prompt.
+If you're hosting your own TimescaleDB database, you can install Toolkit as an
+RPM, Debian, or Ubuntu package. You can also build Toolkit from source.
 
 <procedure>
 
-### Installing Toolkit on self-hosted TimescaleDB
+### Installing Toolkit on Red Hat-based systems
+These instructions use the `dnf` package manager on RHEL, CentOS, and Fedora.
+
+1.  Make sure you have installed TimescaleDB and created a TimescaleDB
+    repository in your `yum` repos. For more information, see [the installation
+    instructions for Red Hat-based systems][red-hat-install].
+1.  Update your local repository list:
+    ```bash
+    dnf update
+    ```
+1.  Install TimescaleDB Toolkit:
+    ```bash
+    dnf install timescaledb-toolkit-postgresql-14
+    ```
+1.  Connect to the database where you want to use Toolkit.
+1.  Create the Toolkit extension in the database:
+    ```sql
+    CREATE EXTENSION timescaledb_toolkit;
+    ```
+
+</procedure>
+
+<procedure>
+
+### Installing Toolkit on Debian-based systems
+These instructions use the `apt` package manager on Debian and Ubuntu.
+
+1.  Make sure you have installed TimescaleDB and added the TimescaleDB
+    repository and GPG key. For more information, see [the installation
+    instructions for Debian-based systems][debian-install].
+1.  Update your local repository list:
+    ```bash
+    apt update
+    ```
+1.  Install TimescaleDB Toolkit:
+    ```bash
+    apt install timescaledb-toolkit-postgresql-14
+    ```
+1.  Connect to the database where you want to use Toolkit.
+1.  Create the Toolkit extension in the database:
+    ```sql
+    CREATE EXTENSION timescaledb_toolkit;
+    ```
+
+</procedure>
+
+<procedure>
+
+### Building Toolkit from source
 1.  The extension requires `rust`, `rustfmt`, `clang`, and `pgx` packages, as
     well as the PostgreSQL headers for your installed version of PostgreSQL.
     Install these using your native package manager. For instructions on how to
@@ -45,10 +94,12 @@ extension from the command prompt.
 
 </procedure>
 
-For more information about installing Toolkit from source, see our
+For more information about installing Toolkit from source, see the
 [developer documentation][toolkit-gh-docs] .
 
-[Timescale Cloud]: /cloud/:currentVersion:/
-[Managed TimescaleDB]: /mst/:currentVersion:/
+[cloud]: /cloud/:currentVersion:/
+[debian-install]: /install/:currentVersion:/self-hosted/installation-debian/
+[mst]: /mst/:currentVersion:/
+[red-hat-install]: /install/:currentVersion:/self-hosted/installation-redhat/
 [rust-install]: https://www.rust-lang.org/tools/install
 [toolkit-gh-docs]: https://github.com/timescale/timescaledb-toolkit#-installing-from-source


### PR DESCRIPTION
# Description

TimescaleDB toolkit is now available as an Ubuntu, Debian, or RPM package. This PR adds package installation instructions to the Toolkit install guide.

Also includes:
- Minor fixes to align with branding and style guide
- Spell out reference links so Vale can check for broken links

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #541 
