### PR TITLE
Add a `_partials` directory

### DIFF
--- a/_partials/_experimental.mdx
+++ b/_partials/_experimental.mdx
@@ -1,0 +1,5 @@
+<highlight type="warning">
+Experimental features could have bugs. They might not be backwards compatible,
+and could be removed in future releases. Use these features at your own risk, and
+do not use any experimental features in production.
+</highlight>


### PR DESCRIPTION
# Description

Adds a directory for partials that we can include as part of other
documents. There is a related web-documentation PR to support this.

Includes first example of a useful partial, for the 'experimental
feature' callout.

# Links

Fixes #[insert issue link, if any]

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
