### PR TITLE
Change database names to tsdb

### DIFF
--- a/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
+++ b/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
@@ -24,10 +24,10 @@ information, see "Troubleshooting version mismatches" in this section.
 ## Back up your entire database
 
 You can perform a backup using the `pg_dump` command at the command prompt. For
-example, to backup a database named `exampledb`:
+example, to backup a database named `tsdb`:
 
 ```bash
-pg_dump -Fc -f exampledb.bak exampledb
+pg_dump -Fc -f tsdb.bak tsdb
 ```
 
 You might see some errors when running `pg_dump`. To learn if they can be safely
@@ -51,8 +51,8 @@ database and restore the data.
 1.  In `psql`, create a new database to restore to, and connect to it:
 
     ```sql
-    CREATE DATABASE exampledb;
-    \c exampledb
+    CREATE DATABASE tsdb;
+    \c tsdb
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     SELECT timescaledb_pre_restore();
     ```
@@ -60,7 +60,7 @@ database and restore the data.
 1.  Restore the database:
 
     ```sql
-    \! pg_restore -Fc -d exampledb exampledb.bak
+    \! pg_restore -Fc -d tsdb tsdb.bak
     SELECT timescaledb_post_restore();
     ```
 

--- a/timescaledb/how-to-guides/migrate-data/migrate-influxdb.md
+++ b/timescaledb/how-to-guides/migrate-data/migrate-influxdb.md
@@ -6,6 +6,7 @@ tags: [import, Outflux]
 ---
 
 # Migrate data to TimescaleDB from InfluxDB
+
 You can migrate data to TimescaleDB from InfluxDB using the Outflux tool.
 [Outflux][outflux] is an open source tool built by Timescale for fast, seamless
 migrations. It pipes exported data directly to TimescaleDB, and manages schema
@@ -17,27 +18,34 @@ Outflux works with earlier versions of InfluxDB. It does not work with InfluxDB
 </highlight>
 
 ## Prerequisites
+
 Before you start, make sure you have:
