### PR TITLE
Remove outdated info about commercial license

### DIFF
--- a/timescaledb/overview/faq/faq-community.md
+++ b/timescaledb/overview/faq/faq-community.md
@@ -7,9 +7,6 @@ Apache 2.0.
 Yes!  We have a very active [online community in Slack][join_slack], and
 you can report any issues on our [GitHub][] page.
 
-## Can I get support or a commercial license?
-Yes. Please [contact us][contact] for more information.
-
 ## Where can I get TimescaleDB source code?
 See [GitHub][].
 


### PR DESCRIPTION
# Description

Remove outdated licensing info in community FAQ

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
