### PR TITLE
Fix query & typo

### DIFF
--- a/timescaledb/tutorials/grafana/visualizations/histograms.md
+++ b/timescaledb/tutorials/grafana/visualizations/histograms.md
@@ -7,7 +7,7 @@ They can answer questions like:
 
 * What is the distribution of the Meta stock price today?
 * What was the transaction volume distribution of AMD stock last week?
-* What was the distribution of daily returns of the S&P in the past year?
+* What was the distribution of daily returns of the S&P500 in the past year?
 
 ## Data for Grafana histograms
 With Grafana, you can plot a histogram by providing data in 1 of 3
@@ -165,7 +165,7 @@ you need to add a new variable called `bucket_interval`.
     FROM stocks_real_time srt
     WHERE symbol = '$symbol'
         AND time >= $__timeFrom()::timestamptz and time < $__timeTo()::timestamptz
-    GROUP BY time_bucket('$date_range',time);
+    GROUP BY time_bucket('$bucket_interval', time);
     ```
 
 1.  This query yields the following histogram:


### PR DESCRIPTION
# Description
This PR fixes:
- a broken query
- a typo (S&P -> S&P500)

# Version

Which documentation version does this PR apply to?

- [x] Latest (Default)
- [ ] Version 1.7
- [ ] Older [specify]