### PR TITLE
Add info on restarting background workers

### DIFF
--- a/timescaledb/how-to-guides/troubleshoot-timescaledb.md
+++ b/timescaledb/how-to-guides/troubleshoot-timescaledb.md
@@ -60,6 +60,12 @@ the database will be looking for the previous version of the timescaledb files.
 
 See [our update docs][update-db] for more info.
 
+### Scheduled jobs stop running
+If your scheduled jobs stop running, try restarting the background workers:
+```
+SELECT _timescaledb_internal.start_background_workers();
+```
+
 ## Getting more information
 
 ###  EXPLAINing query performance [](explain)


### PR DESCRIPTION
# Description

Add info on how to restart background workers without restarting the database, for when scheduled jobs stop running

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #748 
