### PR TITLE
Replace smart quotes with apostrophes

### DIFF
--- a/_procedure-block.md
+++ b/_procedure-block.md
@@ -16,7 +16,7 @@
   ```
 
 3. TimescaleDB is a time-series database, built on top of PostgreSQL. More than that,
-however, it’s a relational database for time-series. Developers who use TimescaleDB
+however, it's a relational database for time-series. Developers who use TimescaleDB
 get the benefit of a purpose-built time-series database, plus a classic relational
 database (PostgreSQL), all in one, with full SQL support.
 

--- a/api/copy_chunk_experimental.md
+++ b/api/copy_chunk_experimental.md
@@ -39,7 +39,7 @@ source data node. To clean up these objects and metadata, use
 ### Sample usage
 
 ``` sql
-CALL timescaledb_experimental.copy_chunk(‘_timescaledb_internal._dist_hyper_1_1_chunk’, ‘data_node_2’, ‘data_node_3’);
+CALL timescaledb_experimental.copy_chunk('_timescaledb_internal._dist_hyper_1_1_chunk', 'data_node_2', 'data_node_3');
 ```
 
 [password-config]: /timescaledb/:currentVersion:/how-to-guides/multinode-timescaledb/multinode-auth/

--- a/api/histogram.md
+++ b/api/histogram.md
@@ -18,8 +18,8 @@ starting with `min`, but values equal to the `max` are in the last bucket.
 |Name|Type|Description|
 |---|---|---|
 | `value` | ANY VALUE | A set of values to partition into a histogram |
-| `min` | NUMERIC | The histogram’s lower bound used in bucketing (inclusive) |
-| `max` | NUMERIC | The histogram’s upper bound used in bucketing (exclusive) |
+| `min` | NUMERIC | The histogram's lower bound used in bucketing (inclusive) |
+| `max` | NUMERIC | The histogram's upper bound used in bucketing (exclusive) |
 | `nbuckets` | INTEGER | The integer value for the number of histogram buckets (partitions) |
 
 ### Sample usage 

--- a/api/job_stats.md
+++ b/api/job_stats.md
@@ -18,7 +18,7 @@ used to implement the policy succeeded and when it is scheduled to run next.
 |`last_run_started_at`| TIMESTAMP WITH TIME ZONE | Start time of the last job|
 |`last_successful_finish`| TIMESTAMP WITH TIME ZONE | Time when the job completed successfully|
 |`last_run_status` | TEXT | Whether the last run succeeded or failed |
-|`job_status`| TEXT | Status of the job. Valid values are ‘Running’, ‘Scheduled’ and 'Paused'|
+|`job_status`| TEXT | Status of the job. Valid values are 'Running', 'Scheduled' and 'Paused'|
 |`last_run_duration`| INTERVAL | Duration of last run of the job|
 |`next_scheduled_run` | TIMESTAMP WITH TIME ZONE | Start time of the next run |
 |`total_runs` | BIGINT | The total number of runs of this job|

--- a/api/move_chunk_experimental.md
+++ b/api/move_chunk_experimental.md
@@ -38,7 +38,7 @@ source data node. To clean up these objects and metadata, use
 ### Sample usage
 
 ``` sql
-CALL timescaledb_experimental.move_chunk(‘_timescaledb_internal._dist_hyper_1_1_chunk’, ‘data_node_2’, ‘data_node_3’);
+CALL timescaledb_experimental.move_chunk('_timescaledb_internal._dist_hyper_1_1_chunk', 'data_node_2', 'data_node_3');
 ```
 
 [password-config]: /timescaledb/:currentVersion:/how-to-guides/multinode-timescaledb/multinode-auth/#v1-set-the-password-encryption-method-for-access-node-and-data-nodes

--- a/install/managed-service-for-timescaledb.md
+++ b/install/managed-service-for-timescaledb.md
@@ -66,7 +66,7 @@ utility for configuring and maintaining PostgreSQL. We recommend
 You can see a green `Running` label and a green dot under the "Nodes" column when
 your instance is ready for use.
 
-Once your instance is ready, navigate to the ‘Overview Tab’ of your Timescale
+Once your instance is ready, navigate to the 'Overview Tab' of your Timescale
 Cloud dashboard and locate your `host`, `port`, and `password`, as highlighted below.
 
 <img class="main-content__illustration" src="https://s3.amazonaws.com/docs.timescale.com/hello-timescale/NYC_figure1_1.png" alt="NYC Taxis"/>

--- a/mst/ingest-data.md
+++ b/mst/ingest-data.md
@@ -76,7 +76,7 @@ Before you begin, make sure you have
     In this example, we are inserting the data using four workers:
     ```sql
     timescaledb-parallel-copy \
