### PR TITLE
fix typo in api/hyperloglog.md

### DIFF
--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -50,11 +50,11 @@ SELECT hyperloglog(32768, weights) FROM samples;
 ```
 
 Alternatively, you can build a view from the aggregate that you can pass to
-other `tdigest` functions:
+other `hyperloglog` functions:
 
 ``` sql
-CREATE VIEW digest AS SELECT hyperloglog(32768, data) FROM samples;
+CREATE VIEW hll AS SELECT hyperloglog(32768, data) FROM samples;
 ```
 
 
-[hyperfunctions-approx-count-distincts]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/approx-count-distincts/
+[hyperfunctions-approx-count-distincts]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/approx-count-distincts/

--- a/api/tdigest.md
+++ b/api/tdigest.md
@@ -69,7 +69,7 @@ SELECT tdigest(100, data) FROM samples;
 ```
 
 This example builds a view from the aggregate that can be passed to other
-tdigest functions:
+`tdigest` functions:
 ```SQL
 CREATE VIEW digest AS
     SELECT tdigest(100, data)
@@ -77,5 +77,5 @@ CREATE VIEW digest AS
 ```
 
 
-[hyperfunctions-percentile-approx]: timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/
+[hyperfunctions-percentile-approx]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/
 [gh-tdigest]: https://github.com/timescale/timescaledb-toolkit/blob/main/docs/tdigest.md


### PR DESCRIPTION
# Description

Saw that the hyperloglog page had a mistaken reference to tdigest.


# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
