### PR TITLE
Clarify details for decompression and add example

### DIFF
--- a/api/decompress_chunk.md
+++ b/api/decompress_chunk.md
@@ -3,27 +3,29 @@ If you need to modify or add data to a chunk that has already been
 compressed, you need to decompress the chunk first. This is especially
 useful for backfilling old data.
 
-<highlight type="tip">
-Prior to decompressing chunks for the purpose of data backfill or updating you should
-first stop any compression policy that is active on the hypertable you plan to perform this
-operation on.  Once the update and/or backfill is complete simply turn the policy back on
-and the system recompresses your chunks.
-</highlight>
+<highlight type="tip">Before decompressing chunks, stop any compression policy
+on the hypertable you are decompressing. When you finish backfilling or updating
+data, turn the policy back on. The database automatically recompresses your
+chunks in the next scheduled job.</highlight>
 
 ### Required arguments
 |Name|Type|Description|
-|---|---|---|
-| `chunk_name` | REGCLASS | Name of the chunk to be decompressed. |
+|-|-|-|
+|`chunk_name`|`REGCLASS`|Name of the chunk to be decompressed.|
 
 ### Optional arguments
 
 |Name|Type|Description|
-|---|---|---|
-| `if_compressed` | BOOLEAN | Setting to true skips chunks that are not compressed. Defaults to false.|
+|-|-|-|
+|`if_compressed`|`BOOLEAN`|Setting to true skips chunks that are not compressed. Defaults to false.|
 
 ### Sample usage
-Decompress a single chunk
-
+Decompress a single chunk:
 ``` sql
 SELECT decompress_chunk('_timescaledb_internal._hyper_2_2_chunk');
+```
+
+Decompress all compressed chunks in a hypertable named `metrics`:
+```sql
+SELECT decompress_chunk(c, true) FROM show_chunks('metrics') c;
 ```

--- a/api/decompress_chunk.md
+++ b/api/decompress_chunk.md
@@ -3,10 +3,12 @@ If you need to modify or add data to a chunk that has already been
 compressed, you need to decompress the chunk first. This is especially
 useful for backfilling old data.
 
-<highlight type="tip">Before decompressing chunks, stop any compression policy
+<highlight type="note">
+Before decompressing chunks, stop any compression policy
 on the hypertable you are decompressing. When you finish backfilling or updating
 data, turn the policy back on. The database automatically recompresses your
-chunks in the next scheduled job.</highlight>
+chunks in the next scheduled job.
+</highlight>
 
 ### Required arguments
 |Name|Type|Description|


### PR DESCRIPTION
# Description

Clarify behavior of decompressed chunks when compression policy is restored. Add example of how to decompress all compressed chunks in a hypertable.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Partial #1005 
