### PR TITLE
Add send data as note in install instructions

### DIFF
--- a/promscale/installation/docker.md
+++ b/promscale/installation/docker.md
@@ -52,10 +52,8 @@ packages and instructions, see the
 
 </procedure>
 
-<highlight type="note">
-Post installation of Promscale, the next step is to ingest the 
-data into Promscale. Follow the [send data][send-data] instructions.
-</highlight>
+When you have installed Promscale, you are ready to ingest 
+data. For instructions, see the [send data][send-data] section.
 
 ## Upgrading from the previous alpine image
 

--- a/promscale/installation/docker.md
+++ b/promscale/installation/docker.md
@@ -52,8 +52,8 @@ packages and instructions, see the
 
 </procedure>
 
-When you have installed Promscale, you are ready to ingest 
-data. For instructions, see the [send data][send-data] section.
+After you have installed Promscale, you can ingest data.
+For instructions, see the [send data][send-data] section.
 
 ## Upgrading from the previous alpine image
 

--- a/promscale/installation/docker.md
+++ b/promscale/installation/docker.md
@@ -52,6 +52,11 @@ packages and instructions, see the
 
 </procedure>
 
+<highlight type="note">
+Post installation of Promscale, the next step is to ingest the 
+data into Promscale. Follow the [send data][send-data] instructions.
+</highlight>
+
 ## Upgrading from the previous alpine image
 
 Previously, our recommended image was located at [`timescaledev/promscale-extension`](https://hub.docker.com/r/timescaledev/promscale-extension).
@@ -107,3 +112,4 @@ If you are using Kubernetes instead of plain docker you should:
 [timescaledb-docker-image]: https://hub.docker.com/r/timescale/timescaledb-ha/tags
 [promscale-install-kubernetes]: promscale/:currentVersion:/installation/kubernetes/
 [alpine-image]: https://hub.docker.com/r/timescaledev/promscale-extension
+[send-data]: promscale/:currentVersion:/send-data/

--- a/promscale/installation/kubernetes.md
+++ b/promscale/installation/kubernetes.md
@@ -169,8 +169,8 @@ manifest file. To deploy TimescaleDB on Kubernetes use
 
 </procedure>
 
-When you have installed Promscale, you are ready to ingest 
-data. For instructions, see the [send data][send-data] section.
+After you have installed Promscale, you can ingest data.
+For instructions, see the [send data][send-data] section.
 
 [timescaledb-host-install]: promscale/:currentVersion:/installation/source#install-timescaledb
 [timescaledb-install-helm]: promscale/:currentVersion:/installation/kubernetes#install-the-timescaledb-helm-chart

--- a/promscale/installation/kubernetes.md
+++ b/promscale/installation/kubernetes.md
@@ -169,10 +169,8 @@ manifest file. To deploy TimescaleDB on Kubernetes use
 
 </procedure>
 
-<highlight type="note">
-Post installation of Promscale, the next step is to ingest the 
-data into Promscale. Follow the [send data][send-data] instructions.
-</highlight>
+When you have installed Promscale, you are ready to ingest 
+data. For instructions, see the [send data][send-data] section.
 
 [timescaledb-host-install]: promscale/:currentVersion:/installation/source#install-timescaledb
 [timescaledb-install-helm]: promscale/:currentVersion:/installation/kubernetes#install-the-timescaledb-helm-chart

--- a/promscale/installation/kubernetes.md
+++ b/promscale/installation/kubernetes.md
@@ -169,6 +169,10 @@ manifest file. To deploy TimescaleDB on Kubernetes use
 
 </procedure>
 
+<highlight type="note">
+Post installation of Promscale, the next step is to ingest the 
+data into Promscale. Follow the [send data][send-data] instructions.
+</highlight>
 
 [timescaledb-host-install]: promscale/:currentVersion:/installation/source#install-timescaledb
 [timescaledb-install-helm]: promscale/:currentVersion:/installation/kubernetes#install-the-timescaledb-helm-chart
@@ -179,3 +183,4 @@ manifest file. To deploy TimescaleDB on Kubernetes use
 [template-manifest]: https://github.com/timescale/promscale/blob/0.10.0/deploy/static/deploy.yaml
 [timescaledb-helm-values-creds]: https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/values.yaml#L33
 [timescaledb-helm-values-certs]: https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/values.yaml#L45
+[send-data]: promscale/:currentVersion:/send-data/

--- a/promscale/installation/source.md
+++ b/promscale/installation/source.md
@@ -53,9 +53,15 @@ In this procedure, you download the Promscale binaries and run them.
 
 </procedure>
 
+<highlight type="note">
+Post installation of Promscale, the next step is to ingest the 
+data into Promscale. Follow the [send data][send-data] instructions.
+</highlight>
+
 [gh-promscale-download]: https://github.com/timescale/promscale/releases
 [tsdb-install-self-hosted]: timescaledb/:currentVersion:/how-to-guides/install-timescaledb/self-hosted/
 [go-install]: https://golang.org/dl/
 [prometheus-config-tips]: https://github.com/timescale/promscale/blob/master/docs/configuring_prometheus.md
 [promscale-extension]: https://github.com/timescale/promscale_extension#promscale-extension
 [releases]: https://github.com/timescale/promscale/releases/
+[send-data]: promscale/:currentVersion:/send-data/

--- a/promscale/installation/source.md
+++ b/promscale/installation/source.md
@@ -53,8 +53,8 @@ In this procedure, you download the Promscale binaries and run them.
 
 </procedure>
 
-When you have installed Promscale, you are ready to ingest 
-data. For instructions, see the [send data][send-data] section.
+After you have installed Promscale, you can ingest data.
+For instructions, see the [send data][send-data] section.
 
 [gh-promscale-download]: https://github.com/timescale/promscale/releases
 [tsdb-install-self-hosted]: timescaledb/:currentVersion:/how-to-guides/install-timescaledb/self-hosted/

--- a/promscale/installation/source.md
+++ b/promscale/installation/source.md
@@ -53,10 +53,8 @@ In this procedure, you download the Promscale binaries and run them.
 
 </procedure>
 
-<highlight type="note">
-Post installation of Promscale, the next step is to ingest the 
-data into Promscale. Follow the [send data][send-data] instructions.
-</highlight>
+When you have installed Promscale, you are ready to ingest 
+data. For instructions, see the [send data][send-data] section.
 
 [gh-promscale-download]: https://github.com/timescale/promscale/releases
 [tsdb-install-self-hosted]: timescaledb/:currentVersion:/how-to-guides/install-timescaledb/self-hosted/


### PR DESCRIPTION
# Description

From google analytics, I see there is a drop in audience engagement from install instructions to send data. In this PR we want to explicitly mention the send data instruction post-installation of Promscale. 