### PR TITLE
promscale: update links to point to release 0.13.0

### DIFF
--- a/promscale/installation/kubernetes.md
+++ b/promscale/installation/kubernetes.md
@@ -171,7 +171,7 @@ manifest file. To deploy TimescaleDB on Kubernetes use
 #### Installing the Promscale Connector with a manifest
 1.  Download the [template manifest file][template-manifest]:
     ```bash
-    curl https://raw.githubusercontent.com/timescale/promscale/0.12.1/deploy/static/deploy.yaml --output promscale-connector.yaml
+    curl https://raw.githubusercontent.com/timescale/promscale/0.13.0/deploy/static/deploy.yaml --output promscale-connector.yaml
     ```
 1.  Edit the manifest and configure the TimescaleDB database details using the
     parameters starting with <PROMSCALE_DB>.
@@ -189,7 +189,7 @@ For instructions, see the [send data][send-data] section.
 [install-helm]: /promscale/:currentVersion:/installation/kubernetes/#install-promscale-with-helm
 [promscale-values-yaml]: https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/values.yaml
 [send-data]: /promscale/:currentVersion:/send-data/
-[template-manifest]: https://github.com/timescale/promscale/blob/0.12.1/deploy/static/deploy.yaml
+[template-manifest]: https://github.com/timescale/promscale/blob/0.13.0/deploy/static/deploy.yaml
 [timescale-backups]: https://github.com/timescale/timescaledb-kubernetes/tree/master/charts/timescaledb-single#create-backups-to-s3
 [timescaledb-helm-values-certs]: https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/values.yaml#L45
 [timescaledb-helm-values-creds]: https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/values.yaml#L33


### PR DESCRIPTION
Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

# Description

Update promscale helm references to point to latest [release 0.13.0](https://github.com/timescale/promscale/releases/tag/0.13.0
).

# Links

Fixes #[insert issue link, if any]

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
