### PR TITLE
Fix broken query in Grafana histogram vis 

### DIFF
--- a/timescaledb/tutorials/grafana/visualizations/histograms.md
+++ b/timescaledb/tutorials/grafana/visualizations/histograms.md
@@ -192,7 +192,7 @@ selected values, and Grafana buckets them in separate histograms.
 1.  Fetch all company symbols from the dataset:
 
     ```sql
-    SELECT DISTINCT symbol FROM company ORDER BY asc;
+    SELECT DISTINCT symbol FROM company ORDER BY symbol ASC;
     ```
 
 1.  Create a new dashboard variable with the previous query: 


### PR DESCRIPTION
# Description
This PR fixes a broken query in the Grafana histogram visualization.


Broken (missing symbol):
```SQL
SELECT DISTINCT symbol FROM company ORDER BY asc;
```

Fixed:
```SQL
SELECT DISTINCT symbol FROM company ORDER BY symbol ASC;
```



# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]
