### PR TITLE
Edit reset service password section

### DIFF
--- a/cloud/operations.md
+++ b/cloud/operations.md
@@ -42,8 +42,8 @@ password you use to connect to your database, not the password to your Timescale
 Cloud account. To reset your Timescale Cloud password, navigate to the `Account`
 page. 
 
-When you reset your service password, you are first prompted for your Timescale
-Cloud password. Once you authenticate, you can create a new service password,
+When you reset your service password, you are prompted for your Timescale
+Cloud password. When you have authenticated, you can create a new service password,
 ask Timescale Cloud to auto-generate a password, or switch your authentication
 type between SCRAM and MD5.
 

--- a/cloud/operations.md
+++ b/cloud/operations.md
@@ -36,10 +36,16 @@ complete the transition before you start forking.
 
 </procedure>
 
-### Reset password
-Use this section to reset the password you use to log in to your Timescale Cloud
-account. You must have access to the current password to do this. If you have
-forgotten your password, you can reset it from the login screen instead.
+### Reset service password
+You can reset your service password from the `Operations` dashboard. This is the
+password you use to connect to your database, not the password to your Timescale
+Cloud account. To reset your Timescale Cloud password, navigate to the `Account`
+page. 
+
+When you reset your service password, you are first prompted for your Timescale
+Cloud password. Once you authenticate, you can create a new service password,
+ask Timescale Cloud to auto-generate a password, or switch your authentication
+type between SCRAM and MD5.
 
 ### Pause service
 You can pause a service if you want to stop it running temporarily. This stops

--- a/cloud/operations.md
+++ b/cloud/operations.md
@@ -47,6 +47,11 @@ Cloud password. Once you authenticate, you can create a new service password,
 ask Timescale Cloud to auto-generate a password, or switch your authentication
 type between SCRAM and MD5.
 
+SCRAM (Salted Challenge Response Authentication Mechanism) and MD5 (Message Digest
+Algorithm 5) are cryptographic authentication mechanisms. Timescale Cloud uses SCRAM
+by default. It is more secure and strongly recommended. The MD5 option is provided
+for compatibility with older clients.
+
 ### Pause service
 You can pause a service if you want to stop it running temporarily. This stops
 your service from costing you, but the service is still available and ready to


### PR DESCRIPTION
# Description

- Correct Operations/Password section to clarify that it resets the service password, not the Cloud password
- Add mention that you can change from SCRAM to MD5 authentication

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #866 
