### PR TITLE
Update hyperloglog with bucket guidance

### DIFF
--- a/api/distinct_count.md
+++ b/api/distinct_count.md
@@ -35,12 +35,12 @@ This example retrieves the distinct values from a hyperloglog
 called `hyperloglog`:
 
 ``` sql
-SELECT distinct_count(hyperloglog(64, data))
-FROM generate_series(1, 100) data
+SELECT distinct_count(hyperloglog(32768, data))
+FROM generate_series(1, 100000) data
 
  distinct_count
 ----------------
-            114
+         100151
 ```
 
 

--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -22,11 +22,13 @@ For more information about approximate count distinct functions, see the
 
 |Name|Type|Description|
 |-|-|-|
-|buckets|integer|Number of buckets in the digest. Rounded up to the next power of 2, must be between 16 and 2^18.|
+|buckets|integer|Number of buckets in the digest. Rounded up to the next power of 2. Must be between 16 and 2^18, values less than 1024 are not recommended.|
 |value|AnyElement| Column to count distinct elements. The type must have an extended, 64-bit, hash function.|
 
 Increasing the `buckets` argument usually provides more accuracy at the expense
-of more storage.
+of more storage.  Because hyperloglog is a probabilistic algorithm, it works
+best on datasets that have many distinct values: at least tens of thousands. But it should
+also be fairly accurate so long as you have more buckets than distinct values.
 
 ## Returns
 
@@ -42,14 +44,14 @@ called `weights` that holds DOUBLE PRECISION values. This command returns a
 digest over that column:
 
 ``` sql
-SELECT hyperloglog(64, weights) FROM samples;
+SELECT hyperloglog(32768, weights) FROM samples;
 ```
 
 Alternatively, you can build a view from the aggregate that you can pass to
 other `tdigest` functions:
 
 ``` sql
-CREATE VIEW digest AS SELECT hyperloglog(64, data) FROM samples;
+CREATE VIEW digest AS SELECT hyperloglog(32768, data) FROM samples;
 ```
 
 

--- a/api/rollup-hyperloglog.md
+++ b/api/rollup-hyperloglog.md
@@ -42,13 +42,14 @@ For more information about approximate count distinct functions, see the
 ```SQL
 SELECT distinct_count(rollup(logs))
 FROM (
-    (SELECT hyperloglog(32, v::text) logs FROM generate_series(1, 100) v)
+    (SELECT hyperloglog(32768, v::text) logs FROM generate_series(1, 100000) v)
     UNION ALL
-    (SELECT hyperloglog(32, v::text) FROM generate_series(50, 150) v)
+    (SELECT hyperloglog(32768, v::text) FROM generate_series(50000, 150000) v)
 ) hll;
- count
--------
-   152
+
+ distinct_count 
+----------------
+         150147
 ```
 
 

--- a/api/stderror.md
+++ b/api/stderror.md
@@ -23,7 +23,7 @@ The `stderror` function returns an estimate of the relative standard error of th
 |8|256|0.0650|192|
 |9|512|0.0460|384|
 |10|1024|0.0325|768|
-|11|2048|0.0230||1536|
+|11|2048|0.0230|1536|
 |12|4096|0.0163|3072|
 |13|8192|0.0115|6144|
 |14|16384|0.0081|12288|
@@ -53,12 +53,12 @@ For more information about approximate count distinct functions, see the
 This examples retrieves the standard error from a hyperloglog called `hyperloglog`:
 
 ``` sql
-SELECT stderror(hyperloglog(64, data))
-FROM generate_series(1, 100) data
+SELECT stderror(hyperloglog(32768, data))
+FROM generate_series(1, 100000) data
 
- stderror
-----------
-     0.13
+       stderror       
+----------------------
+ 0.005745242597140698
 
 ```
 


### PR DESCRIPTION
Update the hyperloglog documentation to recommend a minimum bucket
size of 1024.  Also update all examples to use larger bucket sizes.

Fixes https://github.com/timescale/product/issues/236