### PR TITLE
[How-tos] Fix typo "for a for a" -> "for a"

### DIFF
--- a/timescaledb/how-to-guides/compression/about-compression.md
+++ b/timescaledb/how-to-guides/compression/about-compression.md
@@ -79,7 +79,7 @@ For more information, see the API reference for [`timescaledb_information.jobs`]
 
 ## Remove compression policy
 To remove a compression policy, use `remove_compression_policy`. For example, to remove a compression policy for a
-for a hypertable named `cpu`:
+hypertable named `cpu`:
 ```sql
 SELECT remove_compression_policy('cpu');
 ```


### PR DESCRIPTION
# Description

Fix typo "for a for a" -> "for a" in compression how-to.

# Links

Re: https://docs.timescale.com/timescaledb/latest/how-to-guides/compression/about-compression/#disable-compression

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Are procedure and highlight tags used appropriately?
- [ ] Has the index been updated appropriately?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] Are all links provided in reference style, and resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
