### PR TITLE
Convert all hyperfunction tables to use `hyperfunctionTable` component

### DIFF
--- a/api/approx_count_distincts.md
+++ b/api/approx_count_distincts.md
@@ -9,12 +9,11 @@ Some hyperfunctions are included in the default TimescaleDB product. For
 additional hyperfunctions, you need to install the
 [Timescale Toolkit][install-toolkit] PostgreSQL extension.
 
-|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
-|-|-|-|-|-|
-|Approximate count distincts|Hyperloglog|[`hyperloglog`](hyperfunctions/approx_count_distincts/hyperloglog/)|❌|✅|
-|||[`rollup`](hyperfunctions/approx_count_distincts/rollup-hyperloglog/)|❌|✅|
-|||[`distinct_count`](hyperfunctions/approx_count_distincts/distinct_count/)|❌|✅|
-|||[`stderror`](hyperfunctions/approx_count_distincts/stderror/)|❌|✅|
+<hyperfunctionTable
+    hyperfunctionFamily='approximate count distinct'
+    includeExperimental
+    sortByType
+/>
 
 [hyperfunctions-approx-count-distincts]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/approx-count-distincts/
 [install-toolkit]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/counter_aggs.md
+++ b/api/counter_aggs.md
@@ -10,26 +10,11 @@ Some hyperfunctions are included in the default TimescaleDB product. For
 additional hyperfunctions, you need to install the
 [Timescale Toolkit][install-toolkit] PostgreSQL extension.
 
-|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
-|-|-|-|-|-|
-|Counter and gauge aggregation|Counter aggregate|[`counter_agg`](/hyperfunctions/counter_aggs/counter_agg_point/)|❌|✅|
-||Gauge aggregate|[`gauge_agg`](/hyperfunctions/counter_aggs/gauge_agg/)|❌|✅|
-||Rollup|[`rollup`](/hyperfunctions/counter_aggs/rollup-counter/)|❌|✅|
-||Accessor|[`corr`](/hyperfunctions/counter_aggs/corr-stats/)|❌|✅|
-|||[`counter_zero_time`](/hyperfunctions/counter_aggs/counter_zero_time/)|❌|✅|
-|||[`delta`](/hyperfunctions/counter_aggs/delta/)|❌|✅|
-|||[`extrapolated_delta`](/hyperfunctions/counter_aggs/extrapolated_delta/)|❌|✅|
-|||[`extrapolated_rate`](/hyperfunctions/counter_aggs/extrapolated_rate/)|❌|✅|
-|||[`idelta_left`/`idelta_right`](/hyperfunctions/counter_aggs/idelta/)|❌|✅|
-|||[`intercept`](/hyperfunctions/counter_aggs/intercept-counter/)|❌|✅|
-|||[`irate_left`/`irate_right`](/hyperfunctions/counter_aggs/irate/)|❌|✅|
-|||[`num_changes`](/hyperfunctions/counter_aggs/num_changes/)|❌|✅|
-|||[`num_elements`](/hyperfunctions/counter_aggs/num_elements/)|❌|✅|
-|||[`num_resets`](/hyperfunctions/counter_aggs/num_resets/)|❌|✅|
-|||[`rate`](/hyperfunctions/counter_aggs/rate/)|❌|✅|
-|||[`slope`](/hyperfunctions/counter_aggs/slope-counter/)|❌|✅|
-|||[`time_delta`](/hyperfunctions/counter_aggs/time_delta/)|❌|✅|
-||Mutator|[`with_bounds`](/hyperfunctions/counter_aggs/with_bounds/)|❌|✅|
+<hyperfunctionTable
+    hyperfunctionFamily='metric aggregation'
+    includeExperimental
+    sortByType
+/>
 
 <highlight type="important">
 All accessors can be used with `CounterSummary`. The accessors `delta`,

--- a/api/downsample.md
+++ b/api/downsample.md
@@ -8,9 +8,10 @@ Some hyperfunctions are included in the default TimescaleDB product. For
 additional hyperfunctions, you need to install the
 [Timescale Toolkit][install-toolkit] PostgreSQL extension.
 
