### PR TITLE
Add feedback template as a form

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,35 @@
+name: Feedback
+description: Help us improve the Timescale documentation site by leaving your feedback
+title: "[Feedback]"
+labels: ["documentation", "feedback", "community"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to leave your feedback!
+  - type: dropdown
+    id: navigation
+    attributes:
+      label: Is it easy to find the information you need?
+      options:
+        - Yes
+        - No
+  - type: dropdown
+    id: instructions
+    attributes:
+      label: Are the instructions clear?
+      options:
+        - Yes
+        - No
+  - type: textarea
+    id: improvements
+    attributes:
+      label: How could we improve the Timescale documentation site?
+      placeholder: Send us your ideas!
+  - type: markdown
+    attributes:
+      value: |
+        We welcome documentation contributions!
+
+        * For information about how to suggest a change, see the [contributing guide](https://github.com/timescale/docs/blob/latest/CONTRIBUTING.md) in our GitHub repository.
+        * For information on style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs).


### PR DESCRIPTION
# Description

GitHub has a new issues form feature that seems pretty cool: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms.

Might be a good choice for the feedback form as it's a bit smoother than filling out the Markdown template. Let's add this and see what it looks like.

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
