### PR TITLE
Add that chunks can't be dropped by space

### DIFF
--- a/api/drop_chunks.md
+++ b/api/drop_chunks.md
@@ -1,11 +1,11 @@
 ## drop_chunks()
 
 Removes data chunks whose time range falls completely before (or
-after) a specified time.  Shows a list of the chunks that were
+after) a specified time. Shows a list of the chunks that were
 dropped, in the same style as the `show_chunks` [function](/hypertable/show_chunks).
 
 Chunks are constrained by a start and end time and the start time is
-always before the end time.  A chunk is dropped if its end time is
+always before the end time. A chunk is dropped if its end time is
 older than the `older_than` timestamp or, if `newer_than` is given,
 its start time is newer than the `newer_than` timestamp.
 
@@ -13,6 +13,9 @@ Note that, because chunks are removed if and only if their time range
 falls fully before (or after) the specified timestamp, the remaining
 data may still contain timestamps that are before (or after) the
 specified one.
+
+Chunks can only be dropped based on their time intervals. They cannot be dropped
+based on a space partition.
 
 ### Required arguments
 
@@ -44,7 +47,7 @@ The `older_than` and `newer_than` parameters can be specified in two ways:
 <highlight type="warning">
 When using just an interval type, the function assumes that
 you are are removing things _in the past_. If you want to remove data
-in the future (i.e., erroneous entries), use a timestamp.
+in the future, for example to delete erroneous entries, use a timestamp.
 </highlight>
 
 When both arguments are used, the function returns the intersection of the resulting two ranges. For example,


### PR DESCRIPTION
# Description

Mention that chunks can only be dropped based on time interval, not space partitioning
Also fixes some linting errors so we don't end up with Vale issues

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #912 
