### PR TITLE
Restructure and update contributing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,36 @@
 # Introduction
-There are multiple ways to help make TimescaleDB better. All of our
-documentation and source for the PostgreSQL extension are available to use and
-review with GitHub.
+Help make TimescaleDB better. Our documentation and [source
+code][timescaledb-repo] are available to use and review with GitHub. This guide
+covers the contributing workflow for our documentation. For our style guide, see
+[the contributing page on our site][docs-standards].
+
+## Contribute to documentation
+
+We accept pull requests for [major](#make-a-major-change) and [minor
+changes](#make-a-minor-change).
+
+### Make a minor change
+
+For minor changes, such as typos and broken-link fixes, you can edit directly in
+GitHub. 
+
+#### Making a minor change
+
+1.  Sign in to your [github](github.com) account, or make a new one.
+1.  Open the file you want to edit within GitHub.
+1.  Click the pencil icon in the top-right corner of the code box. GitHub
+    automatically forks the project for you and opens a code editor.
+    <img src="" />
+1.  Make your edits.
+1.  Propose your changes by adding a title and optional description in the
+    `Propose changes` box at the bottom of the page.
+1.  Review the differences between your changes and the `latest` branch on our
+    docs repository. Click `Create pull request`.
+1.  Edit the pull request description. Click `Create pull request`. If
+    this is your first contribution, you receive a comment asking you to sign
+    our Contributor License Agreement.  
+1.  Sign the agreement to allow us to use your contribution in our
+    documentation.
 
 ## First contribution
 You can make contributions to the documentation by creating a fork of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,13 +44,13 @@ GitHub.
 For larger changes, such as new content and long edits, fork the repository and
 make changes on your local machine.
 
-## Fork and clone the repository
+#### Fork and clone the repository
 If this is your first contribution, start by forking the repository and cloning
 the fork to your local machine.
 
 <procedure>
 
-### Forking and cloning the repository
+##### Forking and cloning the repository
 1.  Sign in to your [github](github.com) account.
 1.  Navigate to the [Timescale documentation repo](github.com/timescale/docs).
 1.  Click the `Fork` button in the top-right corner, and select the account you
@@ -106,13 +106,13 @@ the fork to your local machine.
 
 </procedure>
 
-## Commit changes and create a pull request
+#### Commit changes and create a pull request
 Once you have a local copy of the docs, make your changes. Then commit your work
 and create a pull request to the Timescale docs repo.
 
 <procedure>
 
-### Committing changes
+##### Committing changes
 1.  Make your changes. You can edit the Markdown files in any text editor. For
     mroe information, see the sections on [repository
     structure](#repository-structure) and [markup
@@ -134,7 +134,7 @@ and create a pull request to the Timescale docs repo.
     git push --set-upstream origin <BRANCH_NAME>
     ```
 
-### Creating a pull request
+##### Creating a pull request
 1.  Navigate to the [Timescale documentation repo](github.com/timescale/docs).
 1.  Click `Compare and Create Pull Request`.
 1.  Write an informative commit message detailing your changes. 
@@ -160,7 +160,7 @@ soon as possible. Even if you haven't finished work, you can make a pull request
 with the Draft feature. Communicating your work helps prevent duplicated work
 and conflicting information.
 
-## Keep your local copy up to date
+### Keep your local copy up to date
 As other contributors add to the docs, your local copy drifts out of sync with
 the `latest` branch. Avoid merge conflicts by keeping your local copy up to
 date. Fetch and merge changes from `latest` every day before you begin your
@@ -168,7 +168,7 @@ work, and again whenever you switch branches.
 
 <procedure>
 
-### Keeping your local copy up to date
+#### Keeping your local copy up to date
 1.  Check out your fork's `latest` branch:
     ```bash
     git checkout latest
@@ -277,7 +277,7 @@ module.exports = [
 ]
 ```
 
-#### Layout of `page-index.js`
+### Layout of `page-index.js`
 
 Each page listed in `page-index.js` can have the following properties:
 
@@ -291,7 +291,7 @@ Each page listed in `page-index.js` can have the following properties:
 |`type`|Optional|Associates the page with a specific page type that has special features or layout. Not usually required.|
 |`newLabel`|Optional|Adds a `NEW` label to content in the navigation menu. Set the value of `newLabel` the date when the label should expire. Use the format `"Month Day Year"` or `"YYYY-MM-DD"`.|
 
-### How to add a new page
+### Add a new page
 
 To add a new page, create a new `<FILENAME>.md` file within the appropriate
 folder. Name your file descriptively, in lowercase, and separate words with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,7 +282,7 @@ module.exports = [
 Each page listed in `page-index.js` can have the following properties:
 
 |Property|Required or optional|Description|
-|-|-|
+|-|-|-|
 |`href`|Required|The name of the Markdown file containing the content for the page. For example: `example-file.md`|
 |`title`|Optional|The page title to display in the navigation menu and browser title area. If no title is provided, `href` is used, in Camel Case and with hyphens replaced by spaces.|
 |`children`|Optional|An array containing the child pages for the page. Child-page properties are defined in the same way as parent-page properties. Child pages can be nested inside other child pages to form multiple levels. The filenames provided in `href` should be located in a sub-folder with the same name as the parent page.|

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,116 @@ work, and again whenever you switch branches.
 
 ## Repository structure
 
+The documentation site's navigation hierarchy mirrors the repository's folder
+hierarchy. Each top-level section in the site corresponds to a top-level folder
+in the repository:
+
+|Site section|Repository folder|
+|-|-|
+|Install TimescaleDB|`install/`|
+|TimescaleDB|`timescaledb/`|
+|API reference|`api/`|
+|Timescale Cloud|`cloud/`|
+|Managed Service for TimescaleDB|`mst/`|
+|Promscale|`promscale/`|
+
+Each folder must contain an `index.md` file. This file contains the content for
+that section's landing page. For example, `cloud/index.md` contains the content
+for `docs.timescale.com/cloud/`.
+
+Each folder also contains other Markdown files. These files contain the content
+for that section's direct child pages.
+
+Each folder may also contain subfolders. These folders correspond to the
+subsections in that section. Each subfolder has its own `index.md` page and
+child pages, and may have its own subfolders.
+
+To find the repository file corresponding to a specific page, you can use the
+page's URL, ignoring the domain, subdomain, and version. For example, for the
+URL `docs.timescale.com/timescaledb/latest/how-to-guides/hyperfunctions/<SLUG>`,
+ignore the domain and subdomain, `docs.timescale.com`, and the version,
+`latest`. If the page has no sub-pages, the corresponding file is
+`timescaledb/how-to-guides/hyperfunctions/<SLUG>.md`. If the page has sub-pages,
+the corresponding file is
+`timescaledb/how-to-guides/hyperfunctions/<SLUG>/index.md`.
+
+### Site navigation
+
+The documentation site's navigation menu is defined in the `page-index.js`
+files. Each section's `page-index.js` contains the details for that section's
+landing page and child pages. For example:
+
+```js
+module.exports = [
+    {
+        href: "overview",
+        children: [
+          {
+            title: "What is time-series data?",
+            href: "what-is-time-series-data",
+            pageComponents: ['featured-cards'],
+            tags: ['data', 'timescaledb'],
+            keywords: ['TimescaleDB', 'data'],
+            excerpt: "Learn about time-series data"
+          },
+          {
+            title: "Core concepts",
+            href: "core-concepts",
+            excerpt: "Why use TimescaleDB?",
+            children : [
+              {
+                title: "Hypertables and chunks",
+                href: "hypertables-and-chunks",
+                tags: ['hypertables', 'chunks', 'timescaledb'],
+                keywords: ['hypertables', 'chunks', 'TimescaleDB'],
+                excerpt: "Understanding hypertables and chunks"
+              },
+              {
+                title: "Scaling",
+                href: "scaling",
+                tags: ['hypertables', 'chunks', 'timescaledb'],
+                keywords: ['hypertables', 'chunks', 'TimescaleDB'],
+                excerpt: "Scaling hypertables"
+              },
+              ...
+            ]
+          },
+          ...
+        ]
+    }
+]
+```
+
+#### Layout of `page-index.js`
+
+Each page listed in `page-index.js` can have the following properties:
+
+|Property|Required or optional|Description|
+|-|-|
+|`href`|Required|The name of the Markdown file containing the content for the page. For example: `example-file.md`|
+|`title`|Optional|The page title to display in the navigation menu and browser title area. If no title is provided, `href` is used, in Camel Case and with hyphens replaced by spaces.|
+|`children`|Optional|An array containing the child pages for the page. Child-page properties are defined in the same way as parent-page properties. Child pages can be nested inside other child pages to form multiple levels. The filenames provided in `href` should be located in a sub-folder with the same name as the parent page.|
+|`excerpt`|Optional|A short description of the page. Excerpts are displayed within navigation cards and Related Content cards.|
+|`pageComponents`|Optional|If provided, child pages are listed below any other content in the parent page. Takes two possible values, `['featured-cards']` and `['content-list']`, corresponding to the two list styles.|
+|`type`|Optional|Associates the page with a specific page type that has special features or layout. Not usually required.|
+|`newLabel`|Optional|Adds a `NEW` label to content in the navigation menu. Set the value of `newLabel` the date when the label should expire. Use the format `"Month Day Year"` or `"YYYY-MM-DD"`.|
+
+### How to add a new page
+
+To add a new page, create a new `<FILENAME>.md` file within the appropriate
+folder. Name your file descriptively, in lowercase, and separate words with
+hyphens.
+
+Then, add an entry to the `page-index.js` file for that section. To find the
+`page-index.js` file, look in the top-level folder for the section, which should
+be one of `api/`, `cloud/`, `install/`, `mst/`, `promscale/`, or `timescaledb/`.
+The folder contains a `page-index/` subfolder, which holds the `page-index.js`
+file.
+
+In larger sections, `page-index.js` is split into multiple files. In this case,
+the parent `page-index.js` starts with several `require` statements, which show
+the paths to child `page-index.js` files.
+
 ## Markup conventions
 
 ## The Timescale documentation team

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,53 +1,62 @@
 # Introduction
-Help make TimescaleDB better. Our documentation and [source
-code][timescaledb-repo] are available to use and review with GitHub. This guide
-covers the contributing workflow for our documentation. For our style guide, see
-[the contributing page on our site][docs-standards].
+You can help make TimescaleDB better in multiple ways. The documentation and
+TimescaleDB source code are available on GitHub. Issues and pull requests are
+encouraged.
+
+This guide covers the documentation's [contributing
+workflow](#contribute-to-documentation), [repository
+structure](#repository-structure), and [markup
+conventions](#markup-conventions). For the style guide, see [the documentation
+site](docs.timescale.com/timescaledb/latest/contribute-to-docs/).
+
+To contribute to TimescaleDB's source code, see the [TimescaleDB
+repository](github.com/timescale/timescaledb).
 
 ## Contribute to documentation
-
-We accept pull requests for [major](#make-a-major-change) and [minor
-changes](#make-a-minor-change).
+You can make contribute to documentation by making a pull request.
 
 ### Make a minor change
-
 For minor changes, such as typos and broken-link fixes, you can edit directly in
 GitHub. 
 
 #### Making a minor change
 
-1.  Sign in to your [github](github.com) account, or make a new one.
-1.  Open the file you want to edit within GitHub.
+1.  Sign in to your [github](github.com) account.
+1.  Open the file you want to edit within GitHub. For help finding the right
+    file, see the [repository structure section](#repository-structure).
 1.  Click the pencil icon in the top-right corner of the code box. GitHub
     automatically forks the project for you and opens a code editor.
-    <img src="" />
 1.  Make your edits.
 1.  Propose your changes by adding a title and optional description in the
     `Propose changes` box at the bottom of the page.
-1.  Review the differences between your changes and the `latest` branch on our
+1.  Review the differences between your changes and the `latest` branch on the
     docs repository. Click `Create pull request`.
 1.  Edit the pull request description. Click `Create pull request`. If
     this is your first contribution, you receive a comment asking you to sign
-    our Contributor License Agreement.  
-1.  Sign the agreement to allow us to use your contribution in our
-    documentation.
+    the Contributor License Agreement.  
+1.  Sign the agreement so your contribution can be added to the documentation.
 
-## First contribution
-You can make contributions to the documentation by creating a fork of the
-repository.
+### Make a larger change
+For larger changes, such as new content and long edits, fork the repository and
+make changes on your local machine.
+
+## Fork and clone the repository
+If this is your first contribution, start by forking the repository and cloning
+the fork to your local machine.
 
 <procedure>
 
-### Contributing using a fork
-1.  Make sure you have a [github](github.com) account, and that you're signed in.
-1.  Navigate to the [Timescale Documentation
-Repo](https://github.com/timescale/docs) click the `Fork` button in the
-top-right corner, and select the account you want to use.
+### Forking and cloning the repository
+1.  Sign in to your [github](github.com) account.
+1.  Navigate to the [Timescale documentation repo](github.com/timescale/docs).
+1.  Click the `Fork` button in the top-right corner, and select the account you
+    want to use.
 1.  Wait for GitHub to create your fork and redirect you.
-1.  Clone the repository to your local machine. To find this URL, click the green
-    `Code` button and copy the HTTPS URL:
+1.  Clone the repository to your local machine by clicking the green `Code`
+    button, copying the HTTPS URL, and running the following command at your
+    command prompt:
     ```bash
-    git clone https://github.com/<username>/docs.git
+    git clone <YOUR_FORK_URL>
     ```
 1.  List the current remote branches:
     ```bash
@@ -55,22 +64,24 @@ top-right corner, and select the account you want to use.
     ```
     This command should list two remotes, both marked `origin`, like this:
     ```bash
-    origin  https://github.com/<username>/docs.git (fetch)
-    origin  https://github.com/<username>/docs.git (push)
+    origin  https://github.com/<YOUR_GITHUB_USERNAME>/docs.git (fetch)
+    origin  https://github.com/<YOUR_GITHUB_USERNAME>/docs.git (push)
     ```
-    The `origin` remotes are your own fork, and you can do whatever you want here without changing the upstream repository.
+    The `origin` remotes are your own fork. You can do whatever you want here
+    without changing the upstream repository.
 1.  Add the docs repo as an upstream:
     ```bash
     git remote add upstream https://github.com/timescale/docs.git
     ```
-1.  Check:
+1.  Check that the upstream repo was successfully added:
     ```bash
     git remote -v
     ```
-    This command should now have the same two `origin` remotes as before, plus two more labelled `upstream`, like this:
+    This command should now list the two `origin` remotes from before, plus two
+    more labelled `upstream`, like this:
     ```bash
-    origin  https://github.com/<username>/docs.git (fetch)
-    origin  https://github.com/<username>/docs.git (push)
+    origin  https://github.com/<YOUR_GITHUB_USERNAME>/docs.git (fetch)
+    origin  https://github.com/<YOUR_GITHUB_USERNAME>/docs.git (push)
     upstream  https://github.com/timescale/docs.git (fetch)
     upstream  https://github.com/timescale/docs.git (push)
     ```
@@ -78,30 +89,37 @@ top-right corner, and select the account you want to use.
     ```bash
     git fetch upstream
     ```
-1.  Merge the changes from the upstream `latest` branch, into your fork's
+1.  Merge the changes from the upstream `latest` branch into your fork's
     `latest` branch:
     ```bash
     git merge upstream/latest
     ```
-1.  Create a new branch for the work you want to do. Make sure you give it an
-    appropriate name, and include your username:
+1.  Create a new branch for the work you want to do. Give it a descriptive name
+    that includes your GitHub username. For example:
     ```bash
-    git checkout -b update-readme-username
+    git checkout -b update-readme-<USERNAME>
     ```
 
 </procedure>
 
+## Commit changes and create a pull request
+Once you have a local copy of the docs, make your changes. Then commit your work
+and create a pull request to the Timescale docs repo.
+
 <procedure>
 
-### Committing changes and creating a pull request
-1.  Make your changes.
+### Committing changes
+1.  Make your changes. You can edit the Markdown files in any text editor. For
+    mroe information, see the sections on [repository
+    structure](#repository-structure) and [markup
+    conventions](#markup-conventions).
 1.  Add the updated files to your commit:
     ```bash
     git add .
     ```
 1.  Commit your changes:
     ```bash
-    git commit -m "Commit message here"
+    git commit -m "<COMMIT_MESSAGE>"
     ```
 1.  Push your changes:
     ```bash
@@ -109,32 +127,41 @@ top-right corner, and select the account you want to use.
     ```
     If git prompts you to set an upstream in order to push, use this command:
     ```bash
-    git push --set-upstream origin <branchname>
+    git push --set-upstream origin <BRANCH_NAME>
     ```
-1.  Create a pull request (PR) by navigating to <https://github.com/timescale/docs>
-    and clicking `Compare and Create Pull Request`. Write an informative commit
-    message detailing your changes, choose reviewers, and save your PR. If you
-    haven't yet finished the work you want to do, make sure you create a draft PR by
-    selecting it from the drop down box in the GitHub web UI. This lets your
-    reviewers know that you haven't finished work yet, while still being transparent
-    about what you are working on, and making sure we all understand current
-    progress.
+
+### Creating a pull request
+1.  Navigate to the [Timescale documentation repo](github.com/timescale/docs).
+1.  Click `Compare and Create Pull Request`.
+1.  Write an informative commit message detailing your changes. 
+1.  Choose reviewers. Each documentation change needs a reviewer from the
+    [Timescale documentation team](#the-timescale-documentation-team). If you
+    made changes to any technical details, you also neeed a subject matter
+    expert (SME) to review. For help choosing an SME, see the [TimescaleDB
+    source code repo](github.com/timescale/timescaledb) for SMEs who have worked
+    on your topic.
+1.  If you've finished your work, submit a pull request by clicking `Create pull
+    request`. If you haven't finished, create a draft PR by clicking the arrow
+    beside `Create pull request`. This lets your reviewers know that you're
+    working on the topic. They can understand your progress and expect your
+    contribution. Once you've finished, you can click `Ready for review`.
 
 </procedure>
 
-<highlight type="warning">Choose your reviewers carefully! If you have made changes to the technical
-detail of the documentation, choose an appropriate subject matter expert (SME)
-to review those changes. Additionally, every change requires at least one
-documentation team member to approve.</highlight>
+Commit to your feature branch early and often, and create your pull request as
+soon as possible. Even if you haven't finished work, you can make a pull request
+with the Draft feature. Communicating your work often helps prevent duplicated
+work and conflicting information.
 
-## Second contribution
-Once you have checked out the repo and want to keep working on things, you need
-to ensure that your local copy of the repo stays up to date. If you don't do
-this, you *will* end up with merge conflicts.
+## Keep your local copy up to date
+As other contributors add to the docs, your local copy drifts out of sync with
+the `latest` branch. Avoid merge conflicts by keeping your local copy up to
+date. Fetch and merge changes from `latest` every day before you begin your
+work, and again whenever you switch branches.
 
 <procedure>
 
-### Second contribution
+### Keeping your local copy up to date
 1.  Check out your fork's `latest` branch:
     ```bash
     git checkout latest
@@ -144,38 +171,30 @@ this, you *will* end up with merge conflicts.
     Switched to branch 'latest'
     Your branch is up to date with 'origin/latest'.
     ```
-    BEWARE! This is usually a lie!
+    BEWARE! Despite the message, your branch is probably _not_ up to date. Your
+    `origin/` pointers don't reflect the latest changes in the upstream remote
+    repository.
 1.  Fetch the branches in the upstream repository:
     ```bash
     git fetch upstream
     ```
-1.  Merge the changes from the upstream `latest` branch, into your fork's
+1.  Merge the changes from the upstream `latest` branch into your fork's
     `latest` branch:
     ```bash
     git merge upstream/latest
     ```
-1.  If you are continuing work you began earlier, check out the branch that
-    contains your work. For new work, create a new branch. Doing this regularly as
-    you are working means you keep your local copies up to date and avoid
-    conflicts. You should do it at least every day before you begin work, and again
-    whenever you switch branches.
-
+1.  To continue work that you began earlier, check out the branch that contains
+    your work. To start new work, create a new branch. 
 
 </procedure>
 
-<highlight type="warning">Never leave branches lying around on your local system. Create your PR as soon
-as possible, and make good use of the Draft feature. Commit to your feature
-branch early and often! Update your local copy from latest whenever you switch
-branches.</highlight>
+## Repository structure
 
-## Writing standards
-Timescale is in the process of creating comprehensive writing and style standards. For the current guidelines, see [contributing to documentation][docs-standards].
+## Contributor license agreement
 
 ## The Timescale documentation team
 *   Ryan Booz <https://github.com/ryanbooz>
 *   Lana Brindley <https://github.com/Loquacity>
-*   Hel Rabelo <https://github.com/helrabelo>
-*   Ted Sczelecki <https://github.com/tedsczelecki>
+*   Charis Lam <https://github.com/charislam>
+*   Rajakavitha Kodhandapani <https://github.com/Rajakavitha1>
 
-
-[docs-standards]: timescaledb/:currentVersion:/contribute-to-docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ You can make contribute to documentation by making a pull request.
 For minor changes, such as typos and broken-link fixes, you can edit directly in
 GitHub. 
 
+<procedure>
+
 #### Making a minor change
 
 1.  Sign in to your [github](github.com) account.
@@ -35,6 +37,8 @@ GitHub.
     this is your first contribution, you receive a comment asking you to sign
     the Contributor License Agreement.  
 1.  Sign the agreement so your contribution can be added to the documentation.
+
+</procedure>
 
 ### Make a larger change
 For larger changes, such as new content and long edits, fork the repository and
@@ -73,7 +77,7 @@ the fork to your local machine.
     ```bash
     git remote add upstream https://github.com/timescale/docs.git
     ```
-1.  Check that the upstream repo was successfully added:
+1.  Check that the upstream repository is added successfully:
     ```bash
     git remote -v
     ```
@@ -145,13 +149,16 @@ and create a pull request to the Timescale docs repo.
     beside `Create pull request`. This lets your reviewers know that you're
     working on the topic. They can understand your progress and expect your
     contribution. Once you've finished, you can click `Ready for review`.
+1.  If this is your first contribution, you receive a comment asking you to sign
+    the Contributor License Agreement. Sign the agreement so your contribution
+    can be added to the documentation.
 
 </procedure>
 
 Commit to your feature branch early and often, and create your pull request as
 soon as possible. Even if you haven't finished work, you can make a pull request
-with the Draft feature. Communicating your work often helps prevent duplicated
-work and conflicting information.
+with the Draft feature. Communicating your work helps prevent duplicated work
+and conflicting information.
 
 ## Keep your local copy up to date
 As other contributors add to the docs, your local copy drifts out of sync with
@@ -190,11 +197,12 @@ work, and again whenever you switch branches.
 
 ## Repository structure
 
-## Contributor license agreement
+## Markup conventions
 
 ## The Timescale documentation team
 *   Ryan Booz <https://github.com/ryanbooz>
 *   Lana Brindley <https://github.com/Loquacity>
-*   Charis Lam <https://github.com/charislam>
+*   Daniel Bogart <https://github.com/daniel-bogart>
 *   Rajakavitha Kodhandapani <https://github.com/Rajakavitha1>
-
+*   Charis Lam <https://github.com/charislam>
+*   Jacob Prall <https://github.com/jacobprall>


### PR DESCRIPTION
# Description

Contributing and style information is spread between multiple places: two contributing pages on the docs site, `README.md`, and `CONTRIBUTING.md`. This PR reorganizes the information to make it more discoverable and less overlapping, so others find it easier to contribute to our docs.

## Changes so far

### `CONTRIBUTING.md`
- Restructure to include Github workflow information, repository structure, and markup conventions. Making this information available in one place makes it less overwhelming to get started
- Rewrite GitHub workflow instructions to generally follow docs conventions on procedures
- Remove `<highlight>`s as they don't display in GitHub, and the file isn't viewable from the docs site

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
