### PR TITLE
Remove duplicate "add GPG key" instruction

### DIFF
--- a/install/installation-debian.md
+++ b/install/installation-debian.md
@@ -37,10 +37,6 @@ instead.
     ```bash
     /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
     ```
-1.  Add the Timescale GPG key:
-    ```bash
-    curl -L https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
-    ```
 1.  Add the TimescaleDB third party repository:
 
     <terminal>


### PR DESCRIPTION
# Description

In the debian install documentation the instruction to add the timescale
GPG key was duplicated, once before adding the repository, and once
after. This doesn't cause any issues, but is unnecessary.

# Version

Which documentation version does this PR apply to?

- [ ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