-|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
-|-|-|-|-|-|
-|Downsample|ASAP|[`asap_smooth`](hyperfunctions/downsample/asap/)|❌|✅|
-|Downsample|LTTB|[`lttb`](hyperfunctions/downsample/lttb/)|❌|✅|
+<hyperfunctionTable
+    hyperfunctionFamily='downsample'
+    includeExperimental
+    sortByType
+/>
 
 [install-toolkit]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/frequency-analysis.md
+++ b/api/frequency-analysis.md
@@ -8,16 +8,10 @@ Some hyperfunctions are included in the default TimescaleDB product. For
 additional hyperfunctions, you need to install the
 [Timescale Toolkit][install-toolkit] PostgreSQL extension.
 
-|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
-|-|-|-|-|-|
-|Frequency|SpaceSavingAggregate|[`freq_agg`](/hyperfunctions/frequency-analysis/freq_agg/)|❌|✅|
-|Frequency|SpaceSavingAggregate|[`topn_agg`](/hyperfunctions/frequency-analysis/topn_agg/)|❌|✅|
-|Frequency|SpaceSavingAggregate|[`into_values`](/hyperfunctions/frequency-analysis/into_values-freq_agg/)|❌|✅|
-|Frequency|SpaceSavingAggregate|[`topn`](/hyperfunctions/frequency-analysis/topn/)|❌|✅|
-|Frequency|SpaceSavingAggregate|[`min_frequency`](/hyperfunctions/frequency-analysis/min_frequency-max_frequency/)|❌|✅|
-|Frequency|SpaceSavingAggregate|[`max_frequency`](/hyperfunctions/frequency-analysis/min_frequency-max_frequency/)|❌|✅|
-|Frequency|StateAgg|[`state_agg`](/hyperfunctions/frequency-analysis/state_agg/)|❌|✅|
-|Frequency|StateAgg|[`duration_in`](/hyperfunctions/frequency-analysis/duration_in/)|❌|✅|
-|Frequency|StateAgg|[`into_values`](/hyperfunctions/frequency-analysis/into_vals-state-agg/)|❌|✅|
+<hyperfunctionTable
+    hyperfunctionFamily='frequency analysis'
+    includeExperimental
+    sortByType
+/>
 
 [install-toolkit]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/gapfilling-interpolation.md
+++ b/api/gapfilling-interpolation.md
@@ -9,12 +9,11 @@ Some hyperfunctions are included in the default TimescaleDB product. For
 additional hyperfunctions, you need to install the
 [Timescale Toolkit][install-toolkit] PostgreSQL extension.
 
-|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
-|-|-|-|-|-|
-|Gapfilling and interpolation|Time bucket gapfill|[`time_bucket_gapfill`](/hyperfunctions/gapfilling-interpolation/time_bucket_gapfill/)|❌|✅|
-||Last observation carried forward|[`locf`](/hyperfunctions/gapfilling-interpolation/locf/)|✅|❌|
-|||[`interpolate`](/hyperfunctions/gapfilling-interpolation/interpolate/)|✅|❌|
-
+<hyperfunctionTable
+    hyperfunctionFamily='gapfilling and interpolation'
+    includeExperimental
+    sortByType
+/>
 
 [hyperfunctions-gapfilling]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/gapfilling-interpolation/
 [install-toolkit]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/percentile-approximation.md
+++ b/api/percentile-approximation.md
@@ -8,20 +8,11 @@ Some hyperfunctions are included in the default TimescaleDB product. For
 additional hyperfunctions, you need to install the
 [Timescale Toolkit][install-toolkit] PostgreSQL extension.
 
