### PR TITLE
Add error troubleshooting to pg_dump

### DIFF
--- a/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
+++ b/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
@@ -31,8 +31,7 @@ pg_dump -Fc -f exampledb.bak exampledb
 ```
 
 You might see some errors when running `pg_dump`. To learn if they can be safely
-ignored, see the
-[troubleshooting section](#troubleshooting).
+ignored, see the [troubleshooting section][troubleshooting].
 
 <highlight type="warning">
 Do not use the `pg_dump` command to backup individual hypertables. Dumps created
@@ -145,33 +144,8 @@ partitions, or the chunk interval sizes.
 
 </procedure>
 
-## Troubleshooting
-
-### Troubleshoot version mismatches
-
-The PostgreSQL `pg_dump` command does not allow you to specify which version of
-the extension to use when backing up. This can create problems if you have a
-more recent version installed. For example, if you create the backup using an
-older version of TimescaleDB, and when you restore it uses the current version,
-without giving you an opportunity to upgrade first.
-
-You can work around this problem when you are restoring from backup by making
-sure the new PostgreSQL instance has the same extension version as the original
-database before you perform the restore. After the data is restored, you can
-upgrade the version of TimescaleDB.
-
-### Troubleshoot errors when running pg_dump
-
-You might see the following errors when running `pg_dump`. You can safely ignore
-these. Your hypertable data is still accurately copied:
-
-```bash
-pg_dump: NOTICE:  hypertable data are in the chunks, no data will be copied
-DETAIL:  Data for hypertables are stored in the chunks of a hypertable so COPY TO of a hypertable will not copy any data.
-HINT:  Use "COPY (SELECT * FROM &lt;hypertable&gt;) TO ..." to copy all data in hypertable, or copy each chunk individually.
-```
-
 [parallel importer]: https://github.com/timescale/timescaledb-parallel-copy
 [pg_dump]: https://www.postgresql.org/docs/current/static/app-pgdump.html
 [pg_restore]: https://www.postgresql.org/docs/current/static/app-pgrestore.html
 [timescaledb-upgrade]: /timescaledb/:currentVersion:/how-to-guides/upgrades/
+[troubleshooting]: /timescaledb/:currentVersion:/how-to-guides/backup-and-restore/troubleshooting/

--- a/timescaledb/how-to-guides/backup-and-restore/troubleshooting.md
+++ b/timescaledb/how-to-guides/backup-and-restore/troubleshooting.md
@@ -1,0 +1,25 @@
+# Troubleshooting
+
+## Troubleshoot version mismatches
+
+The PostgreSQL `pg_dump` command does not allow you to specify which version of
+the extension to use when backing up. This can create problems if you have a
+more recent version installed. For example, if you create the backup using an
+older version of TimescaleDB, and when you restore it uses the current version,
+without giving you an opportunity to upgrade first.
+
+You can work around this problem when you are restoring from backup by making
+sure the new PostgreSQL instance has the same extension version as the original
+database before you perform the restore. After the data is restored, you can
+upgrade the version of TimescaleDB.
+
+## Troubleshoot errors when running pg_dump
+
+You might see the following errors when running `pg_dump`. You can safely ignore
+these. Your hypertable data is still accurately copied:
+
+```bash
+pg_dump: NOTICE:  hypertable data are in the chunks, no data will be copied
+DETAIL:  Data for hypertables are stored in the chunks of a hypertable so COPY TO of a hypertable will not copy any data.
+HINT:  Use "COPY (SELECT * FROM &lt;hypertable&gt;) TO ..." to copy all data in hypertable, or copy each chunk individually.
+```


### PR DESCRIPTION
# Description

Add troubleshooting section to list safely ignorable `pg_dump` errors so users don't worry when they see these.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #1040 