+
 *   A running instance of InfluxDB and a means to connect to it.
 *   An [installation of TimescaleDB][install] and a means to connect to it.
 *   Data in your InfluxDB instance. If you need to import some sample data for a
     test, see the instructions for [importing sample data](#import-sample-data).
 
 ## Procedures
+
 To import data from Outflux, follow these procedures:
+
 1.  [Install Outflux](#install-outflux)
-1.  [Import sample data](#import-sample-data-into-influxdb) to InfluxDB if you don't have existing data
+1.  [Import sample data](#import-sample-data-into-influxdb) to InfluxDB if you
+    don't have existing data.
 1.  [Discover, validate, and transfer
     schema](#discover-validate-and-transfer-schema) to TimescaleDB (optional)
 1.  [Migrate data to TimescaleDB](#migrate-data-to-timescaledb)
 
 ## Install Outflux
+
 Install Outflux from the GitHub repository. There are builds for Linux, Windows,
 and MacOS.
 
 <procedure>
 
 ### Installing Outflux
+
 1.  Go to the [releases section][outflux-releases] of the Outflux repository.
 1.  Download the latest compressed tarball for your platform.
 1.  Extract it to a preferred location.
@@ -54,6 +62,7 @@ To get help with Outflux, you can run `./outflux --help` from the directory
 where you installed it.
 
 ## Import sample data into InfluxDB
+
 If you don't have an existing InfluxDB database, or if you want to test on a
 sample instance, you can try Outflux by importing sample data. We provide an
 example file with data written in the Influx Line Protocol.
@@ -61,14 +70,17 @@ example file with data written in the Influx Line Protocol.
 <procedure>
 
 ### Importing sample data into InfluxDB
+
 1.  Download the sample data:
     <tag type="download">
       [Outflux taxi data](https://timescaledata.blob.core.windows.net/datasets/outflux_taxi.txt)
     </tag>
-2.  Use the [Influx CLI client][influx-cmd] to load the data into InfluxDB.
+1.  Use the [Influx CLI client][influx-cmd] to load the data into InfluxDB.
+
     ```bash
     influx -import -path=outflux_taxi.txt -database=outflux_tutorial
     ```
+
     This command imports the data into a new database named `outflux_tutorial`.
 
 <highlight type="note">
@@ -84,6 +96,7 @@ available at `http://localhost:8086`.
 ## Discover, validate, and transfer schema
 
 Outflux can:
+
 *   Discover the schema of an InfluxDB measurement
 *   Validate whether a TimescaleDB table exists that can hold the transferred
     data
@@ -99,10 +112,11 @@ of data migration.
 
 To transfer your schema from InfluxDB to TimescaleDB, run `outflux
 schema-transfer`:
+
 ```bash
 outflux schema-transfer <DATABASE_NAME> <INFLUX_MEASUREMENT_NAME> \
 --input-server=http://localhost:8086 \
---output-conn="dbname=postgres user=postgres"
+--output-conn="dbname=tsdb user=tsdbadmin"
 ```  
 
 To transfer all measurements from the database, leave out the measurement name
@@ -115,7 +129,9 @@ Github repo](https://github.com/timescale/outflux#connection).
 </highlight>
 
 ### Schema transfer options
+
 Outflux's `schema-transfer` can use 1 of 4 schema strategies:
+
 *   `ValidateOnly`: checks that TimescaleDB is installed and that the specified
     database has a properly partitioned hypertable with the correct columns, but
     doesn't perform modifications
@@ -136,21 +152,24 @@ your TimescaleDB tables. To transfer tags and fields as a single JSONB column,
 use the flag `--tags-as-json`.
 
 ## Migrate data to TimescaleDB
+
 Transfer your schema and migrate your data all at once with the `migrate`
 command.
 
 For example, run:
-```
+
+```bash
 outflux migrate <DATABASE_NAME> <INFLUX_MEASUREMENT_NAME> \
 --input-server=http://localhost:8086 \
---output-conn="dbname=postgres user=postgres"
+--output-conn="dbname=tsdb user=tsdbadmin"
 ```
 
 The schema strategy and connection options are the same as for
 `schema-transfer`. For more information, see the
 [`schema-transfer`](#discover-validate-and-transfer-schema) section.
 
-In addition, `outflux migrate` also takes the following flags: 
+In addition, `outflux migrate` also takes the following flags:
+
 *   `--limit`: Pass a number, `N`, to `--limit` to export only the first `N`
     rows, ordered by time.
 *   `--from` and `to`: Pass a timestamp to `--from` or `--to` to specify a time
@@ -162,12 +181,13 @@ In addition, `outflux migrate` also takes the following flags:
 
 For more flags, see the [Github documentation for `outflux
 migrate`][outflux-migrate]. Alternatively, see the command line help:
-```
-$ outflux migrate --help
+
+```bash
+outflux migrate --help
 ```
 
 [influx-cmd]: https://docs.influxdata.com/influxdb/v1.7/tools/shell/
 [install]: /install/latest/
 [outflux-migrate]: https://github.com/timescale/outflux#migrate
 [outflux-releases]: https://github.com/timescale/outflux/releases
-[outflux]: https://github.com/timescale/outflux 
+[outflux]: https://github.com/timescale/outflux

--- a/timescaledb/quick-start/dotnet.md
+++ b/timescaledb/quick-start/dotnet.md
@@ -128,8 +128,8 @@ as SSL.
             //
             // This is the constructor for our TimescaleHelper class
             //
-            public TimescaleHelper(string host="localhost", string user="postgres",
-                string dbname="postgres", string password="password",string port="5432")
+            public TimescaleHelper(string host="<HOSTNAME>", string user="<USERNAME>",
+                string dbname="<DATABASE_NAME>", string password="<PASSWORD>",string port="<PORT>")
             {
                 Host=host;
                 User=user;

--- a/timescaledb/quick-start/java.md
+++ b/timescaledb/quick-start/java.md
@@ -11,11 +11,11 @@ keywords: [Java]
 This quick start guide is designed to get Java developers up and running with TimescaleDB as their database.
 In this tutorial, you'll learn how to:
 
-* [Connect Java to TimescaleDB](#connect-java-to-timescaledb)
-* [Create a relational table](#create-a-relational-table)
-* [Generate a hypertable](#generate-a-hypertable)
-* [Insert a batch of rows into TimescaleDB](#insert-a-batch-of-rows-into-timescaledb)
-* [Execute queries on TimescaleDB](#execute-queries-on-timescaledb)
+*   [Connect Java to TimescaleDB](#connect-java-to-timescaledb)
+*   [Create a relational table](#create-a-relational-table)
+*   [Generate a hypertable](#generate-a-hypertable)
+*   [Insert a batch of rows into TimescaleDB](#insert-a-batch-of-rows-into-timescaledb)
+*   [Execute queries on TimescaleDB](#execute-queries-on-timescaledb)
 
 ## Pre-requisites
 
@@ -25,7 +25,7 @@ The tutorial walks you through each SQL command, but it is helpful if you've see
 To start, [install TimescaleDB][timescaledb-install]. Once your installation is complete,
 you can proceed to ingesting or creating sample data and finishing the tutorial.
 
-You also need to install [Java Development Kit (JDK)][jdk] 
+You also need to install [Java Development Kit (JDK)][jdk]
 and [PostgreSQL Java Database Connectivity (JDBC) Driver][pg-jdbc-driver] as well.
 All code is presented for Java 16 and above.
 If you are working with older JDK versions, use legacy coding techniques.
@@ -99,16 +99,16 @@ to use to connect to your TimescaleDB instance.
 
 You'll need these credentials:
 
-* host
-* port
-* database name
-* username
-* password
+*   host
+*   port
+*   database name
+*   username
+*   password
 
 Next, compose your connection string variable using this format:
 
 ```java
-var connUrl = "jdbc:postgresql://host:port/dbname?user=username&password=password";
+var connUrl = "jdbc:postgresql://<HOSTNAME>:<PORT>/<DATABASE_NAME>?user=<USERNAME>&password=<PASSWORD>";
 ```
 
 Full documentation on [the formation of the connection string][pg-jdbc-driver-conn-docs]
@@ -132,7 +132,7 @@ import java.sql.SQLException;
 public class Main {
 
     public static void main(String... args) throws SQLException {
-        var connUrl = "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres";
+        var connUrl = "jdbc:postgresql://<HOSTNAME>:<PORT>/<DATABASE_NAME>?user=<USERNAME>&password=<PASSWORD>";
         var conn = DriverManager.getConnection(connUrl);
         System.out.println(conn.getClientInfo());
     }
@@ -173,7 +173,7 @@ import java.sql.SQLException;
 public class Main {
 
     public static void main(String... args) throws SQLException {
-        var connUrl = "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres";
+        var connUrl = "jdbc:postgresql://<HOSTNAME>:<PORT>/<DATABASE_NAME>?user=<USERNAME>&password=<PASSWORD>";
         var conn = DriverManager.getConnection(connUrl);
 
         var createSensorTableQuery = """
@@ -255,7 +255,7 @@ import java.util.List;
 public class Main {
 
     public static void main(String... args) {
-        final var connUrl = "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres";
+        final var connUrl = "jdbc:postgresql://<HOSTNAME>:<PORT>/<DATABASE_NAME>?user=<USERNAME>&password=<PASSWORD>";
         try (var conn = DriverManager.getConnection(connUrl)) {
             createSchema(conn);
             insertData(conn);
@@ -359,7 +359,7 @@ import java.util.List;
 public class Main {
 
     public static void main(String... args) {
-        final var connUrl = "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres";
+        final var connUrl = "jdbc:postgresql://<HOSTNAME>:<PORT>/<DATABASE_NAME>?user=<USERNAME>&password=<PASSWORD>";
         try (var conn = DriverManager.getConnection(connUrl)) {
             createSchema(conn);
             insertData(conn);
@@ -509,7 +509,7 @@ import java.util.List;
 public class Main {
 
     public static void main(String... args) {
-        final var connUrl = "jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres";
+        final var connUrl = "jdbc:postgresql://<HOSTNAME>:<PORT>/<DATABASE_NAME>?user=<USERNAME>&password=<PASSWORD>";
         try (var conn = DriverManager.getConnection(connUrl)) {
             createSchema(conn);
             insertData(conn);
@@ -612,8 +612,8 @@ Congratulations 🎉, you've successfully executed a query on TimescaleDB using 
 Now that you're able to connect, read, and write to a TimescaleDB instance from your Java application,
 be sure to check out these advanced tutorials:
 
-* Get up and running with TimescaleDB with our [Getting Started][timescaledb-getting-started] tutorial.
-* Refer to the [PostgreSQL JDBC Driver documentation][pg-jdbc-driver-docs] for more information.
+*   Get up and running with TimescaleDB with our [Getting Started][timescaledb-getting-started] tutorial.
+*   Refer to the [PostgreSQL JDBC Driver documentation][pg-jdbc-driver-docs] for more information.
 
 [jdk]: https://openjdk.java.net
 [pg-jdbc-driver-artifact]: https://jdbc.postgresql.org/download.html

--- a/timescaledb/quick-start/ruby.md
+++ b/timescaledb/quick-start/ruby.md
@@ -7,15 +7,16 @@ keywords: [Ruby]
 # Quick Start: Ruby and TimescaleDB
 
 ## Goal
+
 This quick start guide is designed to get the Rails developer up
 and running with TimescaleDB as their database. In this tutorial,
 you'll learn how to:
 
-* [Connect to TimescaleDB](#connect-ruby-to-timescaledb)
-* [Create a relational table](#create-a-relational-table)
-* [Generate a Hypertable](#generate-hypertable)
-* [Insert a batch of rows into your Timescale database](#insert-rows-into-timescaledb)
-* [Execute a query on your Timescale database](#execute-a-query)
+*   [Connect to TimescaleDB](#connect-ruby-to-timescaledb)
+*   [Create a relational table](#create-a-relational-table)
+*   [Generate a Hypertable](#generate-hypertable)
+*   [Insert a batch of rows into your Timescale database](#insert-rows-into-timescaledb)
+*   [Execute a query on your Timescale database](#execute-a-query)
 
 ## Prerequisites
 
@@ -31,6 +32,7 @@ You also need to [install Rails][rails-install].
 ## Connect Ruby to TimescaleDB
 
 ### Step 1: Create a new Rails application
+
 Let's start by creating a new Rails application configured to use PostgreSQL as the
 database. TimescaleDB is a PostgreSQL extension.
 
@@ -46,11 +48,11 @@ Locate your TimescaleDB credentials in order to connect to your TimescaleDB inst
 
 You'll need the following credentials:
 
-* password
-* username
-* host URL
-* port
-* database name
+*   password
+*   username
+*   host URL
+*   port
+*   database name
 
 In the `default` section of the `config/database.yml` section, configure your database:
 
@@ -72,12 +74,12 @@ Experienced Rails developers might want to set and retrieve environment variable
 </highlight>
 
 Then configure the database name in the `development`, `test`, and `production` sections. Let's call our
-database `my_app_db` like so:
+database `tsdb` like so:
 
 ```ruby
 development:
   <<: *default
-  database: my_app_db
+  database: tsdb
 ```
 
 Repeat the step for the `test` and `production` sections further down this file.
@@ -98,25 +100,26 @@ default: &default
 
 development:
   <<: *default
-  database: my_app_db
+  database: tsdb
 
 test:
   <<: *default
-  database: my_app_db
+  database: tsdb
 
 production:
   <<: *default
-  database: my_app_db
+  database: tsdb
 ```
 
 #### Create the database
+
 Now we can run the following `rake` command to create the database in TimescaleDB:
 
 ```bash
 rails db:create
 ```
 
-This creates the `my_app_db` database in your TimescaleDB instance and a `schema.rb`
+This creates the `tsdb` database in your TimescaleDB instance and a `schema.rb`
 file that represents the state of your TimescaleDB database.
 
 ## Create a relational table
@@ -173,8 +176,9 @@ The output should be something like the following:
  timescaledb | 2.1.1   | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 ```
+
 <highlight type="note">
-To ensure that your tests run successfully, add `config.active_record.verify_foreign_keys_for_fixtures = false` 
+To ensure that your tests run successfully, add `config.active_record.verify_foreign_keys_for_fixtures = false`
 to your `config/environments/test.rb` file. Otherwise you get an error because TimescaleDB
 uses internal foreign keys.
 </highlight>
@@ -203,7 +207,6 @@ the [`composite_primary_keys` gem](https://github.com/composite-primary-keys/com
 
 To satisfy this TimescaleDB requirement, we need to change the migration code to _not_ create a `PRIMARY KEY` using the `id` column when `create_table` is used.
 To do this we can change the migration implementation:
-
 
 ```rb
 class CreatePageLoads < ActiveRecord::Migration[6.0]
@@ -262,7 +265,6 @@ least one column specifying a time value.
 The TimescaleDB documentation on [schema management and indexing](/timescaledb/latest/how-to-guides/schema-management/)
 explains this in further detail.
 </highlight>
-
 
 Let's create this migration to modify the `page_loads` database and create a
 hypertable by first running the following command:
@@ -420,7 +422,7 @@ each item:
 ```
 
 Now, each time we refresh our page, we can see that a record is being inserted
-into the `my_app_db` TimescaleDB database, and the counter is incremented on the page.
+into the `tsdb` TimescaleDB database, and the counter is incremented on the page.
 
 ## Generating requests
 
@@ -437,7 +439,6 @@ ab -n 50000 -c 10 http://localhost:3000/static_pages/home
 Now, you can grab a tea and relax while it creates thousands of records in
 your first hypertable. You'll be able to count how many 'empty requests' your
 Rails supports.
-
 
 ## Counting requests per minute
 
@@ -481,7 +482,6 @@ end
 ```
 
 And you can also combine the scopes with other ActiveRecord methods:
-
 
 ```ruby
 PageLoad.last_week.count     # Total of requests from last week
@@ -571,6 +571,7 @@ PageLoad.order(:created_at).last
 # PageLoad Load (1.7ms)  SELECT "page_loads".* FROM "page_loads" ORDER BY "page_loads"."created_at" DESC LIMIT $1  [["LIMIT", 1]]
 # => #<PageLoad:0x00007fdafc5c69d8 path: "/static_pages/home", performance: 0.049275, ...>
 ```
+
 ## Exploring aggregation functions
 
 Now that we know what pages exist, we can explore page by page (or all the
@@ -599,8 +600,8 @@ scope :per_week, -> { time_bucket('1 week') }
 scope :per_month, -> { time_bucket('1 month') }
 ```
 
-
 Create some average response depending on the timeframe:
+
 ```ruby
 scope :average_response_time_per_minute, -> { time_bucket('1 minute', value: 'avg(performance)') }
 scope :average_response_time_per_hour, -> { time_bucket('1 hour', value: 'avg(performance)') }
@@ -666,6 +667,7 @@ PageLoad.resume_for("/page_loads/new")
 # :worst_response_time_last_hour=>2.892941999947652,
 # :best_response_time_last_hour=>0.0030219999607652426}
 ```
+
 And you can keep combining other filters like:
 
 ```ruby
@@ -712,10 +714,10 @@ independent, which is suboptimal but covers different options.
 Now that you get some basics of the TimescaleDB instance from your Rails application,
 be sure to check out these advanced TimescaleDB tutorials:
 
-- [Time Series Forecasting using TimescaleDB, R, Apache MADlib and Python][time-series-forecasting]
-- [Continuous Aggregates][continuous-aggregates]
-- [Try Other Sample Datasets][other-samples]
-- [Migrate your own Data][migrate]
+*   [Time Series Forecasting using TimescaleDB, R, Apache MADlib and Python][time-series-forecasting]
+*   [Continuous Aggregates][continuous-aggregates]
+*   [Try Other Sample Datasets][other-samples]
+*   [Migrate your own Data][migrate]
 
 [ab]: https://httpd.apache.org/docs/2.4/programs/ab.html
 [active-record-query]: https://guides.rubyonrails.org/active_record_querying.html

--- a/timescaledb/tutorials/nyc-taxi-cab.md
+++ b/timescaledb/tutorials/nyc-taxi-cab.md
@@ -9,18 +9,21 @@ keywords: [IoT, analytics, monitor]
 Use case: IoT Analysis and Monitoring
 
 In this tutorial, you learn:
-1.	How to get started with TimescaleDB
-2.	How to use TimescaleDB to analyze and monitor data from IoT sensors
+
+1.  How to get started with TimescaleDB
+2.  How to use TimescaleDB to analyze and monitor data from IoT sensors
 
 Dataset: <tag type="download">[nyc_data.tar.gz](https://timescaledata.blob.core.windows.net/datasets/nyc_data.tar.gz)</tag>
 Estimated time for completion: 25 minutes.
 
 ### Prerequisites
+
 To complete this tutorial, you need a cursory knowledge of the
 Structured Query Language (SQL). The tutorial walks you through each
 SQL command, but it is helpful if you've seen SQL before.
 
 ### Accessing Timescale
+
 There are multiple options for using Timescale to follow along with this tutorial. **All connection information
 and database naming** throughout this tutorial assumes you are connected to **Timescale Cloud**, our hosted,
 fully managed database-as-a-service. [Sign up for a free, 30-day demo account][cloud-signup], no credit-card
@@ -33,8 +36,8 @@ install the **Timescale** extension.
 Using `psql` from the command line, create a database called `nyc_data` and install the extension:
 
 ```sql
-CREATE DATABASE nyc_data;
-\c nyc_data
+CREATE DATABASE tsdb;
+\c tsdb
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 ```
 
@@ -53,9 +56,9 @@ domains use to plan upgrades, set budgets, allocate resources, and more.
 
 In this tutorial, you complete three missions:
 
-- **Mission 1: Gear up [5-15 minutes]** You learn how to setup and connect to a *TimescaleDB* instance and load data from a CSV file in your local terminal using *psql*.
-- **Mission 2: Analysis [10 minutes]** You learn how to analyze a time-series dataset using TimescaleDB and *PostgreSQL*.
-- **Mission 3: Monitoring [10 minutes]** You learn how to use TimescaleDB to monitor IoT devices. You'll also learn about using TimescaleDB in conjunction with other PostgreSQL extensions like *PostGIS*, for querying geospatial data.
+*   **Mission 1: Gear up [5-15 minutes]** You learn how to setup and connect to a *TimescaleDB* instance and load data from a CSV file in your local terminal using *psql*.
+*   **Mission 2: Analysis [10 minutes]** You learn how to analyze a time-series dataset using TimescaleDB and *PostgreSQL*.
+*   **Mission 3: Monitoring [10 minutes]** You learn how to use TimescaleDB to monitor IoT devices. You'll also learn about using TimescaleDB in conjunction with other PostgreSQL extensions like *PostGIS*, for querying geospatial data.
 
 ### Mission 1: Gear up
 
@@ -80,8 +83,9 @@ and space (on your machine), we'll only grab data for the month of January 2016,
 containing ~11 million records!
 
 This download contains two files:
-1. `nyc_data.sql` - A SQL file that sets up the necessary tables
-1. `nyc_data_rides.csv` - A CSV file with the ride data
+
+1.  `nyc_data.sql` - A SQL file that sets up the necessary tables
+1.  `nyc_data_rides.csv` - A CSV file with the ride data
 
 You can download the files from the below link:
 
@@ -139,20 +143,21 @@ vehicle in its fleet, generating data from millions of rides every day.
 
 They collect the following data about each ride:
 
-* Pickup date and time (as a timestamp)
-* Pickup location (latitude and longitude)
-* Drop off date and time (as a timestamp)
-* Drop off location (latitude and longitude)
-* Trip distance (in miles)
-* Fares (in USD)
-* Passenger count
-* Rate type (e.g, standard, airport, etc.)
-* Payment type (Cash, credit card, etc.)
+*   Pickup date and time (as a timestamp)
+*   Pickup location (latitude and longitude)
+*   Drop off date and time (as a timestamp)
+*   Drop off location (latitude and longitude)
+*   Trip distance (in miles)
+*   Fares (in USD)
+*   Passenger count
+*   Rate type (e.g, standard, airport, etc.)
+*   Payment type (Cash, credit card, etc.)
 
 To efficiently store that data, we're going to need three tables:
-1. A [hypertable][hypertables] called `rides`, which stores all of the above data for each ride taken.
-2. A regular Postgres table called `payment_types`, which maps the payment types to their English description.
-3. A regular Postgres table called `rates`, which maps the numeric rate codes to their English description.
+
+1.  A [hypertable][hypertables] called `rides`, which stores all of the above data for each ride taken.
+2.  A regular Postgres table called `payment_types`, which maps the payment types to their English description.
+3.  A regular Postgres table called `rates`, which maps the numeric rate codes to their English description.
 
 The `nyc_data.sql` script defines the schema for our three tables. The script
 automatically configures your TimescaleDB instance with the appropriate
@@ -507,12 +512,12 @@ footprint associated with airport trips.
 Prior to instituting any programs, they would like you to more closely
 examine trips to JFK (code 2) and Newark (code 3). For each airport, they
 would like to know the following for the month of January:
-- Number of trips to that airport
-- Average trip duration (i.e drop off time - pickup time)
-- Average trip cost
-- Average tip
-- Minimum, Maximum and Average trip distance
-- Average number of passengers
+*   Number of trips to that airport
+*   Average trip duration (i.e drop off time - pickup time)
+*   Average trip cost
+*   Average tip
+*   Minimum, Maximum and Average trip distance
+*   Average number of passengers
 
 To do this, we can run the following query:
 
@@ -555,11 +560,11 @@ avg_passengers    | 1.7435501129473309
 ```
 
 Based on your analysis, you are able to identify:
-- There are 13x more rides to JFK than Newark. This often leads to heavy traffic on the roads to and from JFK, especially during peak times. They've decided to explore road improvements to those areas, as well as increasing public transport to and from the airport (e.g, buses, subway, trains, etc.)
-- Each airport ride has on average the same number of passengers per trip (~1.7 passengers per trip).
-- The trip distances are roughly the same 16-17 miles.
-- JFK is about 30% cheaper, most likely because of NJ tunnel and highway tolls.
-- Newark trips are 22% (10 min) shorter.
+*   There are 13x more rides to JFK than Newark. This often leads to heavy traffic on the roads to and from JFK, especially during peak times. They've decided to explore road improvements to those areas, as well as increasing public transport to and from the airport (e.g, buses, subway, trains, etc.)
+*   Each airport ride has on average the same number of passengers per trip (~1.7 passengers per trip).
+*   The trip distances are roughly the same 16-17 miles.
+*   JFK is about 30% cheaper, most likely because of NJ tunnel and highway tolls.
+*   Newark trips are 22% (10 min) shorter.
 
 This data is useful not just for city planners, but also for airport travellers
 and tourism organizations like the NYC Tourism Bureau. For example, a tourism
@@ -585,6 +590,7 @@ a ride's current status.
 >:WARNING: A more realistic setup would involve creating a data pipeline that streams sensor data directly from the cars into TimescaleDB. However, we use the January 2016 data to illustrate the underlying principles that are applicable regardless of setup.
 
 #### How many rides took place every 5 minutes for the first day of 2016?
+
 It's January 1, 2016. NYC riders have celebrated New Year's Eve, and are using taxi
 cabs to travel to and from their first gathering of the new year.
 
@@ -794,6 +800,7 @@ hours, as people headed to breakfast and other New Years activities. New York is
 truly the city that never sleeps and Times Square is a good reflection of that!
 
 ### Conclusions and next steps
+
 In this tutorial you learned how to get started with TimescaleDB.
 
 In **Mission 1**, you learned how to setup and connect to a TimescaleDB instance
@@ -810,10 +817,10 @@ as how TimescaleDB is compatible with other extensions like *PostGIS*, for fast
 querying by time and location.
 
 Ready for more learning? Here's a few suggestions:
-- [Time Series Forecasting using TimescaleDB, R, Apache MADlib and Python][time-series-forecasting]
-- [Continuous Aggregates][continuous-aggregates]
-- [Try Other Sample Datasets][other-samples]
-- [Migrate your own Data][migrate]
+*   [Time Series Forecasting using TimescaleDB, R, Apache MADlib and Python][time-series-forecasting]
+*   [Continuous Aggregates][continuous-aggregates]
+*   [Try Other Sample Datasets][other-samples]
+*   [Migrate your own Data][migrate]
 
 [NYCTLC]: https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page
 [cloud-signup]: https://console.cloud.timescale.com/signup

--- a/timescaledb/tutorials/sample-datasets.md
+++ b/timescaledb/tutorials/sample-datasets.md
@@ -4,6 +4,7 @@ excerpt: Download these sample datasets to start exploring TimescaleDB
 ---
 
 # Sample datasets
+
 Timescale have created several sample datasets to help you get started using
 TimescaleDB. These datasets vary in database size, number of time
 intervals, and number of values for the partition field.
@@ -12,7 +13,6 @@ Each gzip archive contains a single `.sql` file to create the necessary
 hypertables within the database, and several `.csv` files that contain the
 data to be copied into those tables. These files presume the database
 you are importing them to has already been [set up with the TimescaleDB extension][installation].
-
 
 **Device ops**: these datasets include metrics such as CPU, memory, and network,
 that are collected from mobile devices. Click on the name to download.
@@ -39,10 +39,11 @@ For more details and example usage, see [weather datasets](#in-depth-weather-dat
 ## Importing
 <!-- Add steps format-->
 Briefly, the import steps are:
-1. Setup a database with TimescaleDB.
-1. Unzip the archive.
-1. Import the `.sql` file to create the hypertables via `psql`.
-1. Import the data from `.csv` files via `psql`.
+
+1.  Setup a database with TimescaleDB.
+1.  Unzip the archive.
+1.  Import the `.sql` file to create the hypertables via `psql`.
+1.  Import the data from `.csv` files via `psql`.
 
 Each dataset has a name in the format of `[dataset]_[size].tar.gz`.
 For example, `devices_small.tar.gz` is dataset `devices` and size `small`.
@@ -54,16 +55,17 @@ two tables (`device_info` and a hypertable named `readings`) from `devices.sql`.
 Therefore, there are two CSV files: `devices_small_readings.csv` and
 `devices_small_device_info.csv`. So, to import this dataset into a TimescaleDB
 database named `devices_small`:
+
 ```bash
 # (1) unzip the archive
 tar -xvzf devices_small.tar.gz
 
 # (2) import the .sql file to the database
-psql -U postgres -d devices_small < devices.sql
+psql -U postgres -d tsdb < devices.sql
 
 # (3) import data from .csv files to the database
-psql -U postgres -d devices_small -c "\COPY readings FROM devices_small_readings.csv CSV"
-psql -U postgres -d devices_small -c "\COPY device_info FROM devices_small_device_info.csv CSV"
+psql -U postgres -d tsdb -c "\COPY readings FROM devices_small_readings.csv CSV"
+psql -U postgres -d tsdb -c "\COPY device_info FROM devices_small_device_info.csv CSV"
 ```
 
 The data is now ready for use.
@@ -76,11 +78,12 @@ instead.
 </highlight>
 
 ```bash
-# To access your database (for example: `devices_small`)
-psql -U postgres -h localhost -d devices_small
+# To access your database (for example: `tsdb`)
+psql -U postgres -h localhost -d tsdb
 ```
 
 ## Device ops datasets
+
 After importing one of these datasets (`devices_small`, `devices_med`,
 `devices_big`), you have a plain PostgreSQL table called `device_info` and a
 hypertable called `readings`. The `device_info` table has static metadata
@@ -91,6 +94,7 @@ them and join them with the metadata as you would normal SQL tables, as shown in
 the example queries in this section.
 
 #### Schemas
+
 ```sql
 Table "public.device_info"
 Column       | Type | Modifiers
@@ -125,9 +129,11 @@ Indexes:
 ```
 
 #### Example queries
+
 Uses `devices_med` dataset
 
 **10 most recent battery temperature readings for charging devices**
+
 ```sql
 SELECT time, device_id, battery_temperature
 FROM readings
@@ -150,6 +156,7 @@ time                   | device_id  | battery_temperature
 ```
 
 **Busiest devices (1 min avg) whose battery level is below 33% and is not charging**
+
 ```sql
 SELECT time, readings.device_id, cpu_avg_1min,
 battery_level, battery_status, device_info.model
@@ -198,6 +205,7 @@ hour                   | min_battery_level | max_battery_level
 ---
 
 ## Weather datasets
+
 After importing one of these datasets (`weather_small`, `weather_med`,
 `weather_big`), you notice a plain PostgreSQL table called `locations` and a
 hypertable called `conditions`. The `locations` table has metadata about each of
@@ -208,6 +216,7 @@ them with the metadata as you would normal SQL tables, as shown in the example
 queries in this section.
 
 #### Schemas
+
 ```sql
 Table "public.locations"
 Column      | Type | Modifiers
@@ -231,9 +240,11 @@ Indexes:
 ```
 
 #### Example queries
+
 Uses `weather_med` dataset.
 
 **Last ten readings**
+
 ```sql
 SELECT * FROM conditions c ORDER BY time DESC LIMIT 10;
 
@@ -253,6 +264,7 @@ time                   |     device_id      |    temperature     |      humidity
 ```
 
 **Last 10 readings from 'outside' locations**
+
 ```sql
 SELECT time, c.device_id, location,
 trunc(temperature, 2) temperature, trunc(humidity, 2) humidity
@@ -277,6 +289,7 @@ time                   |     device_id      |   location    | temperature | humi
 ```
 
 **Hourly average, min, and max temperatures for "field" locations**
+
 ```sql
 SELECT date_trunc('hour', time) "hour",
 trunc(avg(temperature), 2) avg_temp,

--- a/timescaledb/tutorials/time-series-forecast.md
+++ b/timescaledb/tutorials/time-series-forecast.md
@@ -5,6 +5,7 @@ keywords: [forecast, analytics]
 ---
 
 # Time-series forecasting
+
 Time-series forecasting enables us to predict likely
 future values for a dataset based on historical time-series
 data. Time-series data collectively represents how a system,
@@ -14,11 +15,11 @@ to predict the next set of values likely to occur.
 
 Time-series predictions can be used to:
 
-* Forecast cloud infrastructure expenses next quarter
-* Forecast the value of a given stock in the future
-* Forecast the number of units of a product likely to be sold next quarter
-* Forecast the remaining lifespan of an IoT device
-* Forecast the number of taxi or ride share drivers necessary for a big holiday evening
+*   Forecast cloud infrastructure expenses next quarter
+*   Forecast the value of a given stock in the future
+*   Forecast the number of units of a product likely to be sold next quarter
+*   Forecast the remaining lifespan of an IoT device
+*   Forecast the number of taxi or ride share drivers necessary for a big holiday evening
 
 Time-series forecasting alone is a powerful tool. But time-series
 data joined with business data can be a competitive advantage for
@@ -39,6 +40,7 @@ time-series forecasting model, and explore the use of various forecasting
 and machine learning tools.
 
 ### Setting up
+
 Prerequisites:
 
 *   [Installed TimescaleDB][install]
@@ -51,7 +53,7 @@ First, let's create the schema and populate the tables. Download the file
 [`forecast.sql`][forecast-sql] and execute the following command:
 
 ```bash
-psql -U postgres -d nyc_data -h localhost -f forecast.sql
+psql -U postgres -d tsdb -h localhost -f forecast.sql
 ```
 
 The `forecast.sql` file contains SQL statements that create three
@@ -109,6 +111,7 @@ are in your database.
 ```
 
 ### Seasonal ARIMA with R
+
 The [ARIMA (Autoregressive Integrated Moving Average) model][arima] is a
 tool that is often used in time-series analysis to better understand a
 dataset and make predictions on future values. The ARIMA model can be
@@ -360,6 +363,7 @@ alternative method that allows you to move computations to the database and
 improve this performance.
 
 ### Non-Seasonal ARIMA with Apache MADlib
+
 [MADlib][madlib] is an open source library for in-database data analytics that
 provides a wide collection of popular machine learning methods and various
 supplementary statistical tools.
@@ -436,6 +440,7 @@ WHERE one_hour <= '2016-01-21 23:59:59';
 SELECT * INTO rides_price_test FROM rides_price
 WHERE one_hour >= '2016-01-22 00:00:00';
 ```
+
 Now you can use [MADlib's ARIMA][madlib_arima] library to make forecasts
 on your dataset.
 
@@ -580,6 +585,7 @@ This means that TimescaleDB users can easily take advantage of
 the vast PostgreSQL ecosystem.
 
 ### Holt-Winters with Python
+
 The [Holt-Winters][holt-winters] model is another widely used tool in time-series
 analysis and forecasting. It can only be used for seasonal time-series data.
 The Holt-Winters model uses simple exponential smoothing to make
@@ -748,6 +754,7 @@ also thrown off by the anomalous data points on Martin Luther King
 day on the previous Monday.
 
 ### Takeaways from analysis
+
 This tutorial looked at different ways you can build statistical models to
 analyze time-series data and how you can leverage the full power of the
 PostgreSQL ecosystem with TimescaleDB. This tutorial also looked at integrating


### PR DESCRIPTION
# Description

Change database names to tsdb for consistency in tutorials and examples as that is the database name on Timescale Cloud. In some cases, a placeholder is used instead where that makes more sense.

# Links

Fixes #1215 

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
