### PR TITLE
Change link check to cron job

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken_link_report.md
+++ b/.github/ISSUE_TEMPLATE/broken_link_report.md
@@ -1,0 +1,9 @@
+---
+title: Failing link check ({{ date | date('dddd, MMMM Do') }})
+assignees: timescale/documentation
+labels: bug, automated issue, link check
+---
+
+The broken link check failed. Check
+[the workflow logs](https://github.com/timescale/docs/actions/workflows/daily-link-checker.yml)
+to identify the failing links.

--- a/.github/workflows/daily-link-checker.yml
+++ b/.github/workflows/daily-link-checker.yml
@@ -1,0 +1,31 @@
+name: Check all Markdown links daily
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Check links
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368
+        id: linkcheck
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          config-file: "mlc_config.json"
+
+      - name: Create issue
+        if: steps.linkcheck.outputs.exit_code != 0
+        uses: JasonEtco/create-an-issue@e6b4b190af80961b6462c725454e7828d0247a68
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            filename: .github/ISSUE_TEMPLATE/broken_link_report.md


### PR DESCRIPTION
# Description

Running link check on each PR is a great idea in theory, but occasionally creates a bad dev experience because the link check fails for newly created pages.

Proposing that instead, we can run link checks on the `latest` branch. All links on the `latest` branch should always resolve, as that is the production branch.

This commit creates a daily workflow to run link check on every link in `latest`. If a broken link is detected, an issue is created.

This has the added benefit of detecting links that break passively, when the target page is moved.
