### PR TITLE
Clarify `compress_after` parameter

### DIFF
--- a/api/add_compression_policy.md
+++ b/api/add_compression_policy.md
@@ -12,8 +12,8 @@ enable compression on continuous aggregates
 
 |Name|Type|Description|
 |---|---|---|
-| `hypertable` |REGCLASS| Name of the hypertable or continuous aggregate|
-| `compress_after` | INTERVAL or INTEGER | The age after which the policy job compresses chunks|
+|`hypertable`|REGCLASS|Name of the hypertable or continuous aggregate|
+|`compress_after`|INTERVAL or INTEGER|The age after which the policy job compresses chunks. `compress_after` is calculated relative to the current time. In other words, chunks containing data older than `now - {compress_after}::interval` are compressed.|
 
 The `compress_after` parameter should be specified differently depending 
 on the type of the time column of the hypertable or continuous aggregate:

--- a/api/add_compression_policy.md
+++ b/api/add_compression_policy.md
@@ -13,7 +13,7 @@ enable compression on continuous aggregates
 |Name|Type|Description|
 |---|---|---|
 |`hypertable`|REGCLASS|Name of the hypertable or continuous aggregate|
-|`compress_after`|INTERVAL or INTEGER|The age after which the policy job compresses chunks. `compress_after` is calculated relative to the current time. In other words, chunks containing data older than `now - {compress_after}::interval` are compressed.|
+|`compress_after`|INTERVAL or INTEGER|The age after which the policy job compresses chunks. `compress_after` is calculated relative to the current time, so chunks containing data older than `now - {compress_after}::interval` are compressed.|
 
 The `compress_after` parameter should be specified differently depending 
 on the type of the time column of the hypertable or continuous aggregate:


### PR DESCRIPTION
# Description

Clarify how compress_after works in API reference for `add_compression_policy`

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #899 