-|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
-|-|-|-|-|-|
-|Percentile approximation|Approximate percentile|[`percentile_agg`](/hyperfunctions/percentile-approximation/percentile_agg/)|❌|✅|
-|||[`approx_percentile`](/hyperfunctions/percentile-approximation/approx_percentile/)|❌|✅|
-|||[`approx_percentile_rank`](/hyperfunctions/percentile-approximation/approx_percentile_rank/)|❌|✅|
-|||[`rollup`](/hyperfunctions/percentile-approximation/rollup-percentile/)|❌|✅|
-|||[`max_val`](/hyperfunctions/percentile-approximation/max_val/)|✅|❌|
-|||[`mean`](/hyperfunctions/percentile-approximation/mean/)|✅|❌|
-|||[`error`](/hyperfunctions/percentile-approximation/error/)|✅|❌|
-|||[`min_val`](/hyperfunctions/percentile-approximation/min_val/)|✅|❌|
-|||[`num_vals`](/hyperfunctions/percentile-approximation/num_vals-pct/)|✅|❌|
-||Advanced aggregation methods|[`uddsketch`](/hyperfunctions/percentile-approximation/percentile-aggregation-methods/uddsketch/)|❌|✅|
-|||[`tdigest`](/hyperfunctions/percentile-approximation/percentile-aggregation-methods/tdigest/)|❌|✅|
-
+<hyperfunctionTable
+    hyperfunctionFamily='percentile approximation'
+    includeExperimental
+    sortByType
+/>
 
 [hyperfunctions-percentile-approx]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/
 [install-toolkit]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/stats_aggs.md
+++ b/api/stats_aggs.md
@@ -16,26 +16,11 @@ or `_x` following the name.
 For more information about statistical aggregate functions, see the
 [hyperfunctions documentation][hyperfunctions-stats-aggs].
 
-|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
-|-|-|-|-|-|
-|Statistical Aggregates|Statistical Aggregates|[`stats_agg`](/hyperfunctions/stats_aggs/stats_agg/)|❌|✅|
-|||[`rollup`](/hyperfunctions/stats_aggs/rollup-stats/)|❌|✅|
-|||[`rolling`](/hyperfunctions/stats_aggs/rolling-stats/)|❌|✅|
-|Statistical aggregation|Stats Agg 1D Accessors|[`average` / `average_y` / `average_x`](/hyperfunctions/stats_aggs/average-stats/)|❌|✅|
-|||[`kurtosis` / `kurtosis_y` / `kurtosis_x`](/hyperfunctions/stats_aggs/kurtosis/)|❌|✅|
-|||[`num_vals`](/hyperfunctions/stats_aggs/num_vals-stats/)|❌|✅|
-|||[`skewness` / `skewness_y` / `skewness_x`](/hyperfunctions/stats_aggs/skewness/)|❌|✅|
-|||[`stddev` / `stddev_y` / `stddev_x`](/hyperfunctions/stats_aggs/stddev/)|❌|✅|
-|||[`sum` / `sum_y` / `sum_x`](/hyperfunctions/stats_aggs/sum-stats/)|❌|✅|
-|||[`variance` / `variance_y` / `variance_x`](/hyperfunctions/stats_aggs/variance/)|❌|✅|
-|Statistical aggregation|Stats Agg 2D Accessors|[`corr`](/hyperfunctions/stats_aggs/corr-stats/)|❌|✅|
-|||[`covariance`](/hyperfunctions/stats_aggs/covariance/)|❌|✅|
-|||[`determination_coeff`](/hyperfunctions/stats_aggs/determination_coeff/)|❌|✅|
-|||[`intercept`](/hyperfunctions/stats_aggs/intercept-stats/)|❌|✅|
-|||[`slope`](/hyperfunctions/stats_aggs/slope-stats/)|❌|✅|
-|||[`x_intercept`](/hyperfunctions/stats_aggs/x_intercept/)|❌|✅|
-
-
+<hyperfunctionTable
+    hyperfunctionFamily='statistical aggregates'
+    includeExperimental
+    sortByType
+/>
 
 [hyperfunctions-stats-aggs]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [install-toolkit]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/time-weighted-averages.md
