### PR TITLE
Fixing broken links in new toolkit docs

### DIFF
--- a/api/duration_in.md
+++ b/api/duration_in.md
@@ -1,5 +1,5 @@
 # duration_in()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
-Use this function to report the total duration for a given state in a [state aggregate][(hyperfunctions/frequency-analysis/state_agg/)].
+Use this function to report the total duration for a given state in a [state aggregate][state_agg].
 
 <highlight type="warning">
 Experimental features could have bugs. They might not be backwards compatible,
@@ -44,3 +44,5 @@ Which gives the result:
 --------------
  338400000000
 ```
+
+[state_agg]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/frequency-analysis/state_agg/

--- a/api/freq_agg.md
+++ b/api/freq_agg.md
@@ -2,7 +2,7 @@
 The `freq_agg` aggregate uses the [SpaceSaving][spacesaving-algorithm] algorithm 
 to estimate the most common elements of a set. This API takes a sizing parameter and 
 a PostgreSQL column, and returns a FreqAgg object that can be passed to 
-[other freq_agg APIs][(hyperfunctions/frequency-analysis/).
+[other freq_agg APIs][frequency-analysis].
 
 <highlight type="warning">
 Experimental features could have bugs. They might not be backwards compatible,
@@ -30,4 +30,4 @@ CREATE toolkit_experimental.freq_agg(0.05, ZIP) FROM HomeSales;
 ```
 
 [spacesaving-algorithm]: https://www.cse.ust.hk/~raywong/comp5331/References/EfficientComputationOfFrequentAndTop-kElementsInDataStreams.pdf
-[frequency-analysis]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/function-pipelines/#timevectors
+[frequency-analysis]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/frequency-analysis/

--- a/api/frequency-analysis.md
+++ b/api/frequency-analysis.md
@@ -10,10 +10,10 @@ additional hyperfunctions, you need to install the
 
 |Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
 |-|-|-|-|-|
-|Frequency|FrequencyAggregate|[`freq_agg`][(hyperfunctions/frequency-analysis/freq_agg/)]|❌|✅|
-|Frequency||[`values`][(hyperfunctions/frequency-analysis/values-freq_agg/)]|❌|✅|
-|Frequency||[`topn`][(hyperfunctions/frequency-analysis/topn/)]|❌|✅|
-|Frequency|StateAgg|[`state_agg`][(hyperfunctions/frequency-analysis/state_agg/)]|❌|✅|
-|Frequency||[`duration_in`][(hyperfunctions/frequency-analysis/duration_in/)]|❌|✅|
+|Frequency|FrequencyAggregate|[`freq_agg`](hyperfunctions/frequency-analysis/freq_agg/)|❌|✅|
+|Frequency||[`values`](hyperfunctions/frequency-analysis/values-freq_agg/)|❌|✅|
+|Frequency||[`topn`](hyperfunctions/frequency-analysis/topn/)|❌|✅|
+|Frequency|StateAgg|[`state_agg`](hyperfunctions/frequency-analysis/state_agg/)|❌|✅|
+|Frequency||[`duration_in`](hyperfunctions/frequency-analysis/duration_in/)|❌|✅|
 
 [install-toolkit]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/topn.md
+++ b/api/topn.md
@@ -1,6 +1,6 @@
 # topn()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
 This function returns the most common values accumulated in a 
-[frequency aggregate][(hyperfunctions/frequency-analysis/freq_agg/)]. Note that 
+[frequency aggregate][freq_agg]. Note that 
 since the aggregate operates over `AnyElement` types, this method does require 
 a type parameter to determine the type of the output.
 
@@ -54,3 +54,5 @@ The output for this query:
    16
    15
 ```
+
+[freq_agg]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/frequency-analysis/freq_agg/

--- a/api/values-freq_agg.md
+++ b/api/values-freq_agg.md
@@ -1,6 +1,6 @@
 # values()  <tag type="toolkit">Toolkit</tag><tag type="experimental">Experimental</tag>
 This function returns the data accumulated in a 
-[frequency aggregate][(hyperfunctions/frequency-analysis/freq_agg/)].  
+[frequency aggregate][freq_agg].  
 The aggregate operates over `AnyElement` types, so this method 
 requires a type parameter to determine the type of the output.
 
@@ -56,3 +56,5 @@ The output for this query looks like this, with some variation due to randomness
     11 |  0.05565 |  0.05595
     10 |  0.05286 |  0.05289
 ```
+
+[freq_agg]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/frequency-analysis/freq_agg/


### PR DESCRIPTION
# Description

I recently some new documents for some experimental toolkit features.
It looks like the links in these documents were not properly set up.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
