### PR TITLE
Fix links to percentile aggregation references

### DIFF
--- a/timescaledb/how-to-guides/hyperfunctions/advanced-agg.md
+++ b/timescaledb/how-to-guides/hyperfunctions/advanced-agg.md
@@ -70,6 +70,5 @@ see the developer documentation for [uddsketch][gh-uddsketch] and
 [tdigest][gh-tdigest].
 
 [pg-percentile]: https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE
-[`percentile_cont`](https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE)
-[gh-uddsketch]: https://github.com/timescale/timescaledb-toolkit/blob/main/docs/`tdigest`.md
-[gh-tdigest]: https://github.com/timescale/timescaledb-toolkit/blob/main/docs/`uddsketch`.md
+[gh-uddsketch]: https://github.com/timescale/timescaledb-toolkit/blob/main/docs/uddsketch.md
+[gh-tdigest]: https://github.com/timescale/timescaledb-toolkit/blob/main/docs/tdigest.md


### PR DESCRIPTION
# Description

Fix broken links

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #1026 
