### PR TITLE
Edit templates and add VS Code snippets

### DIFF
--- a/.vscode/api-reference.code-snippets
+++ b/.vscode/api-reference.code-snippets
@@ -1,0 +1,61 @@
+{
+	// Place your docs-timescale workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	 "API Reference": {
+	 	"scope": "markdown",
+	 	"prefix": ["api"],
+	 	"body": [
+	 		"# ${1:api_call}() <tag type=\"$2\" content=\"$2\" />",
+			 "${3:<!--Single sentence description of the API call-->}",
+             "```${4:sql}",
+             "${5:FIXME: Syntax example}",
+             "```",
+             "",
+             "${6:<!--Any special notes about the API call-->}",
+             "",
+             "${7:<!--Insert highlight using snippet `hl`-->}",
+             "",
+             "For more information about `$2`, see the [$8 docs][$9].",
+             "",
+             "## Required arguments",
+             "",
+             "|Name|Type|Description",
+             "|-|-|",
+             "|$10|$11|$12|",
+             "${13:<!--Add more table rows if necessary-->}",
+             "",
+             "${14:<!--Any special notes about the required arguments-->}",
+             "",
+             "## Optional arguments",
+             "",
+             "|Name|Type|Description|",
+             "|-|-|",
+             "|$15|$16|$17|",
+             "${18:<!--Add more table rows if necessary-->}",
+             "",
+             "${19:<!--Any special notes about the optional arguments-->}",
+             "",
+             "## Returns",
+             "",
+             "|Name|Type|Description|",
+             "|-|-|",
+             "|$20|$21|$22|",
+             "",
+             "${23:<!--Any special notes about the returns-->}",
+             "",
+             "## Sample usage",
+             "${24:<!--Single sentence description of what this example does-->}",
+             "```${25:sql}",
+             "$26",
+             "```",
+             "",
+             "[$9]: timescaledb/:currentVersion:/how-to-guides/${27:FIXME}/",
+	 	],
+	 	"description": "Insert API reference template"
+	 }
+}

--- a/.vscode/highlight-blank.code-snippets
+++ b/.vscode/highlight-blank.code-snippets
@@ -6,14 +6,14 @@
 	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
 	// Placeholders with the same ids are connected.
 	// Example:
-	 "Highlight Callout": {
+	 "Highlight Blank": {
 	 	"scope": "markdown",
-	 	"prefix": ["high","callout"],
+	 	"prefix": ["hl"],
 	 	"body": [
 	 		"<highlight type=\"${1:note|important|warning|deprecated}\">",
-			 "$TM_SELECTED_TEXT",
+			 "$2",
 			 "</highlight>"
 	 	],
-	 	"description": "Make the selected text a callout block"
+	 	"description": "Make a blank callout block"
 	 }
 }

--- a/api/_template.md
+++ b/api/_template.md
@@ -1,15 +1,18 @@
 # api_call() <tag type="FIXME" content="FIXME" />
-<!---Single sentence description of the API call-->
+<!--Single sentence description of the API call-->
+```sql
+FIXME: Syntax example
+```
 
-<!---Any special notes about the API call-->
-
-<!---For more information about api_call(), see the [FIXME docs][link_ref]-->
+<!--Any special notes about the API call-->
 
 <!---
 <highlight type="note"
 Use a highlight for any important information. Choose `note`, `important`, or `warning`.
 </highlight>
 -->
+
+For more information about `api_call`, see the [ docs][].
 
 ## Required arguments
 


### PR DESCRIPTION
# Description

Minor edits to API template
- Add syntax example right after the introductory sentence for quick reference (this is the pattern we currently have on many of the hyperfunctions docs)
- Put callouts before "for more information" (not terribly tied to this if anyone disagrees)

Add/edit VS code snippets
- Add an API snippet for quickly inserting the template
- Edit existing highlight snippet to enumerate options for highlight type
- Add a new highlight snippet to insert a blank snippet (existing snippet converts selected text to highlight)

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
