### PR TITLE
[Update] ABL - removed beta information

### DIFF
--- a/promscale/distributed-tracing.md
+++ b/promscale/distributed-tracing.md
@@ -13,8 +13,7 @@ When you have tracing set up in Promscale, you can query the traces using SQL
 queries. This allows you to get deep insights from your tracing data, which can
 help you understand problems and identify optimizations for your applications.
 
-To enable tracing in Promscale 0.7.0 and later, use the
-`-enable-feature=tracing` flag. For more information about installing tracing
+For more information about installing tracing
 support with tobs, see [the tobs installation section][tobs-tracing]. For more
 information about installing tracing support with Docker, see
 [the Docker installation section][docker-tracing].

--- a/promscale/distributed-tracing.md
+++ b/promscale/distributed-tracing.md
@@ -13,13 +13,6 @@ When you have tracing set up in Promscale, you can query the traces using SQL
 queries. This allows you to get deep insights from your tracing data, which can
 help you understand problems and identify optimizations for your applications.
 
-<highlight type="warning">
-Promscale tracing is currently in beta, and could have bugs. This feature might
-not be backwards compatible, and could be removed in a future release. Use this
-feature at your own risk, and do not use any experimental features in
-production.
-</highlight>
-
 To enable tracing in Promscale 0.7.0 and later, use the
 `-enable-feature=tracing` flag. For more information about installing tracing
 support with tobs, see [the tobs installation section][tobs-tracing]. For more

--- a/promscale/installation/docker.md
+++ b/promscale/installation/docker.md
@@ -51,10 +51,6 @@ packages and instructions, see the
 
 ## Install tracing support
 
-<highlight type="important">
-Support for OpenTelemetry traces is currently in beta and is disabled by default.
-</highlight>
-
 In tobs version 0.7.0 and later, tracing components are included in the stack.
 To install the tracing components, run the Promscale Connector with tracing
 enabled:

--- a/promscale/installation/index.md
+++ b/promscale/installation/index.md
@@ -25,13 +25,6 @@ When you have Promscale installed, you can configure
 [Prometheus][config-prometheus] and
 [OpenTelemetry][config-otel] to send data to Promscale.
 
-<highlight type="important">
-Support for OpenTelemetry traces is currently in beta and is disabled by default.
-If you want to send your OpenTelemetry traces to Promscale, see the
-instructions in the
-[tracing documentation](https://github.com/timescale/promscale/blob/master/docs/tracing.md).
-</highlight>
-
 ## Install Promscale with instrumentation
 If you have a Kubernetes environment, you can install a complete, pre-configured
 observability stack with Promscale. The observability stack (tobs) for

--- a/promscale/installation/tobs.md
+++ b/promscale/installation/tobs.md
@@ -35,10 +35,6 @@ cluster. Follow the prompts to complete set up.
 
 ## Install tracing support
 
-<highlight type="important">
-Support for OpenTelemetry traces is currently in beta and is disabled by default.
-</highlight>
-
 In tobs version 0.7.0 and later, tracing components are included in the stack.
 To install the tracing components, use this command:
 ```bash

--- a/promscale/send-data/opentelemetry.md
+++ b/promscale/send-data/opentelemetry.md
@@ -4,13 +4,6 @@ traces. You can use any of the OpenTelemetry client SDKs,
 instrumentation libraries or the OpenTelemetry Collector to send traces to
 Promscale using OTLP. Currently, only gRPC is supported.
 
-<highlight type="important">
-Support for OpenTelemetry traces is currently in beta and is disabled by default.
-If you want to send your OpenTelemetry traces to Promscale, see the
-instructions in the
-[tracing documentation](https://github.com/timescale/promscale/blob/master/docs/tracing.md).
-</highlight>
-
 # Configure the OpenTelemetry Collector
 You can configure the OpenTelemetry collector to forward traces to Promscale. Promscale listens
 to OTLP data on the port you specified with the `otlp-grpc-server-listen-address`


### PR DESCRIPTION
# Description

Removed the beta information in the Promscale documents for the tracing-GA release.

# Version

Which documentation version does this PR apply to?

- [ ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[921] (https://github.com/timescale/docs/issues/921)
