### PR TITLE
[update] Install self-hosted TimescaleDB from a pre-built container

### DIFF
--- a/install/installation-docker.md
+++ b/install/installation-docker.md
@@ -40,7 +40,7 @@ offers the most complete TimescaleDB experience. It
 includes the 
 [TimescaleDB Toolkit](https://github.com/timescale/timescaledb-toolkit), 
 and support for PostGIS and Patroni. If you need the smallest possible image, use
-the `timescale/timescaledb:latest-pg14` image instead.
+the `timescale/timescaledb:pg14-latest` image instead.
 </highlight>
 
 </procedure>
@@ -68,7 +68,7 @@ You can use the Docker image in different ways, depending on your use case.
 If you want to run the image directly from the container, you can use this
 command:
 ```bash
-docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb:latest-pg14
+docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb:pg14-latest
 ```
 
 The `-p` flag binds the container port to the host port. This means that
@@ -82,7 +82,7 @@ outside world, you can bind to `127.0.0.1` instead of the public interface,
 using this command:
 ```bash
 docker run -d --name timescaledb -p 127.0.0.1:5432:5432 \
--e POSTGRES_PASSWORD=password timescale/timescaledb:latest-pg14
+-e POSTGRES_PASSWORD=password timescale/timescaledb:pg14-latest
 ```
 
 If you don't want to install `psql` and other PostgreSQL client tools locally,
@@ -104,7 +104,7 @@ data volume using the `-v` flag. For example:
 ```bash
 docker run -d --name timescaledb -p 5432:5432 \
 -v /your/data/dir:/var/lib/postgresql/data \
--e POSTGRES_PASSWORD=password timescale/timescaledb:latest-pg14
+-e POSTGRES_PASSWORD=password timescale/timescaledb:pg14-latest
 ```
 
 When you install TimescaleDB using a Docker container, the PostgreSQL settings


### PR DESCRIPTION
# Description

Updated the docker image name after checking at [docker hub] (https://hub.docker.com/layers/timescaledb-ha/timescale/timescaledb-ha/pg14-latest/images/sha256-4e00062797afbc8fcdf27910a3cd82171681fb08b826bb3f3b36fb1d49cafa60?context=explore)
# Links

Fixes https://github.com/timescale/docs/issues/1314
# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