-    --connection '<service_url>’ \
+    --connection '<service_url>' \
     --table conditions \
     --file ~/Downloads/example.csv \
     --workers 4 \

--- a/mst/mst-multi-node.md
+++ b/mst/mst-multi-node.md
@@ -12,7 +12,7 @@ supercharge time-series data even further. One of the most anticipated new
 features is what we call **multi-node** - the ability to create a cluster of
 TimescaleDB instances to scale both reads and writes.
 
-In this How To, we’ll show you how to create a multi-node cluster in your
+In this How To, we'll show you how to create a multi-node cluster in your
 Managed Service for TimescaleDB account with TimescaleDB 2.0 as a
 "do-it-yourself" (DIY) multi-node experience.
 
@@ -89,7 +89,7 @@ User mapping authentication allows users to continue connecting with the
 allows you to continue making secure (SSL) connections to your Managed Service
 for TimescaleDB Access node.
 
-With user mapping authentication, you don’t need to manage any new users,
+With user mapping authentication, you don't need to manage any new users,
 however, **you need to have the passwords for the `tsdbadmin` user from each
 data node you are adding to the cluster**.
 

--- a/timescaledb/getting-started/access-timescaledb.md
+++ b/timescaledb/getting-started/access-timescaledb.md
@@ -10,7 +10,7 @@ to your TimescaleDB database.
 
 ## Verify that `psql` is installed
 Before you start, let's confirm that you already have `psql` installed.
-In fact, if you’ve ever installed PostgreSQL or TimescaleDB before, you likely already
+In fact, if you've ever installed PostgreSQL or TimescaleDB before, you likely already
 have `psql` installed.
 
 In a command line or terminal window, run the following command. If `psql` is

--- a/timescaledb/getting-started/add-data.md
+++ b/timescaledb/getting-started/add-data.md
@@ -1,7 +1,7 @@
 # 4. Add time-series data
 
-To showcase TimescaleDB and get you familiar with its features, we’ll need some
-sample data to play around with. We’ll use the real-world scenario of climate
+To showcase TimescaleDB and get you familiar with its features, we'll need some
+sample data to play around with. We'll use the real-world scenario of climate
 change. Data about the climate in a certain region is time-series data, as it
 describes how the climate in that area changes over time.
 