+++ b/api/time-weighted-averages.md
@@ -9,11 +9,11 @@ Some hyperfunctions are included in the default TimescaleDB product. For
 additional hyperfunctions, you need to install the
 [Timescale Toolkit][install-toolkit] PostgreSQL extension.
 
-|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
-|-|-|-|-|-|
-|Time-weighted averages|Time-weighted averages|[`time_weight`](/hyperfunctions/time-weighted-averages/time_weight/)|❌|✅|
-|||[`rollup`](/hyperfunctions/time-weighted-averages/rollup-timeweight/)|❌|✅|
-|||[`average`](/hyperfunctions/time-weighted-averages/average-time-weight/)|❌|✅|
+<hyperfunctionTable
+    hyperfunctionFamily='time-weighted averages'
+    includeExperimental
+    sortByType
+/>
 
 [hyperfunctions-time-weight-average]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/time-weighted-averages/
 [install-toolkit]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/topn.md
+++ b/api/topn.md
@@ -4,7 +4,7 @@ api_category: hyperfunction
 api_experimental: true
 hyperfunction_toolkit: true
 hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: FrequencyAggregate
+hyperfunction_subfamily: SpaceSavingAggregate
 hyperfunction_type: accessor
 ---
 

--- a/timescaledb/how-to-guides/hyperfunctions/about-hyperfunctions.md
+++ b/timescaledb/how-to-guides/hyperfunctions/about-hyperfunctions.md
@@ -13,64 +13,73 @@ Some hyperfunctions are included in the default TimescaleDB product. For
 additional hyperfunctions, you need to install the
 [Timescale Toolkit][install-toolkit] PostgreSQL extension.
 
-|Hyperfunction family|Types|API Calls|Included by default|Toolkit required|
-|-|-|-|-|-|
-|Approximate count distincts|Hyperloglog|`hyperloglog`|❌|✅|
-|||`rollup`|❌|✅|
-|||`distinct_count`|❌|✅|
-|||`stderror`|❌|✅|
-|Statistical aggregates|Statistical functions|`average`|❌|✅|
-|||`stats_agg`|❌|✅|
-|||`rollup`|❌|✅|
-|||`rolling`|❌|✅|
-|||`sum`|❌|✅|
-|||`num_vals`|❌|✅|
-|||`stddev`|❌|✅|
-|||`variance`|❌|✅|
-|||`skewness`|❌|✅|
-|||`kurtosis`|❌|✅|
-||Regression functions|`slope`|❌|✅|
-|||`intercept`|❌|✅|
-|||`x_intercept`|❌|✅|
-|||`corr`|❌|✅|
-|||`covariance`|❌|✅|
-|||`skewness`|❌|✅|
-|||`kurtosis`|❌|✅|
-|||`determination_coeff`|❌|✅|
-|Gapfilling and interpolation|Time bucket gapfill|`time_bucket_gapfill`|❌|✅|
-||Last observation carried forward|`locf`|✅|❌|
-|||`interpolate`|✅|❌|
-|Percentile approximation|Approximate percentile|`percentile_agg`|❌|✅|
-|||`approx_percentile`|❌|✅|
-|||`approx_percentile_rank`|❌|✅|
-|||`rollup`|❌|✅|
-|||`max_val`|✅|❌|
-|||`mean`|✅|❌|
-|||`error`|✅|❌|
-|||`min_val`|✅|❌|
-|||`num_vals`|✅|❌|
-||Advanced aggregation methods|`uddsketch`|❌|✅|
-|||`tdigest`|❌|✅|
-|Counter aggregation|Counter aggregates|`counter_agg`|❌|✅|
-|||`rollup`|❌|✅|
-|||`corr`|❌|✅|
-|||`counter_zero_time`|❌|✅|
-|||`delta`|❌|✅|
-|||`extrapolated_delta`|❌|✅|
-|||`extrapolated_rate`|❌|✅|
-|||`idelta`|❌|✅|
-|||`intercept`|❌|✅|
-|||`irate`|❌|✅|
-|||`num_changes`|❌|✅|
-|||`num_elements`|❌|✅|
-|||`num_resets`|❌|✅|
-|||`rate`|❌|✅|
-|||`slope`|❌|✅|
-|||`time_delta`|❌|✅|
-|||`with_bounds`|❌|✅|
-|Time-weighted averages|Time-weighted averages|`time_weight`|❌|✅|
-|||`rollup`|❌|✅|
-|||`average`|❌|✅|
+## Hyperfunctions available with TimescaleDB and Timescale Toolkit
+
+Here is a list of all the hyperfunctions provided by Timescale. Hyperfunctions
+marked 'Toolkit' require an installation of Timescale Toolkit. Hyperfunctions
+marked 'experimental' are still under development.
+
+<highlight type="warning">
+Experimental features could have bugs. They might not be backwards compatible,
+and could be removed in future releases. Use these features at your own risk,
+and do not use any experimental features in production.
+</highlight>
+
+### Approximate count distincts
+
+<hyperfunctionTable
+	hyperfunctionFamily='approximate count distinct'
+	includeExperimental
+/>
+
+### Statistical aggregates
+
+<hyperfunctionTable
+	hyperfunctionFamily='statistical aggregates'
+	includeExperimental
+/>
+
+### Gapfilling and interpolation
+
+<hyperfunctionTable
+	hyperfunctionFamily='gapfilling and interpolation'
+	includeExperimental
+/>
+
+### Percentile approximation
+
+<hyperfunctionTable
+	hyperfunctionFamily='percentile approximation'
+	includeExperimental
+/>
+
+### Metric aggregation
+
+<hyperfunctionTable
+	hyperfunctionFamily='metric aggregation'
+	includeExperimental
+/>
+
+### Time-weighted averages
+
+<hyperfunctionTable
+	hyperfunctionFamily='time-weighted averages'
+	includeExperimental
+/>
+
+### Downsample
+
+<hyperfunctionTable
+	hyperfunctionFamily='downsample'
+	includeExperimental
+/>
+
+### Frequency analysis
+
+<hyperfunctionTable
+	hyperfunctionFamily='frequency analysis'
+	includeExperimental
+/>
 
 For more information about each of the API calls listed in this table, see our [hyperfunction API documentation][api-hyperfunctions].
 


