### PR TITLE
Update early access description

### DIFF
--- a/cloud/high-availability.md
+++ b/cloud/high-availability.md
@@ -35,9 +35,9 @@ running database that can take over immediately.
 
 <highlight type="note">
 Creating database replicas in Timescale Cloud is an early access feature. Early
-access features are still under active development. We will be continuing to
-develop capabilities around database replication in Timescale Cloud, such as 
-offering replicas in different availability zones.
+access features are still under active development. You can start enjoying the
+benefits of database replication now, while we continue to develop extended 
+capabilities, such as offering replicas in different availability zones.
 </highlight>
 
 You can enable a replica for your single-node services. The

--- a/cloud/high-availability.md
+++ b/cloud/high-availability.md
@@ -33,11 +33,11 @@ Instance redundancy refers to having replicas of your database running
 simultaneously. In the case of a database failure, a replica is an up-to-date,
 running database that can take over immediately.
 
-<highlight type="warning">
+<highlight type="note">
 Creating database replicas in Timescale Cloud is an early access feature. Early
-access features could have bugs! They might not be backwards compatible, and
-could be removed in future releases. Use these features at your own risk, and do
-not use any experimental features in production.
+access features are still under active development. We will be continuing to
+develop capabilities around database replication in Timescale Cloud, such as 
+offering replicas in different availability zones.
 </highlight>
 
 You can enable a replica for your single-node services. The


### PR DESCRIPTION
Changing the early access description to be more in line with the [blog](https://www.timescale.com/blog/high-availability-for-your-production-environments-introducing-database-replication-in-timescale-cloud/)

# Description

The early access description isn't quite accurate. It's more about new features coming to this feature, rather than stability.

# Version

Which documentation version does this PR apply to?

- [X] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
