### PR TITLE
Add clarification about hypertable indexes and unique indexes

### DIFF
--- a/timescaledb/how-to-guides/hypertables/hypertables-and-unique-indexes.md
+++ b/timescaledb/how-to-guides/hypertables/hypertables-and-unique-indexes.md
@@ -1,6 +1,12 @@
 # Hypertable partitioning and unique indexes
 Hypertable partitioning introduces some restrictions on unique indexes.
 
+<highlight type="note">
+This section pertains only to unique indexes, not to indexes in general. You
+can create a hypertable without any unique index, though you might want one to
+enforce constraints.
+</highlight>
+
 ## Partitioning columns
 Before you create a unique index, you need to determine what unique indexes are allowed on your
 hypertable. Begin by identifying your partitioning columns.


### PR DESCRIPTION
# Description

Readers might be confused about the hypertables and unique indexes page if they read it to imply that hypertables _must_ have unique indexes. Adds a clarification that they do not.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
