### PR TITLE
Fix data types for `move_chunk` API reference

### DIFF
--- a/api/move_chunk.md
+++ b/api/move_chunk.md
@@ -21,8 +21,8 @@ to use the `move_chunk()` call.
 |Name|Type|Description|
 |-|-|-|
 |`chunk`|REGCLASS|Name of chunk to be moved|
-|`destination_tablespace`|TEXT|Target tablespace for chunk being moved|
-|`index_destination_tablespace`|TEXT|Target tablespace for index associated with the chunk you are moving|
+|`destination_tablespace`|NAME|Target tablespace for chunk being moved|
+|`index_destination_tablespace`|NAME|Target tablespace for index associated with the chunk you are moving|
 
 ### Optional arguments
 

--- a/api/move_chunk.md
+++ b/api/move_chunk.md
@@ -22,12 +22,12 @@ to use the `move_chunk()` call.
 |-|-|-|
 |`chunk`|REGCLASS|Name of chunk to be moved|
 |`destination_tablespace`|NAME|Target tablespace for chunk being moved|
-|`index_destination_tablespace`|NAME|Target tablespace for index associated with the chunk you are moving|
 
 ### Optional arguments
 
 |Name|Type|Description|
 |-|-|-|
+|`index_destination_tablespace`|NAME|Target tablespace for index associated with the chunk you are moving|
 |`reorder_index`|REGCLASS|The name of the index (on either the hypertable or chunk) to order by|
 |`verbose`|BOOLEAN|Setting to true displays messages about the progress of the move_chunk command. Defaults to false.|
 


### PR DESCRIPTION
# Description

[Relevant Slack message](https://iobeam.slack.com/archives/CEKV5LMK3/p1650650375067429?thread_ts=1650648705.589909&cid=CEKV5LMK3)

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