@@ -49,5 +49,5 @@ After unzipping the file, use the following command (which assumes `weather_data
 -- copy data from weather_data.csv into weather_metrics
 \copy weather_metrics (time, timezone_shift, city_name, temp_c, feels_like_c, temp_min_c, temp_max_c, pressure_hpa, humidity_percent, wind_speed_ms, wind_deg, rain_1h_mm, rain_3h_mm, snow_1h_mm, snow_3h_mm, clouds_percent, weather_type_id) from './weather_data.csv' CSV HEADER;
 ```
-Now that you’re up and running with historical data inside TimescaleDB and a
-method to ingest the latest data into your database, let’s start querying the data.
+Now that you're up and running with historical data inside TimescaleDB and a
+method to ingest the latest data into your database, let's start querying the data.

--- a/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
@@ -7,7 +7,7 @@ the average temperature in each location, you can calculate the average as a
 one-off, with a query like this:
 
 ```sql
-SELECT time_bucket(‘1 day’, time) as day,
+SELECT time_bucket('1 day', time) as day,
        location,
        avg(temperature)
 FROM temperatures
@@ -26,7 +26,7 @@ continuous aggregate view like this:
 
 ```sql
 CREATE MATERIALIZED VIEW daily_average WITH (timescaledb.continuous)
-    AS SELECT time_bucket(‘1 day’, time) as Day,
+    AS SELECT time_bucket('1 day', time) as Day,
               location,
               avg(temperature)
        FROM temperatures

--- a/timescaledb/how-to-guides/update-timescaledb/update-timescaledb-2.md
+++ b/timescaledb/how-to-guides/update-timescaledb/update-timescaledb-2.md
@@ -43,7 +43,7 @@ TimescaleDB 2.0 supports **in-place updates** just like previous releases. Durin
 the update, scripts automatically configure updated features to work as expected
 with TimescaleDB 2.0.
 
-Because this is our first major version release in two years, however, we’re providing additional guidance
+Because this is our first major version release in two years, however, we're providing additional guidance
 to help you ensure the update completes successfully and everything is configured as expected (and optimized
 for your workload). In particular, settings related to [Continuous Aggregates][caggs], [compression][compression],
 and [data retention][retention] have been modified to provide greater configuration transparency and flexibility,

--- a/timescaledb/index.md
+++ b/timescaledb/index.md
@@ -1,7 +1,7 @@
 # Welcome to the TimescaleDB documentation!
 
 TimescaleDB is a time-series database, built on top of PostgreSQL. More than that,
-however, it’s a relational database for time-series. Developers who use TimescaleDB
+however, it's a relational database for time-series. Developers who use TimescaleDB
 get the benefit of a purpose-built time-series database, plus a classic relational
 database (PostgreSQL), all in one, with full SQL support.
 

--- a/timescaledb/integrations/ingesting-data.md
+++ b/timescaledb/integrations/ingesting-data.md
@@ -50,7 +50,7 @@ of Telegraf with our plugin already included.
 </highlight>
 
 The PostgreSQL plugin extends the ease of use users get from leveraging Telegraf by handling schema generation and
-modification. This means that as metrics are collected by Telegraf, the plugin creates a table if it doesn’t exist and alters
+modification. This means that as metrics are collected by Telegraf, the plugin creates a table if it doesn't exist and alters
 the table if a schema has changed. By default, the plugin leverages a [wide model][wide-model], which is typically the schema
 model that TimescaleDB users tend to choose when storing metrics. However, you can specify that you want to store metrics in a
 narrow model with a separate metadata table and foreign keys. You can also choose to use JSONB.
@@ -62,7 +62,7 @@ To get started with the PostgreSQL and TimescaleDB output plugin, visit the [tut
 Another popular method of ingesting data into TimescaleDB is through the use of
 the [PostgreSQL connector with Kafka Connect][postgresql-connector-with-kafka-connect].
 The connector is designed to work with [Kafka Connect][kafka-connect] and to be
-deployed to a Kafka Connect runtime service. It’s purpose is to ingest change
+deployed to a Kafka Connect runtime service. It's purpose is to ingest change
 events from PostgreSQL databases (i.e. TimescaleDB).
 
 The deployed connector monitors one or more schemas within a TimescaleDB
@@ -77,7 +77,7 @@ Kafka Connect, enabling applications and services to directly connect to
 TimescaleDB and obtain the ordered change events. This approach requires the
 application to record the progress of the connector so that upon restart,
 the connect can continue where it left off. This approach may be useful for
-less critical use cases. However, for production use cases, it’s recommended
+less critical use cases. However, for production use cases, it's recommended
 that you use this connector with Kafka and Kafka Connect.
 </highlight>
 

--- a/timescaledb/overview/core-concepts/compression.md
+++ b/timescaledb/overview/core-concepts/compression.md
@@ -6,13 +6,13 @@ software. Compressing time-series data can significantly reduce the storage requ
 of your data and, in many cases, speed up the responsiveness of queries on
 historical, compressed data.
 
-Compression is powered by TimescaleDB’s built-in job scheduler framework. We
+Compression is powered by TimescaleDB's built-in job scheduler framework. We
 leverage it to asynchronously convert individual chunks from an uncompressed
 row-based form to a compressed columnar form across a hypertable: Once a chunk
 is old enough, the chunk is transactionally converted from the row to columnar form.
 
 With native compression, even though a single hypertable in TimescaleDB
-stores data in both row and columnar forms, users don’t need to worry about
+stores data in both row and columnar forms, users don't need to worry about
 this: they continue to see a standard row-based schema when querying data.
 This is similar to building a view on the decompressed columnar data.
 

--- a/timescaledb/overview/core-concepts/scaling.md
+++ b/timescaledb/overview/core-concepts/scaling.md
@@ -13,7 +13,7 @@ on a single machine is the significant cost/performance trade-off between memory
 and disk. Eventually, the entire dataset does not fit in memory, and you need
 to write your data and indexes to disk.
 
-Once the data is sufficiently large that we can’t fit all pages of our indexes
+Once the data is sufficiently large that we can't fit all pages of our indexes
 (e.g., B-trees) in memory, then updating a random part of the tree can involve
 swapping in data from disk.  And databases like PostgreSQL keep a B-tree (or
 other data structure) for each table index, in order for values in that

--- a/timescaledb/overview/index.md
+++ b/timescaledb/overview/index.md
@@ -46,7 +46,7 @@ Ask more complex queries, and build more powerful applications faster.
 
 *   **Centralize storage** of time‑series, application, and sensor data
 *   **Correlate metrics** with business and system‑of‑record data
-*   **Unlimited metadata**, don’t worry about cardinality of labels
+*   **Unlimited metadata**, don't worry about cardinality of labels
 *   **Perform JOINs to understand relations** with time‑series data
 *   **Ensure clean, correct data** with foreign keys and constraints
 
@@ -69,7 +69,7 @@ Spend less with compression savings from best‑in‑class algorithms, including
 *   **Downsampling** keeps aggregated metrics without wasting disk space
 *   Optimize storage consumption with
     **[data retention policies][data-retention]**
-*   **Transparent pricing**, always know what you’ll pay
+*   **Transparent pricing**, always know what you'll pay
 *   **Dynamically scale compute and storage** based on changing needs
 
 This section describes the design and motivation around the TimescaleDB

--- a/timescaledb/overview/release-notes/index.md
+++ b/timescaledb/overview/release-notes/index.md
@@ -57,9 +57,9 @@ hypertable setup. This includes the ability to add a data node and move
 chunks to the new data node for cluster rebalancing.
 
 
-We’re committed to developing these experiments, giving the community a chance to
-provide early feedback and influence the direction of TimescaleDB’s development.
- We’ll travel faster with your input!
+We're committed to developing these experiments, giving the community a chance to
+provide early feedback and influence the direction of TimescaleDB's development.
+ We'll travel faster with your input!
 
 Please [create your feedback as a GitHub issue][github-issue], and add the
 `experimental-schema` label. Describe what you found, and tell us the steps or
@@ -1326,7 +1326,7 @@ aggregates do not need to be refreshed manually; the view is refreshed
 automatically in the background as new data is added, or old data is
 modified. Additionally, it does not need to re-calculate all of the data on
 every refresh. Only new and/or invalidated data is calculated.  Since this
-re-aggregation is automatic, it doesn’t add any maintenance burden to your
+re-aggregation is automatic, it doesn't add any maintenance burden to your
 database.
 
 Our continuous aggregate approach supports high-ingest rates by avoiding the
@@ -1485,7 +1485,7 @@ This release contains bugfixes.
 Our 1.1 release introduces beta support for PG 11, as well as several performance optimizations aimed at improving chunk exclusion for read queries. We are also packaging our new timescale-tune tool (currently in beta) with our Debian and Linux releases. If you encounter any issues with our beta features, please file a GitHub issue.
 
 **Potential breaking changes**
-- In addition to optimizing first() / last() to utilize indices for non-group-by queries, we adjusted its sorting behavior to match that of PostgreSQL’s max() and min() functions. Previously, if the column being sorted had NULL values, a NULL would be returned. First() and last() now instead ignore NULL values.
+- In addition to optimizing first() / last() to utilize indices for non-group-by queries, we adjusted its sorting behavior to match that of PostgreSQL's max() and min() functions. Previously, if the column being sorted had NULL values, a NULL would be returned. First() and last() now instead ignore NULL values.
 
 **Notable commits**
 

--- a/timescaledb/overview/what-is-time-series-data.md
+++ b/timescaledb/overview/what-is-time-series-data.md
@@ -49,7 +49,7 @@ over time.**
 
 ## Characteristics of time-series data [](characteristics)
 
-If you look closely at how it’s produced and ingested, there are important
+If you look closely at how it's produced and ingested, there are important
 characteristics that time-series databases like TimescaleDB typically leverage:
 
 - **Time-centric**: Data records always have a timestamp.

--- a/timescaledb/quick-start/java.md
+++ b/timescaledb/quick-start/java.md
@@ -316,7 +316,7 @@ for (final var sensor : sensors) {
 
 You can insert a batch of rows into TimescaleDB in a couple of different ways.
 Let's see what it looks like to insert a number of rows with batching mechanism.
-For simplicity's sake, we’ll use PostgreSQL to generate some sample time-series data in order
+For simplicity's sake, we'll use PostgreSQL to generate some sample time-series data in order
 to insert into the `sensor_data` hypertable:
 
 ```java

--- a/timescaledb/timescaledb-edition-comparison.md
+++ b/timescaledb/timescaledb-edition-comparison.md
@@ -10,7 +10,7 @@ anyone can take this code and offer it as-a-service.
 
 - _Can I install TimescaleDB Apache 2 Edition in my own on-premises or cloud infrastructure and run it for free?_ <br/>
   Yes.
-- _Can I sell TimescaleDB Apache 2 Edition as a service, even if I’m not the main contributor?_ <br/>
+- _Can I sell TimescaleDB Apache 2 Edition as a service, even if I'm not the main contributor?_ <br/>
   Yes.
 - _Can I modify the TimescaleDB Apache 2 Edition source code and run it for production use?_ <br/>
   Yes.
@@ -25,7 +25,7 @@ Many of the most recent features of TimescaleDB are only available in TimescaleD
 
 - _Can I install TimescaleDB Community Edition in my own on-premises or cloud infrastructure and run it for free?_ <br/>
   Yes. TimescaleDB Community Edition is completely free if you manage your own service.
-- _Can I sell TimescaleDB Community Edition as a service, even if I’m not the main contributor?_ <br/>
+- _Can I sell TimescaleDB Community Edition as a service, even if I'm not the main contributor?_ <br/>
   No.
 - _Can I modify the TimescaleDB Community Edition source code and run it for production use?_ <br/>
   Yes. Developers using TimescaleDB Community Edition have the “right to repair” and make modifications to the source code and run it in their own on-premises or cloud infrastructure. However, consistent with the previous question, users may not make modifications to the TimescaleDB Community Edition source code and offer it as a service.

--- a/timescaledb/tutorials/analyze-nft-data/analyzing-nft-transactions.md
+++ b/timescaledb/tutorials/analyze-nft-data/analyzing-nft-transactions.md
@@ -235,7 +235,7 @@ blockchain and our database contains seller (`seller_account`) and
 buyer (`winner_account`) columns as well, you can analyze the purchase
 activity of a specific account.
 
-This query analyzes [Snoop Dogg’s](https://twitter.com/cozomomedici) address to
+This query analyzes [Snoop Dogg's](https://twitter.com/cozomomedici) address to
 analyze his trades, but you can edit the query to add any address in the `WHERE`
 clause to see the specified account's transactions:
 ```sql
@@ -555,14 +555,14 @@ The first 20 people to complete this tutorial can earn a limited edition NFT
 from the
 [Time Travel Tigers collection][eon-collection], for free!
 
-Now that you’ve completed the tutorial, all you need to do is answer the questions
-in [this form][nft-form] (including the challenge question), and we’ll send one
+Now that you've completed the tutorial, all you need to do is answer the questions
+in [this form][nft-form] (including the challenge question), and we'll send one
 of the limited-edition Eon NFTs to your ETH address (at no cost to you!).
 
 You can see all NFTs in the Time Travel Tigers collection live on [OpenSea][eon-collection].
 
 ### Build on the NFT Starter Kit
-Congratulations! You’re now up and running with NFT data and TimescaleDB. Check out
+Congratulations! You're now up and running with NFT data and TimescaleDB. Check out
 our [NFT Starter Kit][nft-starter-kit] to use as your starting point to
 build your own, more complex NFT analysis projects.
 

--- a/timescaledb/tutorials/analyze-nft-data/index.md
+++ b/timescaledb/tutorials/analyze-nft-data/index.md
@@ -39,7 +39,7 @@ can earn a limited edition NFT from
 the collection, for free!
 
 Claiming your NFT is simple. All you need to do is complete the tutorial below,
-answer the questions in [this form][nft-form], and we’ll send one of the
+answer the questions in [this form][nft-form], and we'll send one of the
 limited-edition Eon NFTs to your ETH address (at no cost to you!).
 
 You can see all NFTs in the Time Travel Tigers collection live on [OpenSea][eon-collection].

--- a/timescaledb/tutorials/analyze-nft-data/nft-schema-ingestion.md
+++ b/timescaledb/tutorials/analyze-nft-data/nft-schema-ingestion.md
@@ -6,7 +6,7 @@ relational tables.
 To help you get familiar with NFT data, here are some of the questions that
 could be answered with this dataset:
 * Which collections have the highest trading volume?
-* What’s the number of daily transactions of a given collection or asset?
+* What's the number of daily transactions of a given collection or asset?
 * Which collections have the most trading volume in Ether (ETH)?
 * Which account made the most NFT trades?
 * How are the mean and median sale prices correlated?
@@ -100,8 +100,8 @@ The `accounts` table includes the accounts that have participated in at least
 one transaction from the nft_sales table.
 One row represents one unique account on the OpenSea platform.
 
-* `address` is never NULL and it’s unique
-* `user_name` is NULL unless it’s been submitted on the OpenSea profile by the user
+* `address` is never NULL and it's unique
+* `user_name` is NULL unless it's been submitted on the OpenSea profile by the user
 
 | Data field | Description |
 |---|---|
@@ -171,8 +171,8 @@ CREATE INDEX idx_payment_symbol ON nft_sales (payment_symbol);
 
 ### Schema design
 The `id` field in each table is `BIGINT` because its storage size is 8 bytes in
-PostgreSQL (as opposed to `INT`’s 4 bytes) which is needed to make sure this
-value doesn’t overflow.
+PostgreSQL (as opposed to `INT`'s 4 bytes) which is needed to make sure this
+value doesn't overflow.
 
 For the `quantity` field we suggest using numeric or decimal (which works the
 same way in PostgreSQL) as the data type, because in some edge cases we

--- a/timescaledb/tutorials/aws-lambda/3rd-party-api-ingest.md
+++ b/timescaledb/tutorials/aws-lambda/3rd-party-api-ingest.md
@@ -109,7 +109,7 @@ pgcopy
 <highlight type="note">
 This example uses `psycopg2-binary` instead of `psycopg2` in the
 `requirements.txt` file. The binary version of the library contains all its
-dependencies, so that you don’t need to install them separately.
+dependencies, so that you don't need to install them separately.
 </highlight>
 
 ## Create the Dockerfile

--- a/timescaledb/tutorials/custom-timescaledb-dashboards.md
+++ b/timescaledb/tutorials/custom-timescaledb-dashboards.md
@@ -30,7 +30,7 @@ own cloud infrastructure.
 You can get the full code for this project from
 [this GitHub repo][repo-example].
 
-This project works on any TimescaleDB instance, but if you’re interested
+This project works on any TimescaleDB instance, but if you're interested
 in generating sample data to use, use our
 [Simulating IoT sensor data][iot-tutorial] tutorial.
 
@@ -75,7 +75,7 @@ tsdb=> SELECT chunk_name, range_start, range_end FROM timescaledb_information.ch
 ## Visualizing tables and chunks
 Hypertables that have data spanning massive time periods can have thousands of chunks, so visualizing them effectively is important. To provide a visual perspective of the table, the image area represents the total size of all table data before compression. Each circle represents a chunk, and the area of each circle represents the size of the chunk on disk.
 
-Here’s an example of what this visualization looks like:
+Here's an example of what this visualization looks like:
 
 <img class="main-content__illustration" src="https://assets.timescale.com/docs/images/tutorials/visualizing-compression/compression-preview.png" alt="Hypertables compression preview"/>
 
@@ -189,7 +189,7 @@ is uncompressed.
 
 ### Building views for our TimescaleDB metrics
 Now that you know how to gather all of the data you need to drive the
-visualization, it’s time to join it together in a view that can be queried using
+visualization, it's time to join it together in a view that can be queried using
 SQL (and eventually, our application).
 
 ```sql
@@ -287,7 +287,7 @@ database and quickly exposes the tables, views, and functions you need. For
 more information about setting up a new data source on Hasura, check out their
 wizard.
 
-We’re going to use two types of operations:
+We're going to use two types of operations:
 
 *   Queries and subscriptions: watch a specific query and keep pulling data
     updates to the client. In this example, you subscribe to the chunks'

--- a/timescaledb/tutorials/grafana/create-dashboard-and-panel.md
+++ b/timescaledb/tutorials/grafana/create-dashboard-and-panel.md
@@ -1,6 +1,6 @@
 # Creating a Grafana dashboard and panel
 
-Grafana is organized into ‘Dashboards' and ‘Panels'. A dashboard represents a view
+Grafana is organized into 'Dashboards' and 'Panels'. A dashboard represents a view
 onto the performance of a system, and each dashboard consists of one or more panels,
 which represents information about a specific metric related to that system.
 

--- a/timescaledb/tutorials/grafana/geospatial-dashboards.md
+++ b/timescaledb/tutorials/grafana/geospatial-dashboards.md
@@ -82,7 +82,7 @@ left of the Grafana user interface. You'll see options for 'Map Visual Options',
 and more.
 
 First, make sure the 'Map Data Options' are set to 'table' and 'current'.  Then in
-the 'Field Mappings' section. Set the 'Table Query Format' to be ‘Table'.
+the 'Field Mappings' section. Set the 'Table Query Format' to be 'Table'.
 We can map the 'Latitude Field' to our `latitude` variable, the 'Longitude Field' to
 our `longitude` variable, and the 'Metric' field to our `value` variable.
 

--- a/timescaledb/tutorials/visualize-with-tableau.md
+++ b/timescaledb/tutorials/visualize-with-tableau.md
@@ -33,14 +33,14 @@ Locate the `host`, `port`, and `password` of your TimescaleDB instance.
 
 Connecting your TimescaleDB instance to Tableau takes just a few clicks, thanks
 to Tableau's  built-in Postgres connector. To connect to your database add a new
-connection and under the  ‘to a server' section, select PostgreSQL as the
+connection and under the  'to a server' section, select PostgreSQL as the
 connection type. Then enter your database  credentials.
 
 ### Step 2: Run a simple query in Tableau
 
 Let's use the built-in SQL editor in Tableau. To run a query, add custom SQL to your data source
 by dragging and dropping the “New Custom SQL” button (in the bottom left of the Tableau desktop
-user interface) to the place that says ‘Drag tables here'.
+user interface) to the place that says 'Drag tables here'.
 
 Type a query in the dialog box. In this case, use the first
 query from the [Cryptocurrency Tutorial][crypto-tutorial]:
@@ -68,7 +68,7 @@ step, let's take our output from the previous step and turn it into an interacti
 graph in Tableau.
 
 To do this, create a new worksheet (or dashboard) and then select your desired data source
-(in our case ‘btc_7_days'), as shown below.
+(in our case 'btc_7_days'), as shown below.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/screenshots-for-tableau-tutorial/tableau-new-worksheet.png" alt="New worksheet in Tableau to examine time-series data"/>
 


### PR DESCRIPTION
# Description

This was created to replace smart quotes with apostrophes throughout the documentation. Smart quotes in code blocks will create problems when copied to a terminal. Also, smart quotes have been sprinkled throughout the regular text. Replacing them will help make quoting consistent throughout the documentation.
  
# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/pull/894#issuecomment-1057641689

I'm totally flexible with this PR. Let me know if you would prefer to only change the smart quotes in the code blocks or would like some other approach. I don't mind adjusting what's in this PR or just closing it and letting the internal documentation team handle these changes.