### PR TITLE
Add note on Promscale extension search_path modification

### DIFF
--- a/promscale/installation/index.md
+++ b/promscale/installation/index.md
@@ -10,6 +10,16 @@ from your applications and infrastructure. It is expected that you use
 instrumentation set up, you can use Promscale to ingest the metric and
 trace data.
 
+<highlight type="note">
+The PostgreSQL `search_path` variable determines in what order schemas are
+searched and which objects such as tables, views, functions, and others do not
+require schema qualification to use. When you install Promscale, the Promscale
+extension modified the `search_path` of the database that it is connected to
+and adds its public schemas to the search path. This makes querying Promscale
+data easier. The public schemas that Promscale adds are: `ps_tag`, `prom_api`,
+`prom_metric`, `ps_trace`. 
+</highlight>
+
 ## Install Promscale without instrumentation
 If you have Prometheus or OpenTelemetry installed, you can install Promscale
 on these environments:

--- a/promscale/installation/index.md
+++ b/promscale/installation/index.md
@@ -14,7 +14,7 @@ trace data.
 The PostgreSQL `search_path` variable determines in what order schemas are
 searched and which objects such as tables, views, functions, and others do not
 require schema qualification to use. When you install Promscale, the Promscale
-extension modified the `search_path` of the database that it is connected to
+extension modifies the `search_path` of the database that it is connected to
 and adds its public schemas to the search path. This makes querying Promscale
 data easier. The public schemas that Promscale adds are: `ps_tag`, `prom_api`,
 `prom_metric`, `ps_trace`. 


### PR DESCRIPTION
# Description

The Promscale extension modifies the `search_path` of the database that it's installed into. This is for convenience of querying from SQL. For advanced Postgres users, this may be unexpected behaviour, so we would like to bring it to their attention.

# Links

Fixes https://github.com/timescale/promscale_extension/issues/322

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
