### PR TITLE
escaped underscore

### DIFF
--- a/timescaledb/how-to-guides/compression/backfill-historical-data.md
+++ b/timescaledb/how-to-guides/compression/backfill-historical-data.md
@@ -73,7 +73,7 @@ SELECT decompress_chunk(i) from show_chunks('conditions', newer_than, older_than
 ```
 
 <highlight type="tip">
-You need to run 'decompress_chunk' for each chunk that is impacted
+You need to run 'decompress\_chunk' for each chunk that is impacted
 by your INSERT or UPDATE statement in backfilling data. Once your needed chunks
 are decompressed you can proceed with your data backfill operations.
 </highlight>


### PR DESCRIPTION
# Description

The underscore is not escaped in this page, causing most of the "tip" section to appear as italic:
![image](https://user-images.githubusercontent.com/6158608/159686512-f2de113f-3f89-43e9-a59b-3a1d5a053661.png)


# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes this page: https://docs.timescale.com/timescaledb/latest/how-to-guides/compression/backfill-historical-data/#manually-decompressing-chunks-for-backfill
