### PR TITLE
Add example of using window functions on caggs

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
@@ -54,7 +54,8 @@ top of the aggregate functions, for example `max(temperature)-min(temperature)`.
 However, aggregates using `ORDER BY` and `DISTINCT` cannot be used with
 continuous aggregates since they are not possible to parallelize with
 PostgreSQL. TimescaleDB does not currently support `FILTER` or `JOIN` clauses,
-or window functions in continuous aggregates.
+or window functions in continuous aggregates. You can work around this by
+[aggregating the other parts of your query beforehand, then using the window function at query time][cagg-window-functions].
 
 To test out continuous aggregates, follow
 the [continuous aggregate tutorial][tutorial-caggs].
@@ -163,7 +164,8 @@ Make sure you are maintaining your invalidation log size to avoid this, for exam
 For more information about setting up multi-node, see the
 [multi-node section][multi-node]
 
+[cagg-mat-hypertables]: /how-to-guides/continuous-aggregates/materialized-hypertables
+[cagg-window-functions]: /how-to-guides/continuous-aggregates/create-a-continuous-aggregate/#use-continuous-aggregates-with-window-functions
+[multi-node]: /how-to-guides/multinode-timescaledb/
 [postgres-parallel-agg]: https://www.postgresql.org/docs/current/parallel-plans.html#PARALLEL-AGGREGATION
 [tutorial-caggs]: /getting-started/create-cagg
-[cagg-mat-hypertables]: /how-to-guides/continuous-aggregates/materialized-hypertables
-[multi-node]: /how-to-guides/multinode-timescaledb/

--- a/timescaledb/how-to-guides/continuous-aggregates/create-a-continuous-aggregate.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/create-a-continuous-aggregate.md
@@ -176,7 +176,7 @@ SELECT
   FROM t;
 ```
 
-You cannot create a continuous aggregate using this query, because it contains
+You can't create a continuous aggregate using this query, because it contains
 the `lag` function. But you can create a continuous aggregate by excluding the
 `lag` function:
 

--- a/timescaledb/how-to-guides/continuous-aggregates/create-a-continuous-aggregate.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/create-a-continuous-aggregate.md
@@ -154,6 +154,54 @@ policies][postgres-rls] enabled.
 
 </procedure>
 
+## Use continuous aggregates with window functions
+Continuous aggregates don't currently support window functions. You can work
+around this by:
+1.  Creating a continuous aggregate for the other parts of your query, then
+1.  Using the window function on your continuous aggregate at query time
+
+For example, say you have a hypertable named `example` with a `time` column and
+a `value` column. You bucket your data by `time` and calculate the delta between
+time buckets using the `lag` window function:
+```sql
+WITH t AS (
+  SELECT
+    time_bucket('10 minutes', time) as bucket,
+    first(value, time) as value
+  FROM example GROUP BY bucket
+)
+SELECT
+  bucket,
+  value - lag(value, 1) OVER (ORDER BY bucket) delta
+  FROM t;
+```
+
+You cannot create a continuous aggregate using this query, because it contains
+the `lag` function. But you can create a continuous aggregate by excluding the
+`lag` function:
+
+```sql
+CREATE MATERIALIZED VIEW example_aggregate
+  WITH (timescaledb.continuous) AS
+    SELECT
+      time_bucket('10 minutes', time) AS bucket,
+      first(value, time) AS value
+    FROM example GROUP BY bucket;
+```
+
+Then, at query time, calculate the delta by using `lag` on your continuous
+aggregate:
+
+```sql
+SELECT
+  bucket,
+  value - lag(value, 1) OVER (ORDER BY bucket) AS delta
+FROM example_aggregate;
+```
+
+This speeds up your query by calculating the aggregation ahead of time. The
+delta still needs to be calculated at query time.
+
 [api-time-bucket]: /api/:currentVersion:/hyperfunctions/time_bucket/
 [api-time-bucket-gapfill]: /api/:currentVersion:/hyperfunctions/gapfilling-interpolation/time_bucket_gapfill/
 [postgres-security-barrier]: https://www.postgresql.org/docs/current/rules-privileges.html


### PR DESCRIPTION
# Description

Add example of how to use window functions with caggs by pre-aggregating the other parts of the query.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #967 
