### PR TITLE
Fix SQL example that does not work

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
@@ -48,7 +48,10 @@ actively refreshed regions are not compressed. This is to prevent refresh
 policies from failing. For example, consider a refresh policy like this:
 
 ```sql
-SELECT add_continuous_aggregate_policy('cagg_name', start_offset=>'30 days', end_offset=>'1 day', '1 h');
+SELECT add_continuous_aggregate_policy('cagg_name',
+  start_offset => INTERVAL '30 days',
+  end_offset => INTERVAL '1 day',
+  schedule_interval => INTERVAL '1 hour');
 ```
 
 With this kind of refresh policy, the compression policy needs the `compress_after` 


### PR DESCRIPTION
# Description

Fix SQL example that did not work because positional argument came after named ones

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #1030 
