### PR TITLE
[Continuous aggregates] Refreshes of historical data

### DIFF
--- a/_partials/_caggs-real-time-historical-data-refreshes.mdx
+++ b/_partials/_caggs-real-time-historical-data-refreshes.mdx
@@ -1,0 +1,9 @@
+Real-time aggregates automatically add the most recent data when you query your
+continuous aggregate. In other words, they include data _more recent than_ your
+last materialized bucket.
+
+If you add new _historical_ data to an already-materialized bucket, it won't be
+reflected in a real-time aggregate. You should wait for the next scheduled
+refresh, or manually refresh by calling `refresh_continuous_aggregate`. You can
+think of real-time aggregates as being eventually consistent for historical
+data.

--- a/timescaledb/how-to-guides/continuous-aggregates/real-time-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/real-time-aggregates.md
@@ -4,6 +4,8 @@ excerpt: Real-time aggregates combine pre-aggregated data with the most recent r
 keywords: [continuous aggregates, real-time aggregates]
 ---
 
+import CaggsRealTimeHistoricalDataRefreshes from 'versionContent/_partials/_caggs-real-time-historical-data-refreshes.mdx';
+
 # Real time aggregates
 Continuous aggregates do not include the most recent data chunk from the
 underlying hypertable. Real time aggregates use the aggregated data and add the
@@ -34,12 +36,11 @@ You can enable and disable real time aggregation by setting the
 
 </procedure>
 
-<highlight type="important">
-If you have a time bucket that has already been materialized, the real-time
-aggregate won't show the data that has been inserted, updated, or deleted. When
-you need to change data that has already been materialized, use
-`refresh_continuous_aggregate()` for the corresponding buckets. For more
-information, see the [Troubleshooting section](/timescaledb/latest/how-to-guides/continuous-aggregates/troubleshooting/).
-</highlight>
+## Real-time aggregates and refreshing historical data
+
+<CaggsRealTimeHistoricalDataRefreshes />
+
+For more information, see the [troubleshooting section][troubleshooting].
 
 [blog-rtaggs]: https://blog.timescale.com/blog/achieving-the-best-of-both-worlds-ensuring-up-to-date-results-with-real-time-aggregation/
+[troubleshooting]: /timescaledb/:currentVersion:/how-to-guides/continuous-aggregates/troubleshooting/#updates-to-previously-materialized-regions-are-not-shown-in-continuous-aggregates

--- a/timescaledb/how-to-guides/continuous-aggregates/troubleshooting.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/troubleshooting.md
@@ -5,6 +5,7 @@ keywords: [continuous aggregates, troubleshooting]
 ---
 
 import CaggsFunctionSupport from 'versionContent/_partials/_caggs-function-support.mdx';
+import CaggsRealTimeHistoricalDataRefreshes from 'versionContent/_partials/_caggs-real-time-historical-data-refreshes.mdx';
 
 # Troubleshooting continuous aggregates
 This section contains some ideas for troubleshooting common problems experienced
@@ -58,14 +59,11 @@ be hard to refresh and would make more sense to isolate these columns in another
 hypertable. Alternatively, you might create one hypertable per metric and
 refresh them independently.
 
-### Updates to previously materialized regions are not shown in real-time aggregates
-If you have a time bucket that has already been materialized, the real-time
-aggregate does not show the data that has been inserted, updated, or deleted 
-into that bucket until the next `refresh_continuous_aggregate` call is executed.
-The continuous aggregate is refreshed either when you manually call 
-`refresh_continuous_aggregate` or when a continuous aggregate policy is executed. 
-This worked example shows the expected behavior of continuous aggregates, when
-real time aggregation is enabled.
+## Updates to previously materialized regions are not shown in real-time aggregates
+
+<CaggsRealTimeHistoricalDataRefreshes />
+
+The following example shows how this works.
 
 Create and fill the hypertable:
 ```sql


### PR DESCRIPTION
# Description

Newly added historical data is not included in real-time aggregates. Real-time aggregates only add the most recent data to the materialized data. To update an already materialized bucket, a refresh is required.

# Links

Fixes #1217

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Are procedure and highlight tags used appropriately?
- [x] Has the index been updated appropriately?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] Are all links provided in reference style, and resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
