### PR TITLE
Add notes about number of DBs per cloud service

### DIFF
--- a/cloud/services/create-a-service.md
+++ b/cloud/services/create-a-service.md
@@ -6,6 +6,18 @@ quickly spin up new TimescaleDB instances. You can
 For installation instructions, and help getting your first service up and
 running, see the [Timescale Cloud installation section][cloud-install].
 
+You can have one database on each of your Timescale Cloud services. If you try
+to create a second database on a service that already has one, you receive an
+error like this:
+
+```sql
+ERROR:  tsdb_admin: database <DB_NAME> is not an allowed database name
+HINT:  Contact your administrator to configure the "tsdb_admin.allowed_databases"
+```
+
+To create a second database, you need to create a second service.
+
+
 ## Where to next
 Now that you have your first service up and running, you can check out the
 [Timescale Cloud][tsc-docs] section in our documentation, and

--- a/cloud/services/create-a-service.md
+++ b/cloud/services/create-a-service.md
@@ -6,7 +6,9 @@ quickly spin up new TimescaleDB instances. You can
 For installation instructions, and help getting your first service up and
 running, see the [Timescale Cloud installation section][cloud-install].
 
-Each Timescale Cloud service can have a single database named `tsdb`. If you try to create an additional database you receive an error like this:
+Each Timescale Cloud service can have a single database. The database must be
+named `tsdb`. If you try to create an additional database you receive an error
+like this:
 
 ```sql
 ERROR:  tsdb_admin: database <DB_NAME> is not an allowed database name
@@ -14,7 +16,6 @@ HINT:  Contact your administrator to configure the "tsdb_admin.allowed_databases
 ```
 
 If you need another database, you need to create a new service.
-
 
 ## Where to next
 Now that you have your first service up and running, you can check out the

--- a/cloud/services/create-a-service.md
+++ b/cloud/services/create-a-service.md
@@ -6,16 +6,14 @@ quickly spin up new TimescaleDB instances. You can
 For installation instructions, and help getting your first service up and
 running, see the [Timescale Cloud installation section][cloud-install].
 
-You can have one database on each of your Timescale Cloud services. If you try
-to create a second database on a service that already has one, you receive an
-error like this:
+Each Timescale Cloud service can have a single database named `tsdb`. If you try to create an additional database you receive an error like this:
 
 ```sql
 ERROR:  tsdb_admin: database <DB_NAME> is not an allowed database name
 HINT:  Contact your administrator to configure the "tsdb_admin.allowed_databases"
 ```
 
-To create a second database, you need to create a second service.
+If you need another database, you need to create a new service.
 
 
 ## Where to next

--- a/install/installation-cloud.md
+++ b/install/installation-cloud.md
@@ -8,8 +8,8 @@ and cost-effective way to store and analyze your time-series data. Get started
 super fast with demo data, or your own dataset, and enjoy the security of
 automated upgrades and backups.
 
-You can have one database on each of your Timescale Cloud services and it has to be named `tsdb`. To create a
-second database, you need to create a second service.
+Each Timescale Cloud service can have a single database. The database must be
+named `tsdb`. To create a second database, you need to create a second service.
 
 <procedure>
 

--- a/install/installation-cloud.md
+++ b/install/installation-cloud.md
@@ -8,6 +8,9 @@ and cost-effective way to store and analyze your time-series data. Get started
 super fast with demo data, or your own dataset, and enjoy the security of
 automated upgrades and backups.
 
+You can have one database on each of your Timescale Cloud services. To create a
+second database, you need to create a second service.
+
 <procedure>
 
 ### Installing Timescale Cloud

--- a/install/installation-cloud.md
+++ b/install/installation-cloud.md
@@ -8,7 +8,7 @@ and cost-effective way to store and analyze your time-series data. Get started
 super fast with demo data, or your own dataset, and enjoy the security of
 automated upgrades and backups.
 
-You can have one database on each of your Timescale Cloud services. To create a
+You can have one database on each of your Timescale Cloud services and it has to be named `tsdb`. To create a
 second database, you need to create a second service.
 
 <procedure>


### PR DESCRIPTION
# Description

Adds two notes about one db per service to the Cloud Install and Cloud Service sections. One also includes the error for people who are searching.

# Links

Fixes https://github.com/timescale/docs/issues/1148

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
