### PR TITLE
Update Docker installation to point to timescaledb-ha image.

### DIFF
--- a/install/installation-docker.md
+++ b/install/installation-docker.md
@@ -22,16 +22,16 @@ instead.
     instructions, see the [Docker installation documentation][docker-install].
 1.  At the command prompt, run the TimescaleDB Docker image:
     ```bash
-    docker pull timescale/timescaledb:latest-pg14
+    docker pull timescale/timescaledb-ha:pg14-latest
     ```
 
 <highlight type="important">
-The `timescaledb` image is a lightweight image recommended for most TimescaleDB
-users. If you need to use
-[TimescaleDB Toolkit](https://github.com/timescale/timescaledb-toolkit),
-PostGIS, or Patroni for high availability, use the
-[`timescaledb-ha`](https://hub.docker.com/r/timescale/timescaledb-ha) image
-instead.
+The [`timescaledb-ha`](https://hub.docker.com/r/timescale/timescaledb-ha) image
+offers the most complete TimescaleDB experience we recommend for most users; it
+includes the [TimescaleDB
+Toolkit](https://github.com/timescale/timescaledb-toolkit) as well as support
+for PostGIS, and Patroni.  If you need the smallest possible image, you can use
+the `timescale/timescaledb:latest-pg14` image instead.
 </highlight>
 
 </procedure>

--- a/install/installation-docker.md
+++ b/install/installation-docker.md
@@ -27,10 +27,10 @@ instead.
 
 <highlight type="important">
 The [`timescaledb-ha`](https://hub.docker.com/r/timescale/timescaledb-ha) image
-offers the most complete TimescaleDB experience we recommend for most users; it
+offers the most complete TimescaleDB experience. It
 includes the [TimescaleDB
-Toolkit](https://github.com/timescale/timescaledb-toolkit) as well as support
-for PostGIS, and Patroni.  If you need the smallest possible image, you can use
+Toolkit](https://github.com/timescale/timescaledb-toolkit), and support
+for PostGIS and Patroni.  If you need the smallest possible image, use
 the `timescale/timescaledb:latest-pg14` image instead.
 </highlight>
 

--- a/install/installation-docker.md
+++ b/install/installation-docker.md
@@ -28,9 +28,9 @@ instead.
 <highlight type="important">
 The [`timescaledb-ha`](https://hub.docker.com/r/timescale/timescaledb-ha) image
 offers the most complete TimescaleDB experience. It
-includes the [TimescaleDB
-Toolkit](https://github.com/timescale/timescaledb-toolkit), and support
-for PostGIS and Patroni. If you need the smallest possible image, use
+includes the 
+[TimescaleDB Toolkit](https://github.com/timescale/timescaledb-toolkit), 
+and support for PostGIS and Patroni. If you need the smallest possible image, use
 the `timescale/timescaledb:latest-pg14` image instead.
 </highlight>
 

--- a/install/installation-docker.md
+++ b/install/installation-docker.md
@@ -30,7 +30,7 @@ The [`timescaledb-ha`](https://hub.docker.com/r/timescale/timescaledb-ha) image
 offers the most complete TimescaleDB experience. It
 includes the [TimescaleDB
 Toolkit](https://github.com/timescale/timescaledb-toolkit), and support
-for PostGIS and Patroni.  If you need the smallest possible image, use
+for PostGIS and Patroni. If you need the smallest possible image, use
 the `timescale/timescaledb:latest-pg14` image instead.
 </highlight>
 


### PR DESCRIPTION
# Description

Update Docker installation to point to timescaledb-ha image.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
