### PR TITLE
[Caggs how-to] Split index creation into own page

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/create-index.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/create-index.md
@@ -1,0 +1,51 @@
+# Create an index on a continuous aggregate
+By default, some indexes are automatically created when you create a continuous
+aggregate. You can change this behavior. You can also manually create and drop
+indexes.
+
+## Automatically created indexes
+When you create a continuous aggregate, an index is automatically created for
+each `GROUP BY` column. The index is a composite index, combining the `GROUP BY`
+column with the `time_bucket` column.
+
+For example, if you define a continuous aggregate view with `GROUP BY device,
+location, bucket`, two composite indexes are created: one on `{device, bucket}`
+and one on `{location, bucket}`.
+
+### Turn off automatic index creation
+To turn off automatic index creation, set `timescaledb.create_group_indexes` to
+`false` when you create the continuous aggregate.
+
+For example:
+```sql
+CREATE MATERIALIZED VIEW conditions_daily
+  WITH (timescaledb.continuous, timescaledb.create_group_indexes=false)
+  AS
+  ...
+```
+
+## Manually create and drop indexes
+You can manually create and drop indexes. To do so, you need to know the name of
+your materialized hypertable. To find the name, see the instructions in the
+[managing materialized hypertables][materialized-hypertable-name] section.
+
+<highlight type="note">
+The name you give when you run `CREATE MATERIALIZED VIEW` is the view name. The
+continuous aggregate's data is stored in a materialized hypertable, which is
+automatically created and named.
+</highlight>
+
+You can then use a regular PostgreSQL statement to create or drop an index on
+the hypertable. For example, to create an index on `avg_temp` for a materialized
+hypertable named `_timescaledb_internal._materialized_hypertable_2`:
+```sql
+CREATE INDEX avg_temp_idx ON _timescaledb_internal._materialized_hypertable_2 (avg_temp);
+```
+
+### Limitations on created indexes
+In TimescaleDB 2.7 and above, you can create an index on any column in the
+materialized view. This includes aggregated columns, such as those storing sums
+and averages. In earlier versions of TimescaleDB, you can't create an index on
+an aggregated column.
+
+[materialized-hypertable-name]: /how-to-guides/continuous-aggregates/materialized-hypertables/#discover-the-name-of-a-materialized-hypertable

--- a/timescaledb/how-to-guides/continuous-aggregates/materialized-hypertables.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/materialized-hypertables.md
@@ -30,18 +30,4 @@ You can then use the name to modify it in the same way as any other hypertable.
 
 </procedure>
 
-## Create indexes on the materialized hypertable
-Materialized hypertables include composite indexes. By default, these indexes
-are created on each column specified as `GROUP BY`, combined with the
-`time_bucket` column. For example, if the continuous aggregate view is defined
-as `GROUP BY device, bucket`, the composite index is created on `{device,
-bucket}`. If you specify grouping by other columns as well, additional indexes
-are also created on those columns.
-
-You can turn this behavior off by setting `timescaledb.create_group_indexes` to
-`false` when you create the view. If you want to create additional indexes, or
-drop some of the default ones, you can do so by creating or dropping the
-appropriate indexes on the materialization hypertable directly.
-
-
 [api-continuous-aggregates-info]: /api/:currentVersion:/informational-views/continuous_aggregates/

--- a/timescaledb/how-to-guides/page-index/page-index.js
+++ b/timescaledb/how-to-guides/page-index/page-index.js
@@ -544,6 +544,13 @@ module.exports = [
             excerpt: "Manage refresh policies for continuous aggregates",
           },
           {
+            title: "Create an index on a continuous aggregate",
+            href: "create-index",
+            tags: ["indexes", "caggs", "timescaledb"],
+            keywords: ["indexes", "caggs", "TimescaleDB"],
+            excerpt: "Manage automatic index creation and manually create additional indexes",
+          },
+          {
             title: "Time in continuous aggregates",
             href: "time",
             tags: ["caggs", "manage", "timescaledb"],


### PR DESCRIPTION
# Description

Now that TimescaleDB 2.7 has removed limitations on creating indexes
with caggs, cagg indexes should get their own page.

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Are procedure and highlight tags used appropriately?
- [x] Has the index been updated appropriately?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] Are all links provided in reference style, and resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
