### PR TITLE
Toolkit: Document installation via Docker.

### DIFF
--- a/install/installation-docker.md
+++ b/install/installation-docker.md
@@ -25,6 +25,15 @@ instead.
     docker pull timescale/timescaledb:latest-pg14
     ```
 
+<highlight type="important">
+The `timescaledb` image is a lightweight image recommended for most TimescaleDB
+users. If you need to use
+[TimescaleDB Toolkit](https://github.com/timescale/timescaledb-toolkit),
+PostGIS, or Patroni for high availability, use the
+[`timescaledb-ha`](https://hub.docker.com/r/timescale/timescaledb-ha) image
+instead.
+</highlight>
+
 </procedure>
 
 <highlight type="warning">

--- a/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
+++ b/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
@@ -33,6 +33,11 @@ docker pull timescale/timescaledb-ha:pg14-latest
 See [Pre-built containers][docker-install] for more information on running
 TimescaleDB via Docker.
 
+<highlight type="tip">
+For ARM64 deployment, use the `timescaledb` Docker image documented in the
+aforementioned [Pre-built containers][docker-install] instructions.
+</highlight>
+
 ### Install Toolkit on Red Hat-based systems
 
 These instructions use the `dnf` package manager on RHEL, CentOS, and Fedora.

--- a/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
+++ b/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
@@ -18,25 +18,28 @@ ALTER EXTENSION timescaledb_toolkit UPDATE;
 ```
 
 ## Install Toolkit on self-hosted TimescaleDB
-If you're hosting your own TimescaleDB database, you can install Toolkit as an
-RPM, Debian, or Ubuntu package. You can also build Toolkit from source.
+If you're hosting your own TimescaleDB database, you can install Toolkit by:
+*   Using the TimescaleDB high-availability Docker image
+*   Using the RPM, Debian, or Ubuntu package
+*   Building from source
 
 ### Install Docker image
 
-The recommended way to install the Toolkit is using the [TimescaleDB Docker
-image](https://github.com/timescale/timescaledb-docker-ha):
-
+The recommended way to install the Toolkit is to use the
+[TimescaleDB Docker image](https://github.com/timescale/timescaledb-docker-ha).
+To get Toolkit, pull the high availability image, `timescaledb-ha`:
 ```bash
 docker pull timescale/timescaledb-ha:pg14-latest
 ```
 
-See [Pre-built containers][docker-install] for more information on running
-TimescaleDB via Docker.
-
-<highlight type="tip">
-For ARM64 deployment, use the `timescaledb` Docker image documented in the
-aforementioned [Pre-built containers][docker-install] instructions.
+<highlight type="important">
+The `timescaledb-ha` image does not support ARM64. For AM64 deployment, use the
+`timescaledb` Docker image, which does not contain Toolkit by default. Then add
+Toolkit using the package or build-from-source methods.
 </highlight>
+
+For more information on running TimescaleDB using Docker, see the section on
+[pre-built containers][docker-install].
 
 ### Install Toolkit on Red Hat-based systems
 

--- a/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
+++ b/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
@@ -27,15 +27,15 @@ If you're hosting your own TimescaleDB database, you can install Toolkit by:
 
 The recommended way to install the Toolkit is to use the
 [TimescaleDB Docker image](https://github.com/timescale/timescaledb-docker-ha).
-To get Toolkit, pull the high availability image, `timescaledb-ha`:
+To get Toolkit, use the high availability image, `timescaledb-ha`:
 ```bash
 docker pull timescale/timescaledb-ha:pg14-latest
 ```
 
 <highlight type="important">
-The `timescaledb-ha` image does not support ARM64. For AM64 deployment, use the
-`timescaledb` Docker image, which does not contain Toolkit by default. Then add
-Toolkit using the package or build-from-source methods.
+The `timescaledb-ha` image does not support ARM64. For ARM64 environments, use the
+`timescaledb` Docker image. By default, this image does not contain Toolkit. You can add
+Toolkit using the package installation method, or by building from source.
 </highlight>
 
 For more information on running TimescaleDB using Docker, see the section on

--- a/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
+++ b/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
@@ -21,6 +21,18 @@ ALTER EXTENSION timescaledb_toolkit UPDATE;
 If you're hosting your own TimescaleDB database, you can install Toolkit as an
 RPM, Debian, or Ubuntu package. You can also build Toolkit from source.
 
+### Install Docker image
+
+The recommended way to install the Toolkit is using the [TimescaleDB Docker
+image](https://github.com/timescale/timescaledb-docker-ha):
+
+```bash
+docker pull timescale/timescaledb-ha:pg14-latest
+```
+
+See [Pre-built containers][docker-install] for more information on running
+TimescaleDB via Docker.
+
 ### Install Toolkit on Red Hat-based systems
 
 These instructions use the `dnf` package manager on RHEL, CentOS, and Fedora.
@@ -81,6 +93,7 @@ developer documentation][toolkit-gh-docs] .
 
 [cloud]: /cloud/:currentVersion:/
 [debian-install]: /install/:currentVersion:/self-hosted/installation-debian/
+[docker-install]: /install/:currentVersion:/installation-docker/
 [mst]: /mst/:currentVersion:/
 [red-hat-install]: /install/:currentVersion:/self-hosted/installation-redhat/
 [rust-install]: https://www.rust-lang.org/tools/install


### PR DESCRIPTION
# Description

- Add a tip to use timescaledb image for ARM64 deployments.
- Point to timescaledb-ha image.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
