### PR TITLE
Upgrade instructions for Toolkit in Docker

### DIFF
--- a/timescaledb/how-to-guides/upgrades/upgrade-docker.md
+++ b/timescaledb/how-to-guides/upgrades/upgrade-docker.md
@@ -5,6 +5,7 @@ keywords: [upgrade, Docker]
 ---
 
 # Upgrades within a Docker container
+
 If you originally installed TimescaleDB using Docker, you can upgrade from
 within the Docker container. This allows you to upgrade to the latest
 TimescaleDB version, while retaining your data.
@@ -16,6 +17,7 @@ commands.
 </highlight>
 
 ## Determine the mount point type
+
 When you start your upgraded Docker container, you need to be able to point the
 new Docker image to the location that contains the data from your previous
 version. To do this, you need to work out where the current mount point is. The
@@ -25,6 +27,7 @@ mounts, or bind mounts.
 <procedure>
 
 ### Determining the mount point type
+
 1.  Work out what type of mount your Docker container uses by running this
     command, which returns either `volume` or `bind`:
 
@@ -61,6 +64,7 @@ mounts, or bind mounts.
 </procedure>
 
 ## Upgrade TimescaleDB within Docker
+
 To upgrade TimescaleDB within Docker, you need to download the upgraded image,
 stop the old container, and launch the new container pointing to your existing
 data.
@@ -69,7 +73,10 @@ data.
 
 ### Upgrading TimescaleDB within Docker
 
-1.  Pull the latest TimescaleDB image:
+1.  Pull the latest TimescaleDB image. This command pulls the image for
+    PostgreSQL&nbsp;14. If you're using another PostgreSQL version, look for the
+    relevant tag in the
+    [TimescaleDB HA Docker Hub repository](https://hub.docker.com/r/timescale/timescaledb-ha/tags).
 
     ```bash
     docker pull timescale/timescaledb-ha:pg14-latest
@@ -93,7 +100,8 @@ data.
     <tab label='Volume mount'>
 
     ```bash
-    docker run -v 069ba64815f0c26783b81a5f0ca813227fde8491f429cf77ed9a5ae3536c0b2c:/var/lib/postgresql/data -d --name timescaledb -p 5432:5432 timescale/timescaledb
+    docker run -v 069ba64815f0c26783b81a5f0ca813227fde8491f429cf77ed9a5ae3536c0b2c:/var/lib/postgresql/data \
+      -d --name timescaledb -p 5432:5432 timescale/timescaledb-ha
     ```
 
     </tab>
@@ -101,7 +109,8 @@ data.
     <tab label='Bind mount'>
 
     ```bash
-    docker run -v /path/to/data:/var/lib/postgresql/data -d --name timescaledb -p 5432:5432 timescale/timescaledb
+    docker run -v /path/to/data:/var/lib/postgresql/data -d --name timescaledb \
+      -p 5432:5432 timescale/timescaledb-ha
     ```
 
     </tab>
@@ -120,4 +129,15 @@ data.
     ALTER EXTENSION timescaledb UPDATE;
     ```
 
+1.  Update the [TimescaleDB Toolkit][toolkit] extension. Toolkit is packaged
+    with TimescaleDB's HA Docker image, and includes additional hyperfunctions
+    to help you with queries and data analysis:
+
+    ```sql
+    CREATE EXTENSION IF NOT EXISTS timescaledb-toolkit;
+    ALTER EXTENSION timescaledb-toolkit UPDATE;
+    ```
+
 </procedure>
+
+[toolkit]: https://docs.timescale.com/timescaledb/latest/how-to-guides/hyperfunctions/install-toolkit/


### PR DESCRIPTION

# Description

Change the instructions for Docker update to use the TimescaleDB HA that includes Toolkit. The install instructions already point to the TimescaleDB HA image. https://docs.timescale.com/install/latest/installation-docker/#install-self-hosted-timescaledb-from-a-pre-built-container

# Links

N/A

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
