### PR TITLE
Add hyperfunction category cards to hyperfunction how-to index

### DIFF
--- a/timescaledb/how-to-guides/hyperfunctions/index.md
+++ b/timescaledb/how-to-guides/hyperfunctions/index.md
@@ -6,26 +6,15 @@ Some hyperfunctions are included in the default TimescaleDB product. For
 additional hyperfunctions, you need to install the
 [Timescale Toolkit][install-toolkit] PostgreSQL extension.
 
-*   [Learn about hyperfunctions][about-hyperfunctions] to understand how it works
-    before you begin using it.
+For more information, read the [hyperfunctions blog post][hyperfunctions-blog].
+
+## Learn hyperfunction basics and install Timescale Toolkit
+*   [Learn about hyperfunctions][about-hyperfunctions] to understand how they
+    work before using them.
 *   Install the [Toolkit extension][install-toolkit] to access more
     hyperfunctions.
-*   Learn how to use [function pipelines][about-pipelines] to construct
-    hyperfunction queries.
-*   Use the [approximate count distinct][hyperfunctions-approx-count-distinct]
-    functions.
-*   Use the [statistical aggregate][hyperfunctions-stats-agg]
-    functions.
-*   Use the [gapfilling and interpolation][hyperfunctions-gapfilling]
-    functions.
-*   Use the [approximate percentile][hyperfunctions-approximate-percentile]
-    functions.
-*   Use the [counter aggregation][hyperfunctions-counteragg] functions.
-*   Use the [time-weighted average][hyperfunctions-time-weighted-averages]
-    functions.
 
-For more information about hyperfunctions, read our [blog post][hyperfunctions-blog].
-
+## Browse hyperfunctions and Toolkit features by category
 
 [about-hyperfunctions]: /how-to-guides/hyperfunctions/about-hyperfunctions
 [install-toolkit]: /how-to-guides/hyperfunctions/install-toolkit

--- a/timescaledb/how-to-guides/page-index/page-index.js
+++ b/timescaledb/how-to-guides/page-index/page-index.js
@@ -613,6 +613,16 @@ module.exports = [
       {
         title: "Hyperfunctions",
         href: "hyperfunctions",
+        pageComponents: ["featured-cards"],
+        featuredChildren: [
+          "/timescaledb/:currentVersion:/how-to-guides/hyperfunctions/function-pipelines",
+          "/timescaledb/:currentVersion:/how-to-guides/hyperfunctions/approx-count-distincts",
+          "/timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs",
+          "/timescaledb/:currentVersion:/how-to-guides/hyperfunctions/gapfilling-interpolation",
+          "/timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx",
+          "/timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation",
+          "/timescaledb/:currentVersion:/how-to-guides/hyperfunctions/time-weighted-averages",
+        ],
         children: [
           {
             title: "About hyperfunctions",
@@ -640,12 +650,13 @@ module.exports = [
             href: "function-pipelines",
             tags: ["toolkit", "hyperfunctions", "query", "timescaledb"],
             keywords: ["TimescaleDB", "hyperfunctions", "Toolkit"],
-            excerpt: "Learn about function pipelines",
+            excerpt: "Use functional programming to simplify complex SQL queries",
           },
           {
             title: "Approximate count distincts",
             href: "approx-count-distincts",
             type: "directory",
+            excerpt: "Count the number of unique values in a dataset",
             children: [
               {
                 title: "Hyperloglog",
@@ -661,12 +672,14 @@ module.exports = [
             href: "stats-aggs",
             tags: ["hyperfunctions", "toolkit", "query", "timescaledb"],
             keywords: ["TimescaleDB", "hyperfunctions", "Toolkit"],
-            excerpt: "Learn about the statistical aggregates hyperfunction",
+            excerpt:
+              "Calculate descriptive statistics and models, including averages, standard deviation, linear regression, and more",
           },
           {
             title: "Gapfilling and interpolation",
             href: "gapfilling-interpolation",
             type: "directory",
+            excerpt: "Fill in data collected at irregular time intervals",
             children: [
               {
                 title: "Time bucket gapfill",
@@ -689,6 +702,7 @@ module.exports = [
             title: "Percentile approximation",
             href: "percentile-approx",
             type: "directory",
+            excerpt: "Calculate percentiles",
             children: [
               {
                 title: "Approximate percentile",
@@ -711,6 +725,7 @@ module.exports = [
             title: "Counter aggregation",
             href: "counter-aggregation",
             type: "directory",
+            excerpt: "Calculate statistics from gauges and counters",
             children: [
               {
                 title: "Counter aggregates",
@@ -725,6 +740,7 @@ module.exports = [
             title: "Time-weighted averages",
             href: "time-weighted-averages",
             type: "directory",
+            excerpt: "Calculate time-weighted averages",
             children: [
               {
                 title: "Time-weighted averages",


### PR DESCRIPTION
# Description

Hyperfunctions are difficult to navigate right now. Navigation hierarchy is deep, and it's difficult to know what all the categories do (especially as some categories have grown over time). This provides a first step to fixing that by making it easier to browse the categories.

<img width="735" alt="image" src="https://user-images.githubusercontent.com/26616127/167936279-83e354b3-7b32-4b47-8e7b-11262a407141.png">

Future work should include evaluating the hyperfunction categorization scheme and category naming.

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #[insert issue link, if any]
