### PR TITLE
Clarify that Promscale pg extension is required

### DIFF
--- a/promscale/about-promscale.md
+++ b/promscale/about-promscale.md
@@ -217,7 +217,7 @@ For examples of querying a specific metric view, see
 [slack]: https://slack.timescale.com
 [promscale-extension]: https://github.com/timescale/promscale_extension#promscale-extension
 [Prometheus native format]: https://prometheus.io/docs/instrumenting/exposition_formats/
-[query-data]: promscale/:currentVersion:/query-data
+[query-data]: /promscale/:currentVersion:/query-data
 [promlabs-test]: https://promlabs.com/promql-compliance-test-results/2021-10-14/promscale
-[tsdb-compression]: timescaledb/:currentVersion:/how-to-guides/compression/
-[tsdb-hypertables]: timescaledb/:currentVersion:/how-to-guides/hypertables/
+[tsdb-compression]: /timescaledb/:currentVersion:/how-to-guides/compression/
+[tsdb-hypertables]: /timescaledb/:currentVersion:/how-to-guides/hypertables/

--- a/promscale/about-promscale.md
+++ b/promscale/about-promscale.md
@@ -66,9 +66,8 @@ through the PostgreSQL data source.
 ## Promscale PostgreSQL extension
 Promscale has a dependency on the
 [Promscale PostgreSQL extension][promscale-extension], which contains support
-functions to improve the performance of Promscale. While Promscale is able to
-run without the additional extension installed, adding this extension gets
-better performance from Promscale.
+functions to improve the performance of Promscale. If you are using
+Promscale&nbsp;0.11.0 or later, this extension is required.
 
 ## Promscale schema for metric data
 To achieve high ingestion, query performance, and optimal storage the Promscale


### PR DESCRIPTION
# Description

Updates section about promscale pg extension to note that the extension is required for Promscale v 0.11.0 and later.

# Links

Fixes https://github.com/timescale/docs/issues/1295

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
