### PR TITLE
Add config link to API references

### DIFF
--- a/api/configuration.md
+++ b/api/configuration.md
@@ -1,0 +1,7 @@
+# Configuration
+By default, TimescaleDB uses the default PostgreSQL server configuration
+settings. You can also change both PostgreSQL and TimescaleDB configuration
+settings yourself. For a list of settings, see the
+[configuration how-to guide][configuration-how-to]. 
+
+[configuration-how-to]: /timescaledb/:currentVersion:/how-to-guides/configuration/about-configuration/

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -652,6 +652,10 @@ module.exports = [
         ],
       },
       {
+        href: 'configuration',
+        excerpt: 'Configure PostgreSQL and TimescaleDB',
+      },
+      {
         title: 'Administration Functions',
         type: 'directory',
         href: 'administration',


### PR DESCRIPTION
# Description

Add a config section to API references that links to the config how-to.

Considered putting the actual configuration settings on this page, but that just seemed like a maintenance hassle, since the how-to is quite 'reference-y' already. Should set up single-sourcing for this eventually.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #1032 
