### PR TITLE
Remove install PostgreSQL banner from main install page

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -22,11 +22,6 @@ head over to [Managed Service for TimescaleDB][mst-install]. This option allows
 you more flexibility in choosing where your installation is hosted, from more
 than 75 regions on Amazon Web Services, Azure, or Google Cloud Platform.
 
-<highlight type="important">
-Before you begin installing TimescaleDB, make sure you have installed PostgreSQL
-version 12 or later.
-</highlight>
-
 *   Start using the [Timescale Cloud][tsc-install] hosted service.
 *   Install self-hosted TimescaleDB on [your own server hardware][self-hosted-install].
 *   Install self-hosted TimescaleDB [from source][self-hosted-source].


### PR DESCRIPTION
# Description
Banner is now a bit misleading because all of our install pages cover how to install PostgreSQL and also tell you that if you already installed PostgreSQL using another method, it could cause problems. Also you don't need to install PostgreSQL for Cloud and MST.

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Are procedure and highlight tags used appropriately?
- [x] Has the index been updated appropriately?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] Are all links provided in reference style, and resolvable?
- [x] Have you checked the built version of this content?
