### PR TITLE
Fix for broken links and paths in promscale docs.

### DIFF
--- a/promscale/installation/kubernetes.md
+++ b/promscale/installation/kubernetes.md
@@ -48,13 +48,13 @@ You can provide arguments to the `helm install` command using this format:
 `--set key=value[,key=value]`. For example, to install the  chart with backups
 enabled, use this command:
 ```bash
-helm install my-release charts/timescaledb-single --set backup.enabled=true
+helm install my-release timescale/timescaledb-single --set backup.enabled=true
 ```
 
 Alternatively, you can provide a YAML file that includes parameters for
 installing the chart, like this:
 ```bash
-helm install my-release -f myvalues.yaml charts/timescaledb-single
+helm install my-release -f myvalues.yaml timescale/timescaledb-single
 ```
 
 ### Install the Promscale Helm chart

--- a/promscale/tobs/about.md
+++ b/promscale/tobs/about.md
@@ -32,6 +32,7 @@ projects.
 [kube-state-metrics]: https://github.com/kubernetes/kube-state-metrics
 [prometheus-operator]: https://github.com/prometheus-operator/prometheus-operator#prometheus-operator
 [promscale]: https://github.com/timescale/promscale
+[design-doc]: https://docs.google.com/document/d/1e3mAN3eHUpQ2JHDvnmkmn_9rFyqyYisIgdtgd3D1MHA/edit?usp=sharing
 [timescaledb]: https://github.com/timescale/timescaledb
 [promlens]: https://promlens.com/
 [opentelemetry-operator]: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-operator-for-kubernetes


### PR DESCRIPTION
# Description

As I was going through the promscale & friends installation process I've noticed a few links and paths were broken.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