### PR DESCRIPTION
# Description

Convert hyperfunction Markdown tables to use the `hyperfunctionTable` component. These should now auto-update on build when changes are made to the hyperfunction API reference frontmatter.

Previews:
- https://docs-dev.timescale.com/docs-charis-hyperfunction-tables/timescaledb/charis-hyperfunction-tables/how-to-guides/hyperfunctions/about-hyperfunctions/#hyperfunctions-available-with-timescaledb-and-timescale-toolkit
- https://docs-dev.timescale.com/docs-charis-hyperfunction-tables/api/charis-hyperfunction-tables/hyperfunctions/approx_count_distincts/
- https://docs-dev.timescale.com/docs-charis-hyperfunction-tables/api/charis-hyperfunction-tables/hyperfunctions/stats_aggs/
- https://docs-dev.timescale.com/docs-charis-hyperfunction-tables/api/charis-hyperfunction-tables/hyperfunctions/gapfilling-interpolation/
- https://docs-dev.timescale.com/docs-charis-hyperfunction-tables/api/charis-hyperfunction-tables/hyperfunctions/percentile-approximation/
- https://docs-dev.timescale.com/docs-charis-hyperfunction-tables/api/charis-hyperfunction-tables/hyperfunctions/counter_aggs/
- https://docs-dev.timescale.com/docs-charis-hyperfunction-tables/api/charis-hyperfunction-tables/hyperfunctions/time-weighted-averages/
- https://docs-dev.timescale.com/docs-charis-hyperfunction-tables/api/charis-hyperfunction-tables/hyperfunctions/downsample/
- https://docs-dev.timescale.com/docs-charis-hyperfunction-tables/api/charis-hyperfunction-tables/hyperfunctions/frequency-analysis/

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
