### PR TITLE
[Update] Quick Start: Ruby and TimescaleDB

### DIFF
--- a/timescaledb/quick-start/ruby.md
+++ b/timescaledb/quick-start/ruby.md
@@ -101,7 +101,14 @@ test:
 production:
   <<: *default
   database: my_app_db
+```
 
+<highlight type="NOTE">
+In the *config/environments/test.rb* file
+add:`config.active_record.verify_foreign_keys_for_fixtures = false` to ensure
+that the tests run succesfully because there are internal foreign keys in
+timescaledb.
+</highlight>
 
 #### Create the database
 ```

--- a/timescaledb/quick-start/ruby.md
+++ b/timescaledb/quick-start/ruby.md
@@ -168,7 +168,7 @@ The output should be something like the following:
  timescaledb | 2.1.1   | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 ```
-<highlight type="NOTE">
+<highlight type="note">
 To ensure that your tests run successfully, add `config.active_record.verify_foreign_keys_for_fixtures = false` 
 to your `config/environments/test.rb` file. Otherwise you get an error because TimescaleDB
 uses internal foreign keys.

--- a/timescaledb/quick-start/ruby.md
+++ b/timescaledb/quick-start/ruby.md
@@ -169,10 +169,9 @@ The output should be something like the following:
 (2 rows)
 ```
 <highlight type="NOTE">
-After you migrate in the *config/environments/test.rb* file
-add:`config.active_record.verify_foreign_keys_for_fixtures = false` to ensure
-that the tests run succesfully because there are internal foreign keys in
-timescaledb.
+To ensure that your tests run successfully, add `config.active_record.verify_foreign_keys_for_fixtures = false` 
+to your `config/environments/test.rb` file. Otherwise you get an error because TimescaleDB
+uses internal foreign keys.
 </highlight>
 
 ### Step 3: Create a table

--- a/timescaledb/quick-start/ruby.md
+++ b/timescaledb/quick-start/ruby.md
@@ -104,7 +104,6 @@ production:
 ```
 
 #### Create the database
-```
 Now we can run the following `rake` command to create the database in TimescaleDB:
 
 ```bash

--- a/timescaledb/quick-start/ruby.md
+++ b/timescaledb/quick-start/ruby.md
@@ -103,13 +103,6 @@ production:
   database: my_app_db
 ```
 
-<highlight type="NOTE">
-In the *config/environments/test.rb* file
-add:`config.active_record.verify_foreign_keys_for_fixtures = false` to ensure
-that the tests run succesfully because there are internal foreign keys in
-timescaledb.
-</highlight>
-
 #### Create the database
 ```
 Now we can run the following `rake` command to create the database in TimescaleDB:
@@ -175,6 +168,12 @@ The output should be something like the following:
  timescaledb | 2.1.1   | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 ```
+<highlight type="NOTE">
+After you migrate in the *config/environments/test.rb* file
+add:`config.active_record.verify_foreign_keys_for_fixtures = false` to ensure
+that the tests run succesfully because there are internal foreign keys in
+timescaledb.
+</highlight>
 
 ### Step 3: Create a table
 


### PR DESCRIPTION
# Description

Added a note about configuring environment so that the tests don't fail.

# Version

Which documentation version does this PR apply to?

- [*] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]

[#752](https://github.com/timescale/docs/issues/752)
