### PR TITLE
Adding missng page for compressing continuous aggregates

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
@@ -31,7 +31,7 @@ You can enable and disable compression on continuous aggregated by setting
 
 </procedure>
 
-Disabling compression on a continuous aggregate will fail if there are 
+Disabling compression on a continuous aggregate fails if there are 
 compressed chunks associated with the continuous aggregate. In this case, you 
 need to decompress the chunks, and then drop any compression policy on the 
 continuous aggregate, before you disable compression. For more detailed information, see the

--- a/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
@@ -13,7 +13,7 @@ the compressed chunk and then execute a [`refresh_continuous_aggregate`](/api/la
 </highlight>
 
 ## Enable compression on continuous aggregates
-You can enable and disable compression on continuous aggregated by setting
+You can enable and disable compression on continuous aggregated by setting the
 `compress` parameter when you alter the view.
 
 <procedure>

--- a/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
@@ -6,9 +6,11 @@ store the materialized data in compressed form to save on storage costs.
 You can get these cost savings by enabling compression on continuous 
 aggregates.
 
+<highlight type="warning">
 Currently, TimescaleDB does not support refreshing compressed regions of a 
 continuous aggregate. To do this, you have to manually decompress 
-the compressed chunk and then execute a `refresh_continuous_aggregate` call.
+the compressed chunk and then execute a [`refresh_continuous_aggregate`](/api/latest/continuous-aggregates/refresh_continuous_aggregate) call.
+</highlight>
 
 ## Enable compression on continuous aggregates
 You can enable and disable compression on continuous aggregated by setting
@@ -26,19 +28,22 @@ You can enable and disable compression on continuous aggregated by setting
     ```sql
     ALTER MATERIALIZED VIEW cagg_name set (timescaledb.compress = false);
     ```
+
 </procedure>
-The decompress command fails if there are compressed chunks associated with the 
-continuous aggregate. In this case, you need to decompress the chunks, and then 
-drop any compression policy on the continuous aggregate, before you disable 
-compression. For more detailed information, see the
+
+Disabling compression on a continuous aggregate will fail if there are 
+compressed chunks associated with the continuous aggregate. In this case, you 
+need to decompress the chunks, and then drop any compression policy on the 
+continuous aggregate, before you disable compression. For more detailed information, see the
 [decompress chunks] [decompress-chunks] section:
+
 ```sql
 SELECT decompress_chunk(c, true) FROM show_chunks('cagg_name') c;
- 
+```
 
 ## Compression policies on continuous aggregates
 Before  setting up a compression policy on a continuous aggregate, you should
-set up a refresh policy. The compression policy interval should be set so that
+set up a [refresh policy][refresh-policy]. The compression policy interval should be set so that
 actively refreshed regions are not compressed. This is to prevent refresh
 policies from failing. For example, consider a refresh policy like this:
 
@@ -48,6 +53,7 @@ SELECT add_continuous_aggregate_policy('cagg_name', start_offset=>'30 days', end
 
 With this kind of refresh policy, the compression policy needs the `compress_after` 
 parameter greater than the `refresh_start` parameter of the continuous aggregate policy:
+
 ```sql
 SELECT add_compression_policy('cagg_name', compress_after=>'45 days'::interval);
 ```
@@ -60,4 +66,5 @@ CALL refresh_continuous_aggregate('cagg_name', NULL, now() - '30 days'::interval
 ERROR:  cannot update/delete rows from chunk "_hyper_3_3_chunk" as it is compressed
 ```
 
-[decompress-chunks]:  how-to-guides/compression/decompress-chunks.md 
+[decompress-chunks]:  /how-to-guides/compression/decompress-chunks 
+[refresh-policy]: /how-to-guides/continuous-aggregates/refresh-policies

--- a/timescaledb/how-to-guides/page-index/page-index.js
+++ b/timescaledb/how-to-guides/page-index/page-index.js
@@ -280,6 +280,13 @@ module.exports = [
             excerpt: "Manage real time aggregates in continuous aggregates",
           },
           {
+            title: "Compress continuous aggregates",
+            href: "compression-on-continuous-aggregates",
+            tags: ["caggs", "manage", "timescaledb"],
+            keywords: ["caggs", "compression", "TimescaleDB"],
+            excerpt: "Manage real time aggregates in continuous aggregates",
+          },          
+          {
             title: "Troubleshoot continuous aggregates",
             href: "troubleshooting",
             tags: ["caggs", "tshoot", "timescaledb"],

--- a/timescaledb/how-to-guides/page-index/page-index.js
+++ b/timescaledb/how-to-guides/page-index/page-index.js
@@ -282,9 +282,9 @@ module.exports = [
           {
             title: "Compress continuous aggregates",
             href: "compression-on-continuous-aggregates",
-            tags: ["caggs", "manage", "timescaledb"],
+            tags: ["caggs", "compression", "timescaledb"],
             keywords: ["caggs", "compression", "TimescaleDB"],
-            excerpt: "Manage real time aggregates in continuous aggregates",
+            excerpt: "Compress continuous aggregates",
           },          
           {
             title: "Troubleshoot continuous aggregates",


### PR DESCRIPTION
# Description

With the 2.6 release, the page for compressing continuous aggregates was missed. This adds the page back in and fixes content.

# Version

Which documentation version does this PR apply to?

- [ x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
