### PR TITLE
Updating Frequency Analysis page to reflect toolkit 1.6.0

### DIFF
--- a/api/frequency-analysis.md
+++ b/api/frequency-analysis.md
@@ -12,9 +12,12 @@ additional hyperfunctions, you need to install the
 |-|-|-|-|-|
 |Frequency|SpaceSavingAggregate|[`freq_agg`](/hyperfunctions/frequency-analysis/freq_agg/)|❌|✅|
 |Frequency|SpaceSavingAggregate|[`topn_agg`](/hyperfunctions/frequency-analysis/topn_agg/)|❌|✅|
-|Frequency||[`values`](/hyperfunctions/frequency-analysis/values-freq_agg/)|❌|✅|
-|Frequency||[`topn`](/hyperfunctions/frequency-analysis/topn/)|❌|✅|
+|Frequency|SpaceSavingAggregate|[`into_values`](/hyperfunctions/frequency-analysis/into_values-freq_agg/)|❌|✅|
+|Frequency|SpaceSavingAggregate|[`topn`](/hyperfunctions/frequency-analysis/topn/)|❌|✅|
+|Frequency|SpaceSavingAggregate|[`min_frequency`](/hyperfunctions/frequency-analysis/min_frequency-max_frequency/)|❌|✅|
+|Frequency|SpaceSavingAggregate|[`max_frequency`](/hyperfunctions/frequency-analysis/min_frequency-max_frequency/)|❌|✅|
 |Frequency|StateAgg|[`state_agg`](/hyperfunctions/frequency-analysis/state_agg/)|❌|✅|
-|Frequency||[`duration_in`](/hyperfunctions/frequency-analysis/duration_in/)|❌|✅|
+|Frequency|StateAgg|[`duration_in`](/hyperfunctions/frequency-analysis/duration_in/)|❌|✅|
+|Frequency|StateAgg|[`into_values`](/hyperfunctions/frequency-analysis/into_vals-state-agg/)|❌|✅|
 
 [install-toolkit]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit


### PR DESCRIPTION
# Description

The Frequency Analysis page under API Reference->Hyperfunctions contained a broken link and hadn't been updated with all of the new methods included in toolkit 1.6.0.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
