### PR TITLE
Add info on Docker logging

### DIFF
--- a/timescaledb/how-to-guides/troubleshoot-timescaledb.md
+++ b/timescaledb/how-to-guides/troubleshoot-timescaledb.md
@@ -99,7 +99,7 @@ query is immensely helpful.
 
 ### View logs in Docker
 If you have TimescaleDB installed in a Docker container, you can view your logs
-via Docker, instead of looking in `/var/lib/logs` or `/var/logs`. For more
+using Docker, instead of looking in `/var/lib/logs` or `/var/logs`. For more
 information, see the [Docker documentation on logs][docker-logs].
 
 ## Dump TimescaleDB meta data [](dump-meta-data)

--- a/timescaledb/how-to-guides/troubleshoot-timescaledb.md
+++ b/timescaledb/how-to-guides/troubleshoot-timescaledb.md
@@ -97,7 +97,10 @@ When asking query-performance related questions in our [support portal][]
 or via [slack][], providing the EXPLAIN output of a
 query is immensely helpful.
 
----
+### View logs in Docker
+If you have TimescaleDB installed in a Docker container, you can view your logs
+via Docker, instead of looking in `/var/lib/logs` or `/var/logs`. For more
+information, see the [Docker documentation on logs][docker-logs].
 
 ## Dump TimescaleDB meta data [](dump-meta-data)
 
@@ -114,10 +117,11 @@ psql [your connect flags] -d your_timescale_db < dump_meta_data.sql > dumpfile.t
 
 and then inspect `dump_file.txt` before sending it together with a bug report or support question.
 
-[slack]: https://slack.timescale.com/
+[docker-logs]: https://docs.docker.com/config/containers/logging/
+[downloaded separately]: https://raw.githubusercontent.com/timescale/timescaledb/master/scripts/dump_meta_data.sql
 [github]: https://github.com/timescale/timescaledb/issues
+[slack]: https://slack.timescale.com/
+[support portal]: https://www.timescale.com/support
+[track_io_timing]: https://www.postgresql.org/docs/current/static/runtime-config-statistics.html#GUC-TRACK-IO-TIMING
 [update-db]: /how-to-guides/update-timescaledb/
 [using explain]: https://www.postgresql.org/docs/current/static/using-explain.html
-[track_io_timing]: https://www.postgresql.org/docs/current/static/runtime-config-statistics.html#GUC-TRACK-IO-TIMING
-[downloaded separately]: https://raw.githubusercontent.com/timescale/timescaledb/master/scripts/dump_meta_data.sql
-[support portal]: https://www.timescale.com/support


### PR DESCRIPTION
# Description

Add info on where to find TimescaleDB logs in Docker

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]

# Links

Fixes #1047 
