### PR TITLE
Add details for `distributed_exec`

### DIFF
--- a/api/distributed_exec.md
+++ b/api/distributed_exec.md
@@ -23,6 +23,12 @@ any introduced inconsistency.
 Note that the command is _not_ executed on the access node itself and
 it is not possible to chain multiple commands together in one call.
 
+<highlight type="important">
+You cannot run `distributed_exec` with some SQL commands. For example, `ALTER
+EXTENSION` doesn't work because it can't be called after the TimescaleDB
+extension is already loaded.
+</highlight>
+
 ### Required arguments
 
 |Name|Type|Description|
@@ -42,17 +48,22 @@ Create the role `testrole` across all data nodes in a distributed database:
 
 ```sql
 CALL distributed_exec($$ CREATE USER testrole WITH LOGIN $$);
-
 ```
 
 Create the role `testrole` on two specific data nodes:
 
 ```sql
 CALL distributed_exec($$ CREATE USER testrole WITH LOGIN $$, node_list => '{ "dn1", "dn2" }');
-
 ```
 
-Create new databases `dist_database` on data nodes, which requires to set `transactional` to FALSE:
+Create the table `example` on all data nodes:
+
+```sql
+CALL distributed_exec($$ CREATE TABLE example (ts TIMESTAMPTZ, value INTEGER) $$);
+```
+
+Create new databases `dist_database` on data nodes, which requires setting
+`transactional` to FALSE:
 
 ```sql
 CALL distributed_exec('CREATE DATABASE dist_database', transactional => FALSE);


### PR DESCRIPTION
# Description

* Add another example that is Timescale Cloud-compatible
* Add a callout about some commands being incompatible

The original request was to remove the `CREATE DATABASE` example, as it is not Cloud-compatible. After evaluation, decided to keep it as it is a useful example for our self-hosted users. Chose to add another Cloud-compatible example instead, so readers see more use cases for this function.

# Links

Fixes https://github.com/timescale/docs-private/issues/38

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
