### PR TITLE
[Vale] Fix GitHub linting workflow

### DIFF
--- a/.github/workflows/vale-linter.yml
+++ b/.github/workflows/vale-linter.yml
@@ -11,10 +11,8 @@ jobs:
     - name: Vale
       uses: errata-ai/vale-action@v2
       with:
-        onlyAnnotateModifiedLines: true
-        # config: https://raw.githubusercontent.com/errata-ai/vale/master/.vale.ini
-        # styles: |
-        #   https://github.com/errata-ai/Google/releases/latest/download/Google.zip
+        reporter: github-pr-check
+        filter_mode: added
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       continue-on-error: true


### PR DESCRIPTION
# Description

The upgrade to Vale 2.0 broke PR linting, because the configuration
options changed.
[See new options here.](https://github.com/errata-ai/vale-action#inputs)

# Links

Fixes #[insert issue link, if any]

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
