### PR TITLE
[update]Install self-hosted TimescaleDB on macOS systems

### DIFF
--- a/install/installation-macos.md
+++ b/install/installation-macos.md
@@ -41,7 +41,7 @@ You can use Homebrew to install TimescaleDB on macOS-based systems.
     ```
 1. Run the `timescaledb-tune` script to configure your database:
    ```bash
-   timescaledb-tune -conf-path /opt/homebrew/var/postgres/postgresql.conf --yes 
+   timescaledb-tune --quiet --yes 
    ```    
 1. Change to the directory where the setup script is located. It is typically,
    located at `/opt/homebrew/Cellar/timescaledb/<VERSION>/bin/`, where


### PR DESCRIPTION
# Description

To run the timescales-tune we had to specify the path to the `.conf` file this has now been fixed in the latest release.

# Links
Here's the related issue https://github.com/timescale/timescaledb-tune/issues/98

Fixes #[insert issue link, if any]

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
