### PR TITLE
Quick fix to problem with short url returning 403

### DIFF
--- a/promscale/installation/tobs.md
+++ b/promscale/installation/tobs.md
@@ -8,7 +8,7 @@ cluster.
 ## Install the packages
 You can install tobs at the command prompt, using the `curl` command:
 ```bash
-curl --proto '=https' --tlsv1.2 -sSLf  https://tsdb.co/install-tobs-sh |sh
+curl --proto '=https' -A 'tobs' --tlsv1.2 -sSLf  https://tsdb.co/install-tobs-sh |sh
 ```
 
 Alternatively, you can download directly from our [repository][download-tobs] to


### PR DESCRIPTION
# Description

Quick fix to problem with short url returning 403 when the user agent is set to "curl/....".

