### PR TITLE
Update the column names

### DIFF
--- a/api/add_dimension.md
+++ b/api/add_dimension.md
@@ -88,8 +88,8 @@ queries.
 |Column|Type|Description|
 |-|-|-|
 |`dimension_id`|INTEGER|ID of the dimension in the TimescaleDB internal catalog|
-|`schema_name`|TEXT|Schema name of the hypertable|
-|`table_name`|TEXT|Table name of the hypertable|
+|`hypertable_schema`|TEXT|Schema name of the hypertable|
+|`hypertable_name`|TEXT|Table name of the hypertable|
 |`column_name`|TEXT|Column name of the column to partition by|
 |`created`|BOOLEAN|True if the dimension was added, false when `if_not_exists` is true and no dimension was added|
 

--- a/api/add_dimension.md
+++ b/api/add_dimension.md
@@ -88,8 +88,8 @@ queries.
 |Column|Type|Description|
 |-|-|-|
 |`dimension_id`|INTEGER|ID of the dimension in the TimescaleDB internal catalog|
-|`hypertable_schema`|TEXT|Schema name of the hypertable|
-|`hypertable_name`|TEXT|Table name of the hypertable|
+|`schema_name`|TEXT|Schema name of the hypertable|
+|`table_name`|TEXT|Table name of the hypertable|
 |`column_name`|TEXT|Column name of the column to partition by|
 |`created`|BOOLEAN|True if the dimension was added, false when `if_not_exists` is true and no dimension was added|
 

--- a/timescaledb/how-to-guides/user-defined-actions/example-generic-retention.md
+++ b/timescaledb/how-to-guides/user-defined-actions/example-generic-retention.md
@@ -18,7 +18,7 @@ BEGIN
     RAISE EXCEPTION 'Config must have drop_after';
   END IF;
 
-  PERFORM drop_chunks(format('%I.%I', table_schema, table_name), older_than => drop_after)
+  PERFORM drop_chunks(format('%I.%I', hypertable_schema, hypertable_name), older_than => drop_after)
     FROM timescaledb_information.hypertables;
 END
 $$;


### PR DESCRIPTION
# Description

The available columns in TimescaleDB are:

           View "timescaledb_information.hypertables"
       Column        |   Type   | Collation | Nullable | Default
---------------------+----------+-----------+----------+---------
 hypertable_schema   | name     |           |          |
 hypertable_name     | name     |           |          |
 owner               | name     |           |          |
 num_dimensions      | smallint |           |          |
 num_chunks          | bigint   |           |          |
 compression_enabled | boolean  |           |          |
 is_distributed      | boolean  |           |          |
 replication_factor  | smallint |           |          |
 data_nodes          | name[]   |           |          |
 tablespaces         | name[]   |           |          |


# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes https://github.com/timescale/docs/issues/1010