### PR TITLE
Add Ubuntu 22.04 (Jammy Jellyfish) to supported distros

### DIFF
--- a/install/installation-debian.md
+++ b/install/installation-debian.md
@@ -9,6 +9,7 @@ instructions use the `apt` package manager on these distributions:
 *   Ubuntu 20.04 LTS Focal Fossa
 *   Ubuntu 21.04 Hirsute Hippo
 *   Ubuntu 21.10 Impish Indri
+*   Ubuntu 22.04 LTS Jammy Jellyfish
 
 <highlight type="important">
 Before you begin installing TimescaleDB, make sure you have installed PostgreSQL


### PR DESCRIPTION
# Description

We've recently added packages for 22.04.

# Version

Which documentation version does this PR apply to?

- [ ] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
