### PR TITLE
Fix broken Promscale link

### DIFF
--- a/promscale/manage-data/retention.md
+++ b/promscale/manage-data/retention.md
@@ -52,4 +52,4 @@ SELECT ps_trace.set_trace_retention_period(30 * INTERVAL '1 day');
 
 
 
-[promscale-install]: promscale/:currentVersion/installation/
+[promscale-install]: promscale/:currentVersion:/installation/


### PR DESCRIPTION
# Description

`currentVersion` was missing a colon so the link was going to
https://docs.timescale.com/promscale/latest/promscale/:currentVersion/installation/
which doesn't exist.

# Links

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] Have you checked the built version of this content?
