### PR TITLE
Can only exec ps_trace.delete_all_traces() when Promscale not running

### DIFF
--- a/promscale/manage-data/delete-data.md
+++ b/promscale/manage-data/delete-data.md
@@ -121,7 +121,13 @@ SELECT compress_chunk(show_chunks('prom_data.container_cpu_load_average_10s', ol
 You can delete all trace data from the database using the
 `ps_trace.delete_all_traces()` function. This function restores the schema to a
 default state, truncates the tables in the `_ps_trace` schema, and deletes all
-the data.
+the data. You can only run the function when the Promscale Connector is not
+running.
+<highlight type="note">
+To run this function: first stop the Promscale Connector, then connect to the
+database and run `SELECT ps_trace.delete_all_traces();`, finally start the
+Promscale Connector.
+</highlight>
 
 [retention]: /promscale/:currentVersion:/manage-data/retention/
 [web-enable-admin-api]: /promscale/:currentVersion:/cli/#web-server-flags


### PR DESCRIPTION
# Description

In https://github.com/timescale/promscale_extension/pull/437 we adjusted how this function behaves.

# Links

Related to https://github.com/timescale/promscale_extension/pull/437
Fixes https://github.com/timescale/docs/issues/1332

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [x] Is the content technically accurate?
- [x] Is the content complete?
- [x] Is the content presented in a logical order?
- [x] Does the content use appropriate names for features and products?
- [x] Does the content provide relevant links to further information?

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Are procedure and highlight tags used appropriately?
- [x] Has the index been updated appropriately?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] Are all links provided in reference style, and resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
