### PR TITLE
[Caggs] Clarify `ORDER BY` support

### DIFF
--- a/_partials/_caggs-function-support.mdx
+++ b/_partials/_caggs-function-support.mdx
@@ -8,4 +8,3 @@ This table summarizes aggregate function support in continuous aggregates:
 |Hypothetical-set aggregates|❌|✅|
 |`DISTINCT` in aggregate functions|❌|✅|
 |`FILTER` in aggregate functions|❌|✅|
-|`ORDER BY` in aggregate functions|❌|✅|

--- a/api/create_materialized_view.md
+++ b/api/create_materialized_view.md
@@ -42,7 +42,7 @@ Continuous aggregates have some limitations of what types of queries they can
 support, described in more length below. For example, the `FROM` clause must
 provide only one hypertable, and joins, CTEs, views or subqueries are not
 supported. The `GROUP BY` clause must include a time bucket on the hypertable
-time column, and all aggregates must be parallelizable.
+time column.
 
 Some important things to remember when constructing your `SELECT` query:
 *   Only a single hypertable can be specified in the `FROM` clause of
@@ -56,14 +56,12 @@ Some important things to remember when constructing your `SELECT` query:
 *   You cannot use [`time_bucket_gapfill`][time-bucket-gapfill] in continuous
     aggregates, but you can run them in a `SELECT` query from the continuous
     aggregate view.
-*   You can usually use aggregates that are
-    [parallelized by PostgreSQL][postgres-parallel-agg] in the view definition,
-    including most aggregates distributed by PostgreSQL. However, the `ORDER BY`,
-    `DISTINCT` and `FILTER` clauses are not supported.
 *   All functions and their arguments included in `SELECT`, `GROUP BY` and
     `HAVING` clauses must be [immutable][postgres-immutable].
 *   The view cannot be a [security barrier view][postgres-security-barrier].
 *   You cannot use Window functions with continuous aggregates.
+*   Not all keywords are supported in continuous aggregates. To see what is
+    supported, check the [function support table][function-support].
 
 The settings for continuous aggregates are in the
 [informational views][info-views].
@@ -89,7 +87,7 @@ Optional `WITH` clause options:
 |-|-|-|-|
 |`timescaledb.materialized_only`|BOOLEAN|Return only materialized data when querying the continuous aggregate view|`FALSE`|
 |`timescaledb.create_group_indexes`|BOOLEAN|Create indexes on the continuous aggregate for columns in its `GROUP BY` clause. Indexes are in the form `(<GROUP_BY_COLUMN>, time_bucket)`|`TRUE`|
-|`timescaledb.finalized`|BOOLEAN|In TimescaleDB 2.7 and above, use the new version of continuous aggregates, which stores finalized results for aggregate functions. Supports all aggregate functions, including ones that use `FILTER`, `ORDER BY`, and `DISTINCT` clauses.|`TRUE`|
+|`timescaledb.finalized`|BOOLEAN|In TimescaleDB 2.7 and above, use the new version of continuous aggregates, which stores finalized results for aggregate functions. Supports ordered-set aggregates, hypothetical-set aggregates, and aggregate queries that use `FILTER` and `DISTINCT` clauses.|`TRUE`|
 
 For more information, see the [real-time aggregates][real-time-aggregates] section.
 
@@ -121,12 +119,13 @@ WITH (timescaledb.continuous) AS
     GROUP BY time_bucket('1h', timec);
 ```
 
+[function-support]: /timescaledb/:currentVersion:/how-to-guides/continuous-aggregates/about-continuous-aggregates/#function-support
+[info-views]: /api/:currentVersion:/informational-views/
 [postgres-immutable]: https://www.postgresql.org/docs/current/xfunc-volatility.html
 [postgres-parallel-agg]: https://www.postgresql.org/docs/current/parallel-plans.html#PARALLEL-AGGREGATION
 [postgres-rls]: https://www.postgresql.org/docs/current/ddl-rowsecurity.html
 [postgres-security-barrier]: https://www.postgresql.org/docs/current/rules-privileges.html
 [real-time-aggregates]: /timescaledb/:currentVersion:/how-to-guides/continuous-aggregates/real-time-aggregates/
-[refresh-cagg]: /continuous-aggregates/refresh_continuous_aggregate/
-[time-bucket]: /hyperfunctions/time_bucket/
-[time-bucket-gapfill]: /hyperfunctions/gapfilling-interpolation/time_bucket_gapfill/
-[info-views]: /informational-views/
+[refresh-cagg]: /api/:currentVersion:/continuous-aggregates/refresh_continuous_aggregate/
+[time-bucket-gapfill]: /api/:currentVersion:/hyperfunctions/gapfilling-interpolation/time_bucket_gapfill/
+[time-bucket]: /api/:currentVersion:/hyperfunctions/time_bucket/

--- a/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/about-continuous-aggregates.md
@@ -60,9 +60,8 @@ and `AVG`, and non-parallelizable aggregates, such as `RANK`.
 
 In older versions of TimescaleDB, continuous aggregates only support
 [aggregate functions that can be parallelized by PostgreSQL][postgres-parallel-agg].
-They also don't support `FILTER` and `ORDER BY` clauses, and the `DISTINCT` keyword. You can
-work around this by aggregating the other parts of your query in the continuous
-aggregate, then
+You can work around this by aggregating the other parts of your query in the
+continuous aggregate, then
 [using the window function to query the aggregate][cagg-window-functions].
 
 <CaggsFunctionSupport />

--- a/timescaledb/overview/core-concepts/continuous-aggregates.md
+++ b/timescaledb/overview/core-concepts/continuous-aggregates.md
@@ -83,12 +83,11 @@ ORDER BY bucket;
 <highlight type="important">
 In TimescaleDB 2.7 and above, continuous aggregates support all PostgreSQL
 aggregate functions. They also support aggregates with keywords such as
-`DISTINCT`, `ORDER BY`, and `FILTER`. Older versions of TimescaleDB only support
-aggregate functions that can be
+`DISTINCT` and `FILTER`. Older versions of TimescaleDB only support aggregate
+functions that can be
 [parallelized by PostgreSQL](https://www.postgresql.org/docs/current/parallel-plans.html#PARALLEL-AGGREGATION).
-They don't support `DISTINCT`, `ORDER BY`, and `FILTER`. For more information,
-see the
-[how-to guide on continuous aggregates](/timescaledb/latest/how-to-guides/continuous-aggregates/about-continuous-aggregates/#unsupported-functions).
+For more information, see the
+[how-to guide on continuous aggregates](/timescaledb/latest/how-to-guides/continuous-aggregates/about-continuous-aggregates/#function-support).
 </highlight>
 
 ## Real-time aggregation [](real-time-aggregates)


### PR DESCRIPTION
# Description

There is some confusion around `ORDER BY` in caggs within the docs. It is supported in ordered-set aggregates, but not in general (at least not yet).

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Are procedure and highlight tags used appropriately?
- [x] Has the index been updated appropriately?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] Are all links provided in reference style, and resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
