### PR TITLE
Add send data to Jaeger and Zipkin to index

### DIFF
--- a/promscale/page-index/page-index.js
+++ b/promscale/page-index/page-index.js
@@ -116,6 +116,20 @@ module.exports = [
             keywords: ["Promscale", "OpenTelemetry"],
             excerpt: "Send OpenTelemetry data to Promscale",
           },
+          {
+            title: 'Jaeger',
+            href: 'jaeger',
+            tags: ['promscale', 'configure', 'jaeger', 'traces'],
+            keywords: ['Promscale', 'Jaeger'],
+            excerpt: 'Send Jaeger traces to Promscale',
+          },
+          {
+            title: 'Zipkin',
+            href: 'zipkin',
+            tags: ['promscale', 'configure', 'zipkin', 'traces'],
+            keywords: ['Promscale', 'Zipkin'],
+            excerpt: 'Send Zipkin traces to Promscale',
+          }
         ],
       },
       {
@@ -229,20 +243,6 @@ module.exports = [
             ],
             excerpt: "Configure Promscale multi-tenancy for Prometheus",
           },
-          {
-            title: 'Jaeger',
-            href: 'jaeger',
-            tags: ['promscale', 'configure', 'jaeger', 'traces'],
-            keywords: ['Promscale', 'Jaeger'],
-            excerpt: 'Send Jaeger traces to Promscale',
-          },
-          {
-            title: 'Zipkin',
-            href: 'zipkin',
-            tags: ['promscale', 'configure', 'zipkin', 'traces'],
-            keywords: ['Promscale', 'Zipkin'],
-            excerpt: 'Send Zipkin traces to Promscale',
-          }
         ],
       },
       {

--- a/promscale/send-data/index.md
+++ b/promscale/send-data/index.md
@@ -4,6 +4,8 @@ It also has APIs that you can use to send metrics in a variety of formats.
 
 *   [Configure Prometheus][configure-prometheus] to send metrics to Promscale.
 *   [Configure OpenTelemetry][configure-opentelemetry] to send data to Promscale.
+*   [Configure Jaeger] to send data to Promscale via the OpenTelemetry Collector
+*   [Configure Jaeger] to send data to Promscale via the OpenTelemetry Collector
 *   [Use Promscale's write api][promscale-write-api] to send metrics in 
     json, protobuf or text format.
 


### PR DESCRIPTION
# Description

Somehow the page-index was messed up for send data to Jaeger and Zipkin and they don't show up. This fixes that and also adds a reference in the send data index page. 
