### PR TITLE
Fixed the typo in Windows Installation Page

### DIFF
--- a/install/installation-windows/index.md
+++ b/install/installation-windows/index.md
@@ -77,7 +77,7 @@ installed it yet, check out our [installing psql][install-psql] section.
     ```
 1.  Connect to the database you created:
     ```sql
-    \c tutorial
+    \c example
     ```
 1.  Add the TimescaleDB extension:
     ```sql


### PR DESCRIPTION
# Description

The name of the database while connecting via psql is wrong. It is currently `tutorial` but on the step before, we created `example` database. I also verified this while following the instructions and it was indeed wrong.

# Version

Which documentation version does this PR apply to?

- Latest (Default)

# Links

Fixes #1069
