### PR TITLE
Add warning to replicas docs

### DIFF
--- a/cloud/service-operations/replicas.md
+++ b/cloud/service-operations/replicas.md
@@ -67,6 +67,11 @@ over to the replica.
 
 ## Create a database replica
 
+<highlight type="warning">
+If your service was created before June 2022, adding a replica may cause your 
+service to restart. Restarts typically take about one minute to complete.
+</highlight>
+
 <procedure>
 
 ### Creating a database replica


### PR DESCRIPTION
# Description
Users who have a single node service created before June 2022 might have their _entire_ service restarted if they try to add a replica. For the user, this is likely alarming and unexpected! As a result, I've added a warning to the docs to try to warn the user that this might happen until we are able to get the issue resolved on the backend.

# Links

Fixes #[insert issue link, if any]

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [x] Is the content technically accurate?
- [x] Is the content complete?
- [x] Is the content presented in a logical order?
- [x] Does the content use appropriate names for features and products?
- [x] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
