### PR TITLE
Clean up API frontmatter

### DIFF
--- a/api/actions.md
+++ b/api/actions.md
@@ -15,7 +15,7 @@ even enhancing existing policies with additional functionality.
 The following APIs and views allow you to manage the jobs that you create and
 get details around automatic jobs used by other TimescaleDB functions like
 continuous aggregation refresh policies and data retention policies. To view the
-policies that you set or the policies that already exist, see 
+policies that you set or the policies that already exist, see
 [informational views][informational-views].
 
 [informational-views]: /api/:currentVersion:/informational-views/jobs/

--- a/api/add_compression_policy.md
+++ b/api/add_compression_policy.md
@@ -1,23 +1,26 @@
 ---
 api_name: add_compression_policy()
 excerpt: Add policy to schedule automatic compression of chunks
-license: community
-topic: compression
+topics: [compression, jobs]
 keywords: [compression, policies]
 tags: [scheduled jobs, background jobs, automation framework]
+api:
+  license: community
+  type: function
 ---
 
 # add_compression_policy() <tag type="community" content="community" />
+
 Allows you to set a policy by which the system compresses a chunk
 automatically in the background after it reaches a given age.
 
 Note that compression policies can only be created on hypertables or continuous
-aggregates that already have compression enabled. Use the 
-[`ALTER TABLE`][compression_alter-table] command to set `timescaledb.compress` 
-and other configuration parameters for hypertables. Use 
-[`ALTER MATERIALIZED VIEW`][compression_continuous-aggregate] command to 
-enable compression on continuous aggregates. To view the policies that you set or 
-the policies that already exist, see 
+aggregates that already have compression enabled. Use the
+[`ALTER TABLE`][compression_alter-table] command to set `timescaledb.compress`
+and other configuration parameters for hypertables. Use
+[`ALTER MATERIALIZED VIEW`][compression_continuous-aggregate] command to
+enable compression on continuous aggregates. To view the policies that you set or
+the policies that already exist, see
 [informational views][informational-views].
 
 ### Required arguments
@@ -27,10 +30,11 @@ the policies that already exist, see
 |`hypertable`|REGCLASS|Name of the hypertable or continuous aggregate|
 |`compress_after`|INTERVAL or INTEGER|The age after which the policy job compresses chunks. `compress_after` is calculated relative to the current time, so chunks containing data older than `now - {compress_after}::interval` are compressed.|
 
-The `compress_after` parameter should be specified differently depending 
+The `compress_after` parameter should be specified differently depending
 on the type of the time column of the hypertable or continuous aggregate:
-- For hypertables with TIMESTAMP, TIMESTAMPTZ, and DATE time columns: the time interval should be an INTERVAL type.
-- For hypertables with integer-based timestamps: the time interval should be an integer type (this requires
+
+*   For hypertables with TIMESTAMP, TIMESTAMPTZ, and DATE time columns: the time interval should be an INTERVAL type.
+*   For hypertables with integer-based timestamps: the time interval should be an integer type (this requires
 the [integer_now_func][set_integer_now_func] to be set).
 
 ### Optional arguments
@@ -41,12 +45,13 @@ the [integer_now_func][set_integer_now_func] to be set).
 
 <highlight type="important">
 Compression policies on continuous aggregates should be set up so that they do
-not overlap with refresh policies on continuous aggregates. This is due to a 
+not overlap with refresh policies on continuous aggregates. This is due to a
 current TimescaleDB limitation that prevents refresh of compressed regions of
 continuous aggregates.
 </highlight>
 
 ### Sample usage
+
 Add a policy to compress chunks older than 60 days on the 'cpu' hypertable.
 
 ``` sql
@@ -59,8 +64,9 @@ Add a compress chunks policy to a hypertable with an integer-based time column:
 SELECT add_compression_policy('table_with_bigint_time', BIGINT '600000');
 ```
 
-Add a policy to compress chunks of a continuous aggregate called `cpu_weekly`, that are 
+Add a policy to compress chunks of a continuous aggregate called `cpu_weekly`, that are
 older than eight weeks:
+
 ``` sql
 SELECT add_compression_policy('cpu_weekly', INTERVAL '8 weeks');
 ```

--- a/api/add_continuous_aggregate_policy.md
+++ b/api/add_continuous_aggregate_policy.md
@@ -1,10 +1,12 @@
 ---
 api_name: add_continuous_aggregate_policy()
 excerpt: Add policy to schedule automatic refresh of a continuous aggregate
-license: community
-topic: continuous aggregates
+topics: [continuous aggregates, jobs]
 keywords: [continuous aggregates, policies]
 tags: [scheduled jobs, refresh]
+api:
+  license: community
+  type: function
 ---
 
 ## add_continuous_aggregate_policy() <tag type="community">Community</tag>
@@ -36,7 +38,7 @@ depending on the type of the time column of the hypertable:
 While setting `end_offset` to `NULL` is possible, it is not recommended. By
 default, querying a continuous aggregate returns data between `end_offset` and
 the current time. There is no need to set `end_offset` to `NULL`. To learn more
-about how continuous aggregates use real-time aggregation, see the 
+about how continuous aggregates use real-time aggregation, see the
 [real-time aggregation section](/timescaledb/latest/how-to-guides/continuous-aggregates/real-time-aggregates/).
 </highlight>
 

--- a/api/add_data_node.md
+++ b/api/add_data_node.md
@@ -1,10 +1,12 @@
 ---
 api_name: add_data_node()
 excerpt: Add a new data node to a multi-node cluster
-license: community
-topic: multi-node
+topics: [multi-node]
 keywords: [multi-node]
 tags: [data nodes, distributed hypertables, cluster]
+api:
+  license: community
+  type: function
 ---
 
 ## add_data_node() <tag type="community">Community</tag>
@@ -24,15 +26,16 @@ data node, the access node also tries to connect to the data node
 and therefore needs a way to authenticate with it. TimescaleDB
 currently supports several different such authentication methods for
 flexibility (including trust, user mappings, password, and certificate
-methods). Refer to [Setting up Multi-Node TimescaleDB][multinode] for more 
+methods). Refer to [Setting up Multi-Node TimescaleDB][multinode] for more
 information about node-to-node authentication.
 
 Unless `bootstrap` is false, the function attempts to bootstrap
 the data node by:
-1. Creating the database given in `database` that serve as the
+
+1.  Creating the database given in `database` that serve as the
    new data node.
-2. Loading the TimescaleDB extension in the new database.
-3. Setting metadata to make the data node part of the distributed
+2.  Loading the TimescaleDB extension in the new database.
+3.  Setting metadata to make the data node part of the distributed
    database.
 
 Note that user roles are not automatically created on the new data
@@ -72,13 +75,14 @@ after it is added.
 #### Errors
 
 An error is given if:
-* The function is executed inside a transaction.
-* The function is executed in a database that is already a data node.
-* The data node already exists and `if_not_exists` is `FALSE`.
-* The access node cannot connect to the data node due to a network
+
+*   The function is executed inside a transaction.
+*   The function is executed in a database that is already a data node.
+*   The data node already exists and `if_not_exists` is `FALSE`.
+*   The access node cannot connect to the data node due to a network
   failure or invalid configuration (for example, wrong port, or there is no
   way to authenticate the user).
-* If `bootstrap` is `FALSE` and the database was not previously
+*   If `bootstrap` is `FALSE` and the database was not previously
   bootstrapped.
 
 #### Privileges

--- a/api/add_dimension.md
+++ b/api/add_dimension.md
@@ -1,13 +1,16 @@
 ---
 api_name: add_dimension()
 excerpt: Add a space-partitioning dimension to a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables, partitions]
 tags: [dimensions, chunks]
+api:
+  license: apache
+  type: function
 ---
 
 ## add_dimension()
+
 Add an additional partitioning dimension to a TimescaleDB hypertable.
 The column selected as the dimension can either use interval
 partitioning (for example, for a second time partition) or hash partitioning.
@@ -33,6 +36,7 @@ across multiple disks within the same time interval
 (in the case of single-node deployments).
 
 ### Parallelizing queries across multiple data nodes
+
 In a distributed hypertable, space partitioning enables inserts to be
 parallelized across data nodes, even while the inserted rows share
 timestamps from the same time interval, and thus increases the ingest rate.
@@ -45,6 +49,7 @@ when using `location` as a space partition). Please see our
 for more information.
 
 ### Parallelizing disk I/O on a single node
+
 Parallel I/O can benefit in two scenarios: (a) two or more concurrent
 queries should be able to read from different disks in parallel, or
 (b) a single query should be able to use query parallelization to read
@@ -52,10 +57,10 @@ from multiple disks in parallel.
 
 Thus, users looking for parallel I/O have two options:
 
-1. Use a RAID setup across multiple physical disks, and expose a
+1.  Use a RAID setup across multiple physical disks, and expose a
 single logical disk to the hypertable (that is, via a single tablespace).
 
-1. For each physical disk, add a separate tablespace to the
+1.  For each physical disk, add a separate tablespace to the
 database. TimescaleDB allows you to actually add multiple tablespaces
 to a *single* hypertable (although under the covers, a hypertable's
 chunks are spread across the tablespaces associated with that hypertable).
@@ -108,11 +113,11 @@ dimension uses hash or interval partitioning.
 
 The `chunk_time_interval` should be specified as follows:
 
-- If the column to be partitioned is a TIMESTAMP, TIMESTAMPTZ, or
+*   If the column to be partitioned is a TIMESTAMP, TIMESTAMPTZ, or
 DATE, this length should be specified either as an INTERVAL type or
 an integer value in *microseconds*.
 
-- If the column is some other integer type, this length
+*   If the column is some other integer type, this length
 should be an integer that reflects
 the column's underlying semantics (for example, the
 `chunk_time_interval` should be given in milliseconds if this column
@@ -122,11 +127,14 @@ is the number of milliseconds since the UNIX epoch).
  Supporting more than **one** additional dimension is currently
  experimental. For any production environments, users are recommended
  to use at most one "space" dimension.
+
 </highlight>
 
 ### Sample use
+
 First convert table `conditions` to hypertable with just time
 partitioning on column `time`, then add an additional partition key on `location` with four partitions:
+
 ```sql
 SELECT create_hypertable('conditions', 'time');
 SELECT add_dimension('conditions', 'location', number_partitions => 4);

--- a/api/add_job.md
+++ b/api/add_job.md
@@ -1,13 +1,16 @@
 ---
 api_name: add_job()
 excerpt: Add a job to run a user-defined action automatically
-license: community
-topic: jobs
+topics: [jobs]
 keywords: [jobs]
 tags: [user-defined actions, scheduled jobs, background jobs, automation framework]
+api:
+  license: community
+  type: function
 ---
 
 ## add_job() <tag type="community">Community</tag>
+
 Register an action for scheduling by the automation framework. For more information about scheduling, including example actions, see the [actions section][using-actions].
 
 ### Required arguments
@@ -32,7 +35,9 @@ Register an action for scheduling by the automation framework. For more informat
 |`job_id`|INTEGER|TimescaleDB background job ID|
 
 ### Sample use
+
 Register the `user_defined_action` procedure to run every hour:
+
 ```sql
 CREATE OR REPLACE PROCEDURE user_defined_action(job_id int, config jsonb) LANGUAGE PLPGSQL AS
 $$
@@ -43,6 +48,5 @@ $$;
 
 SELECT add_job('user_defined_action','1h');
 ```
-
 
 [using-actions]: /timescaledb/:currentVersion:/overview/core-concepts/user-defined-actions

--- a/api/add_reorder_policy.md
+++ b/api/add_reorder_policy.md
@@ -1,20 +1,23 @@
 ---
 api_name: add_reorder_policy()
 excerpt: Add a policy to reorder rows in hypertable chunks
-license: community
-topic: hypertables
+topics: [hypertables, jobs]
 keywords: [hypertables, chunks, policies]
 tags: [reorder]
+api:
+  license: community
+  type: function
 ---
 
 ## add_reorder_policy() <tag type="community">Community</tag>
+
 Create a policy to reorder chunks on a given hypertable index in the
 background. (See [reorder_chunk][reorder_chunk]). Only one reorder policy may
 exist per hypertable. Only chunks that are the third from the most recent are
 reordered to avoid reordering chunks that are still being inserted into.
 
 <highlight type="tip">
- Once a chunk has been reordered by the background worker it is not 
+ Once a chunk has been reordered by the background worker it is not
 reordered again. So if one were to insert significant amounts of data in to
 older chunks that have already been reordered, it might be necessary to manually
 re-run the [reorder_chunk](/api/latest/hypertable/reorder_chunk) function on older chunks, or to drop
@@ -40,9 +43,7 @@ and re-create the policy if many older chunks have been affected.
 |---|---|---|
 |`job_id`| INTEGER | TimescaleDB background job id created to implement this policy|
 
-
 ### Sample usage
-
 
 ```sql
 SELECT add_reorder_policy('conditions', 'conditions_device_id_time_idx');

--- a/api/add_retention_policy.md
+++ b/api/add_retention_policy.md
@@ -1,10 +1,12 @@
 ---
 api_name: add_retention_policy()
 excerpt: Add a policy to drop older chunks
-license: community
-topic: data retention
+topics: [data retention, jobs]
 keywords: [data retention, policies, delete]
 tags: [hypertables, drop]
+api:
+  license: community
+  type: function
 ---
 
 ## add_retention_policy() <tag type="community">Community</tag>
@@ -23,9 +25,10 @@ one retention policy may exist per hypertable.
 
 The `drop_after` parameter should be specified differently depending on the
 type of the time column of the hypertable:
-- For hypertables with TIMESTAMP, TIMESTAMPTZ, and DATE time columns: the time
+
+*   For hypertables with TIMESTAMP, TIMESTAMPTZ, and DATE time columns: the time
 interval should be an INTERVAL type.
-- For hypertables with integer-based timestamps: the time interval should be an
+*   For hypertables with integer-based timestamps: the time interval should be an
 integer type (this requires the [integer_now_func][set_integer_now_func] to be set).
 
 ### Optional arguments
@@ -43,11 +46,13 @@ integer type (this requires the [integer_now_func][set_integer_now_func] to be s
 ### Sample usage
 
 Create a data retention policy to discard chunks greater than 6 months old:
+
 ```sql
 SELECT add_retention_policy('conditions', INTERVAL '6 months');
 ```
 
 Create a data retention policy with an integer-based time column:
+
 ```sql
 SELECT add_retention_policy('conditions', BIGINT '600000');
 ```

--- a/api/administration.md
+++ b/api/administration.md
@@ -1,7 +1,7 @@
 ---
 title: Administrative functions
 excerpt: Prepare a database for backup and restore, and keep track of your setup data
-keywords: [admin]
+keywords: [administration]
 tags: [backup, restore, set up]
 ---
 

--- a/api/alter_job.md
+++ b/api/alter_job.md
@@ -1,13 +1,16 @@
 ---
 api_name: alter_job()
 excerpt: Alter a job that is scheduled to run automatically
-license: community
-topic: jobs
+topics: [jobs]
 keywords: [jobs]
 tags: [scheduled jobs, user-defined actions, automation framework, background jobs, alter, change]
+api:
+  license: community
+  type: function
 ---
 
 ## alter_job() <tag type="community">Community</tag>
+
 Actions scheduled using the TimescaleDB automation framework run periodically in
 a background worker. You can change the schedule of these jobs with the
 `alter_job` function. To alter an existing job, refer to it by `job_id`. The
@@ -34,7 +37,7 @@ other useful statistics for deciding what the new schedule should be.
 |`scheduled`|BOOLEAN|Set to `FALSE` to exclude this job from being run as background job|
 |`config`|JSONB|Job-specific configuration, passed to the function when it runs|
 |`next_start`|TIMESTAMPTZ|The next time at which to run the job. The job can be paused by setting this value to `infinity`, and restarted with a value of `now()`|
-|`if_exists`|BOOLEAN|Set to `true `to issue a notice instead of an error if the job does not exist. Defaults to false.|
+|`if_exists`|BOOLEAN|Set to `true`to issue a notice instead of an error if the job does not exist. Defaults to false.|
 
 When a job begins, the `next_start` parameter is set to `infinity`. This
 prevents the job from attempting to be started again while it is running. When
@@ -55,12 +58,15 @@ automatically updated to the next computed start time.
 |`next_start`|TIMESTAMPTZ|The next time to run the job|
 
 ### Sample usage
+
 Reschedules job ID `1000` so that it runs every two days:
+
 ```sql
 SELECT alter_job(1000, schedule_interval => INTERVAL '2 days');
 ```
 
 Disables scheduling of the compression policy on the `conditions` hypertable:
+
 ```sql
 SELECT alter_job(job_id, scheduled => false)
 FROM timescaledb_information.jobs
@@ -68,6 +74,7 @@ WHERE proc_name = 'policy_compression' AND hypertable_name = 'conditions'
 ```
 
 Reschedules continuous aggregate job ID `1000` so that it next runs at 9:00:00 on 15 March, 2020:
+
 ```sql
 SELECT alter_job(1000, next_start => '2020-03-15 09:00:00.0+00');
 ```

--- a/api/alter_materialized_view.md
+++ b/api/alter_materialized_view.md
@@ -1,39 +1,46 @@
 ---
 api_name: ALTER MATERLIALIZED VIEW (Continuous Aggregate)
 excerpt: Change an existing continuous aggregate
-license: community
-topic: continuous aggregates
+topics: [continuous aggregates]
 keywords: [continuous aggregates]
 tags: [materialized views, hypertables, alter, change]
+api:
+  license: community
+  type: command
 ---
 
 ## ALTER MATERIALIZED VIEW (Continuous Aggregate) <tag type="community">Community</tag>
+
 `ALTER MATERIALIZED VIEW` statement can be used to modify some of the `WITH` clause [options][create_materialized_view] for the continuous aggregate view.
 `ALTER MATERIALIZED VIEW` statement also supports the following
 [PostgreSQL clauses][postgres-alterview] on the
 continuous aggregate view:
 
-- `RENAME TO` clause to rename the continuous aggregate view;
-- `SET SCHEMA` clause to set the new schema for the continuous aggregate view;
-- `SET TABLESPACE` clause to move the materialization of the continuous
+*   `RENAME TO` clause to rename the continuous aggregate view;
+*   `SET SCHEMA` clause to set the new schema for the continuous aggregate view;
+*   `SET TABLESPACE` clause to move the materialization of the continuous
   aggregate view to the new tablespace;
-- `OWNER TO` clause to set new owner for the continuous aggregate view.
+*   `OWNER TO` clause to set new owner for the continuous aggregate view.
 
 ``` sql
 ALTER MATERIALIZED VIEW <view_name> SET ( timescaledb.<option> =  <value> [, ... ] )
 ```
+
 ### Parameters
+
 |Name|Type|Description|
 |---|---|---|
 | `<view_name>` | TEXT | Name (optionally schema-qualified) of continuous aggregate view to be created.|
 
 ### Options
+
 |Name|Description|
 |-|-|
 |timescaledb.materialized_only|Enable and disable real time aggregation|
 |timescaledb.compress|Enable and disable compression|
 
 ### Sample usage
+
 To disable real-time aggregates for a
 continuous aggregate:
 

--- a/api/alter_table_compression.md
+++ b/api/alter_table_compression.md
@@ -1,10 +1,12 @@
 ---
 api_name: ALTER TABLE (Compression)
 excerpt: Change compression settings on a compressed hypertable
-license: community
-topic: compression
+topics: [compression]
 keywords: [compression]
 tags: [settings, hypertables, alter, change]
+api:
+  license: community
+  type: command
 ---
 
 ## ALTER TABLE (Compression) <tag type="community" content="community" />
@@ -19,24 +21,29 @@ ALTER TABLE <table_name> SET (timescaledb.compress, timescaledb.compress_orderby
 timescaledb.compress_segmentby = '<column_name> [, ...]'
 );
 ```
+
 #### Required arguments
+
 |Name|Type|Description|
 |---|---|---|
 | `timescaledb.compress` | BOOLEAN | Enable/Disable compression |
 
 #### Optional arguments
+
 |Name|Type|Description|
 |---|---|---|
 | `timescaledb.compress_orderby` | TEXT |Order used by compression, specified in the same way as the ORDER BY clause in a SELECT query. The default is the descending order of the hypertable's time column. |
 | `timescaledb.compress_segmentby` | TEXT |Column list on which to key the compressed segments. An identifier representing the source of the data such as `device_id` or `tags_id` is usually a good candidate. The default is no `segment by` columns. |
 
 ### Parameters
+
 |Name|Type|Description|
 |---|---|---|
 | `table_name` | TEXT |Hypertable that supports compression |
 | `column_name` | TEXT | Column used to order by and/or segment by |
 
 ### Sample usage
+
 Configure a hypertable that ingests device data to use compression.
 
 ```sql

--- a/api/api-tag-overview.md
+++ b/api/api-tag-overview.md
@@ -5,35 +5,40 @@ tags: [licenses, toolkit, experimental]
 ---
 
 # API Reference tag overview
-The Timescale API Reference uses tags to categorize functions. The tags are `Community`, 
+
+The Timescale API Reference uses tags to categorize functions. The tags are `Community`,
 `Experimental`, `Toolkit`, and `Experimental (Toolkit)`. This section explains each tag.
 
 ## Community <tag type="community">Community</tag>
-This tag indicates that the function is available under TimescaleDB Community 
-Edition, and are not available under the Apache 2 Edition. For more information, 
+
+This tag indicates that the function is available under TimescaleDB Community
+Edition, and are not available under the Apache 2 Edition. For more information,
 visit our [TimescaleDB License comparison sheet][tsl-comparison].
 
 ## Experimental (TimescaleDB Experimental Schema) <tag type="experimental">Experimental</tag>
-This tag indicates that the function is included in the TimescaleDB experimental schema. 
-Do not use experimental functions in production. Experimental features could include bugs, 
-and are likely to change in future versions. The experimental schema is used by Timescale 
-to develop new features more quickly. If experimental functions are successful, 
-they can move out of the experimental schema and go into production use. For more 
+
+This tag indicates that the function is included in the TimescaleDB experimental schema.
+Do not use experimental functions in production. Experimental features could include bugs,
+and are likely to change in future versions. The experimental schema is used by Timescale
+to develop new features more quickly. If experimental functions are successful,
+they can move out of the experimental schema and go into production use. For more
 information about the experimental schema, [read the Timescale blog post][experimental-blog].
 
 ## Toolkit <tag type="toolkit">Toolkit</tag>
-This tag indicates that the function is included in the TimescaleDB Toolkit extension. 
-Toolkit functions are available under Timescale Community Edition. 
+
+This tag indicates that the function is included in the TimescaleDB Toolkit extension.
+Toolkit functions are available under Timescale Community Edition.
 For installation instructions, [see the installation guide][toolkit-install].
 
 ## Experimental (TimescaleDB Toolkit) <tag type="experimental-toolkit">Experimental</tag>
-This tag is used with the Toolkit tag. It indicates a Toolkit function that is under 
-active development. Do not use experimental toolkit functions in production. 
-Experimental toolkit functions could include bugs, and are likely to change in future versions. 
-These functions might not correctly handle unusual use cases or errors, and they 
-could have poor performance. Updates to the TimescaleDB extension drop database 
-objects that depend on experimental features like this function. If you use experimental 
-toolkit functions on Timescale Cloud, this function is automatically dropped when the 
+
+This tag is used with the Toolkit tag. It indicates a Toolkit function that is under
+active development. Do not use experimental toolkit functions in production.
+Experimental toolkit functions could include bugs, and are likely to change in future versions.
+These functions might not correctly handle unusual use cases or errors, and they
+could have poor performance. Updates to the TimescaleDB extension drop database
+objects that depend on experimental features like this function. If you use experimental
+toolkit functions on Timescale Cloud, this function is automatically dropped when the
 Toolkit extension is updated. For more information, [see the TimescaleDB Toolkit docs][toolkit-docs].
 
 [tsl-comparison]: /timescaledb/:currentVersion:/timescaledb-edition-comparison/

--- a/api/approx_count.md
+++ b/api/approx_count.md
@@ -1,13 +1,22 @@
 ---
 api_name: approx_count()
 excerpt: Estimate an item's frequency from a `count_min_sketch`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, frequency, count min sketch]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: accessor
+  aggregates:
+    - count_min_sketch()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: CountMinSketch
 hyperfunction_type: accessor
@@ -16,6 +25,7 @@ hyperfunction_type: accessor
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # approx_count() <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+
 Returns an estimate of the number of times that the text `item` was seen by the [Count-Min Sketch][count-min-sketch] `agg`.
 
 ```sql
@@ -33,7 +43,6 @@ approx_count (
 |-|-|-|
 |`item`|`TEXT`|The text whose frequency you want to estimate|
 |`agg`|`CountMinSketch`|The aggregate to use for estimating the frequency of `item`|
-
 
 ## Returns
 

--- a/api/approx_count_distinct.md
+++ b/api/approx_count_distinct.md
@@ -1,19 +1,27 @@
 ---
 api_name: approx_count_distinct()
 excerpt: Aggregate data into a hyperloglog for approximate counting without having to specify the number of buckets.
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, approximate count distinct, distinct count, hyperloglog]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: approximate count distinct
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'approximate count distinct'
 hyperfunction_subfamily: hyperloglog
 hyperfunction_type: aggregate
 ---
 
 # approx_count_distinct()  <tag type="toolkit">Toolkit</tag>
+
 The `approx_count_distinct` function constructs and returns a hyperloglog with a
 default size appropriate for the majority of use cases.
 
@@ -35,6 +43,7 @@ For more information about approximate count distinct functions, see the
 <!---Any special notes about the returns-->
 
 ## Sample usage
+
 This examples assumes you have a table called `samples`, that contains a column
 called `weights` that holds DOUBLE PRECISION values. This command returns a
 digest over that column:
@@ -49,6 +58,5 @@ other `hyperloglog` functions:
 ``` sql
 CREATE VIEW hll AS SELECT toolkit_experimental.approx_count_distinct(data) FROM samples;
 ```
-
 
 [hyperfunctions-approx-count-distincts]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/approx-count-distincts/

--- a/api/approx_percentile.md
+++ b/api/approx_percentile.md
@@ -1,15 +1,23 @@
 ---
 api_name: approx_percentile()
 excerpt: Estimate the value at a given percentile from values in a percentile aggregate
-license: community
-toolkit: true
-experimental: false
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [percentile, hyperfunctions]
 tags: [approximate, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: accessor
+  aggregates:
+    - percentile_agg()
+    - tdigest()
+    - uddsketch()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'percentile approximation'
 hyperfunction_type: accessor
@@ -49,11 +57,11 @@ SELECT
     approx_percentile(0.01, percentile_agg(data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
 approx_percentile
 -------------------
              0.999
 ```
-
 
 [hyperfunctions-percentile-approx]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/

--- a/api/approx_percentile_rank.md
+++ b/api/approx_percentile_rank.md
@@ -1,21 +1,30 @@
 ---
 api_name: approx_percentile_rank()
 excerpt: Estimate the percentile of a given value from values in a percentile aggregate
-license: community
-toolkit: true
-experimental: false
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [percentile, hyperfunctions]
 tags: [approximate, rank, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: accessor
+  aggregates:
+    - percentile_agg()
+    - tdigest()
+    - uddsketch()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'percentile approximation'
 hyperfunction_type: accessor
 ---
 
 # approx_percentile_rank()  <tag type="toolkit">Toolkit</tag>
+
 Estimate what percentile a given value would be located at in a `UddSketch`.
 
 ```SQL
@@ -50,12 +59,12 @@ SELECT
     approx_percentile_rank(99, percentile_agg(data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  approx_percentile_rank
 ----------------------------
          0.9851485148514851
 ```
-
 
 [hyperfunctions-percentile-approx]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/
 [advanced-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/advanced-agg/

--- a/api/approximate_row_count.md
+++ b/api/approximate_row_count.md
@@ -1,10 +1,14 @@
 ---
 api_name: approximate_row_count()
 excerpt: Estimate the number of rows in a table
-license: apache
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [count, hyperfunctions]
 tags: [approximate, rows]
+api:
+  license: apache
+  type: function
+hyperfunction:
+  type: one-step aggregate
 ---
 
 ## approximate_row_count()
@@ -23,6 +27,7 @@ The accuracy of `approximate_row_count` depends on the database having up-to-dat
 ### Sample usage
 
 Get the approximate row count for a single hypertable.
+
 ```sql
 ANALYZE conditions;
 
@@ -30,6 +35,7 @@ SELECT * FROM approximate_row_count('conditions');
 ```
 
 The expected output:
+
 ```
 approximate_row_count
 ----------------------

--- a/api/asap.md
+++ b/api/asap.md
@@ -1,26 +1,33 @@
 ---
 api_name: asap_smooth()
 excerpt: Downsample a time series using the ASAP smoothing algorithm
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [downsample, smooth, hyperfunctions]
 tags: [toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: downsample
+  type: one-step aggregate
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'downsample'
 hyperfunction_subfamily: 'downsample'
 hyperfunction_type: other
 ---
 
 # asap_smooth()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
-The [ASAP smoothing alogrithm][asap-algorithm] is designed to create 
-human-readable graphs that preserve the rough shape and larger trends 
-of the input data, while minimizing the local variance between points. 
-The `asap_smooth` hyperfunction provides an implementation of this 
-algorithm that takes `(timestamptz, double precision)` data and returns 
+
+The [ASAP smoothing alogrithm][asap-algorithm] is designed to create
+human-readable graphs that preserve the rough shape and larger trends
+of the input data, while minimizing the local variance between points.
+The `asap_smooth` hyperfunction provides an implementation of this
+algorithm that takes `(timestamptz, double precision)` data and returns
 an ASAP smoothed [`timevector`][hyperfunctions-timevectors] line.
 
 ## Required arguments
@@ -38,11 +45,13 @@ an ASAP smoothed [`timevector`][hyperfunctions-timevectors] line.
 |`normalizedtimevector`|`NormalizedTimevector`|An object representing a series of values occurring at set intervals from a starting time. It can be unpacked via `unnest`.|
 
 ## Sample usage
-This example uses a table called `metrics`, with columns for `date` and 
-`reading` that contain measurements that have been accumulated over 
-a large interval of time. This example takes that data and provides a 
-smoothed representation of approximately 10 points, but that still shows 
+
+This example uses a table called `metrics`, with columns for `date` and
+`reading` that contain measurements that have been accumulated over
+a large interval of time. This example takes that data and provides a
+smoothed representation of approximately 10 points, but that still shows
 any anomalous readings:
+
 ```sql
 SET TIME ZONE 'UTC';
 CREATE TABLE metrics(date TIMESTAMPTZ, reading DOUBLE PRECISION);
@@ -61,6 +70,7 @@ SELECT * FROM toolkit_experimental.unnest(
 ```
 
 The output for this query:
+
 ```sql
           time          |        value
 ------------------------+---------------------
@@ -73,7 +83,6 @@ The output for this query:
  2020-01-06 01:00:00+00 |  5.366481456572268
  2020-01-06 21:00:00+00 |  5.949469264090643
 ```
-
 
 [asap-algorithm]: https://arxiv.org/pdf/1703.00983.pdf
 [hyperfunctions-timevectors]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/function-pipelines/#timevectors

--- a/api/attach_data_node.md
+++ b/api/attach_data_node.md
@@ -1,10 +1,12 @@
 ---
 api_name: attach_data_node()
 excerpt: Attach a data node to a distributed hypertable
-license: community
-topic: multi-node
+topics: [multi-node, distributed hypertables]
 keywords: [multi-node, distributed hypertables]
 tags: [distributed hypertables, data nodes, attach]
+api:
+  license: community
+  type: function
 ---
 
 ## attach_data_node() <tag type="community">Community</tag>

--- a/api/attach_tablespace.md
+++ b/api/attach_tablespace.md
@@ -1,10 +1,12 @@
 ---
 api_name: attach_tablespace()
 excerpt: Attach a tablespace to a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables, data tiering]
 keywords: [hypertables, tablespaces]
 tags: [data tiering, chunks, attach]
+api:
+  license: apache
+  type: function
 ---
 
 ## attach_tablespace()
@@ -14,7 +16,7 @@ Attach a tablespace to a hypertable and use it to store chunks. A
 that allows control over where individual tables and indexes are
 stored on the filesystem. A common use case is to create a tablespace
 for a particular storage disk, allowing tables to be stored
-there. To learn more, see the [PostgreSQL documentation on 
+there. To learn more, see the [PostgreSQL documentation on
 tablespaces][postgres-tablespaces].
 
 TimescaleDB can manage a set of tablespaces for each hypertable,
@@ -50,7 +52,6 @@ using the `TABLESPACE` option to `CREATE TABLE`, prior to calling
 ### Sample usage
 
 Attach the tablespace `disk1` to the hypertable `conditions`:
-
 
 ```sql
 SELECT attach_tablespace('disk1', 'conditions');

--- a/api/average-stats.md
+++ b/api/average-stats.md
@@ -1,14 +1,20 @@
 ---
-api_name: 'average() | average_y() | average_x()'
+api_name: average() | average_y() | average_x()
 excerpt: Calculate the average of values in a statistical aggregate
-license: community
-toolkit: true
-experimental: false
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [average, statistics, statistical aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 1D
+  aggregates:
+    - stats_agg()
+# fields below this will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-1d
@@ -19,16 +25,18 @@ hyperfunction_type: accessor-1d
 ```SQL
 average(summary StatsSummary1D) RETURNS BIGINT
 ```
+
 ```SQL
 average_y(summary StatsSummary2D) RETURNS BIGINT
 ```
+
 ```SQL
 average_x(summary StatsSummary2D) RETURNS BIGINT
 ```
 
 Get the average of the values contained in a statistical aggregate.
-In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x` form to access the 
-average of the dependent and independent variables. 
+In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x` form to access the
+average of the dependent and independent variables.
 
 For more information about statistical aggregate functions, see the
 [hyperfunctions documentation][hyperfunctions-stats-agg].
@@ -51,12 +59,12 @@ For more information about statistical aggregate functions, see the
 SELECT average(stats_agg(data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  average
 -----------
        50
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/average-time-weight.md
+++ b/api/average-time-weight.md
@@ -1,14 +1,20 @@
 ---
 api_name: average()
 excerpt: Calculate the time-weighted average of values in a `TimeWeightSummary`
-license: community
-toolkit: true
-experimental: false
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [average, time-weighted, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: time-weighted averages
+  type: accessor
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'time-weighted averages'
 hyperfunction_subfamily: 'time-weighted averages'
 hyperfunction_type: accessor
@@ -55,7 +61,6 @@ FROM (
     GROUP BY id
 ) t
 ```
-
 
 [hyperfunctions-time-weight-average]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/time-weighted-averages/
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/

--- a/api/chunk_compression_stats.md
+++ b/api/chunk_compression_stats.md
@@ -1,21 +1,23 @@
 ---
 api_name: chunk_compression_stats()
 excerpt: Get compression-related statistics for chunks
-license: community
-topic: compression
+topics: [compression]
 keywords: [compression, statistics, chunks, information]
 tags: [disk space, schemas, size]
+api:
+  license: community
+  type: function
 ---
 
-## chunk_compression_stats() <tag type="community">Community</tag> 
+## chunk_compression_stats() <tag type="community">Community</tag>
 
 Get chunk-specific statistics related to hypertable compression.
 All sizes are in bytes.
 
-This view shows the cached size of chunks. The cached sizes are computed 
-when `compress_chunk` is executed, or when a compression policy touches 
-the chunk. An insert into a compressed chunk does not update the cached 
-sizes. For more information about how to compute exact sizes, rather than 
+This view shows the cached size of chunks. The cached sizes are computed
+when `compress_chunk` is executed, or when a compression policy touches
+the chunk. An insert into a compressed chunk does not update the cached
+sizes. For more information about how to compute exact sizes, rather than
 cached sizes, see the `chunks_detailed_size` section.
 
 ### Required arguments
@@ -24,7 +26,8 @@ cached sizes, see the `chunks_detailed_size` section.
 |---|---|---|
 | `hypertable` | REGCLASS | Name of the hypertable |
 
-### Returns 
+### Returns
+
 |Column|Type|Description|
 |---|---|---|
 |`chunk_schema` | TEXT | Schema name of the chunk |
@@ -40,7 +43,8 @@ cached sizes, see the `chunks_detailed_size` section.
 |`after_compression_total_bytes` | BIGINT | Size of the entire chunk table (table+indexes+toast) after compression (NULL if currently uncompressed) |
 |`node_name` | TEXT | nodes on which the chunk is located, applicable only to distributed hypertables |
 
-### Sample usage 
+### Sample usage
+
 ```sql
 SELECT * FROM chunk_compression_stats('conditions')
   ORDER BY chunk_name LIMIT 2;
@@ -74,6 +78,7 @@ node_name                      |
 ```
 
 Use `pg_size_pretty` get the output in a more human friendly format.
+
 ```sql
 SELECT pg_size_pretty(after_compression_total_bytes) AS total
   FROM chunk_compression_stats('conditions')

--- a/api/chunks.md
+++ b/api/chunks.md
@@ -1,10 +1,12 @@
 ---
 api_name: timescaledb_information.chunks
 excerpt: Get metadata about hypertable chunks
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [chunks, hypertables, information]
 tags: [schemas, tablespaces, data nodes, time ranges]
+api:
+  license: apache
+  type: view
 ---
 
 ## timescaledb_information.chunks

--- a/api/chunks_detailed_size.md
+++ b/api/chunks_detailed_size.md
@@ -1,13 +1,15 @@
 ---
-api_name: chunks_detailed_size
+api_name: chunks_detailed_size()
 excerpt: Get detailed information about disk space used by chunks
-license: community
-topic: hypertables
+topics: [hypertables]
 keywords: [chunks, hypertables, size, information]
 tags: [disk space, schemas]
+api:
+  license: community
+  type: function
 ---
 
-## chunks_detailed_size()   
+## chunks_detailed_size()
 
 Get information about the disk space used by the chunks belonging to a
 hypertable, returning size information for each chunk table, any
@@ -18,7 +20,7 @@ If the function is executed on a distributed hypertable, it returns
 disk space usage information as a separate row per node. The access
 node is not included since it doesn't have any local chunk data.
 
-Additional metadata associated with a chunk can be accessed 
+Additional metadata associated with a chunk can be accessed
 via the `timescaledb_information.chunks` view.
 
 ### Required arguments
@@ -27,7 +29,8 @@ via the `timescaledb_information.chunks` view.
 |---|---|---|
 | `hypertable` | REGCLASS | Name of the hypertable |
 
-### Returns 
+### Returns
+
 |Column|Type|Description|
 |---|---|---|
 |chunk_schema| TEXT | Schema name of the chunk |
@@ -43,7 +46,8 @@ If executed on a relation that is not a hypertable, the function
 returns `NULL`.
 </highlight>
 
-### Sample usage 
+### Sample usage
+
 ```sql
 SELECT * FROM chunks_detailed_size('dist_table')
   ORDER BY chunk_name, node_name;
@@ -54,4 +58,3 @@ SELECT * FROM chunks_detailed_size('dist_table')
  _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
  _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | data_node_3
 ```
-

--- a/api/cleanup_copy_chunk_operation_experimental.md
+++ b/api/cleanup_copy_chunk_operation_experimental.md
@@ -1,17 +1,20 @@
 ---
 api_name: cleanup_copy_chunk_operation()
 excerpt: Clean up after a failed chunk move or chunk copy operation
-license: community
-topic: multi-node
+topics: [multi-node, distributed hypertables]
 keywords: [chunks, multi-node, distributed hypertables, move, copy]
+api:
+  license: community
+  type: function
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 ## cleanup_copy_chunk_operation() <tag type="community">Community</tag> <tag type="experimental">Experimental</tag>
+
 You can [copy][copy_chunk] or [move][move_chunk] a
 chunk to a new location within a multi-node environment. The
-operation happens over multiple transactions so, if it fails, it 
+operation happens over multiple transactions so, if it fails, it
 is manually cleaned up using this function. Without cleanup,
 the failed operation might hold a replication slot open, which in turn
 prevents storage from being reclaimed. The operation ID is logged in
@@ -40,7 +43,5 @@ Get a list of running copy or move operations:
 SELECT * FROM _timescaledb_catalog.chunk_copy_operation;
 ```
 
-
 [copy_chunk]: /api/:currentVersion:/distributed-hypertables/copy_chunk_experimental
 [move_chunk]: /api/:currentVersion:/distributed-hypertables/move_chunk_experimental
-

--- a/api/compress_chunk.md
+++ b/api/compress_chunk.md
@@ -1,10 +1,12 @@
 ---
 api_name: compress_chunk()
 excerpt: Manually compress a given chunk
-license: community
-topic: compression
+topics: [compression]
 keywords: [compression]
 tags: [chunks]
+api:
+  license: community
+  type: function
 ---
 
 ## compress_chunk() <tag type="community">Community</tag>
@@ -26,7 +28,6 @@ You can get a list of chunks belonging to a hypertable using the
 |---|---|---|
 | `chunk_name` | REGCLASS | Name of the chunk to be compressed|
 
-
 ### Optional arguments
 
 |Name|Type|Description|
@@ -39,8 +40,8 @@ You can get a list of chunks belonging to a hypertable using the
 |---|---|
 | `compress_chunk` | (REGCLASS) Name of the chunk that was compressed|
 
-
 ### Sample usage
+
 Compress a single chunk.
 
 ``` sql

--- a/api/compression_settings.md
+++ b/api/compression_settings.md
@@ -1,19 +1,21 @@
 ---
 api_name: timescaledb_information.compression_settings
 excerpt: Get information about compression settings for hypertables
-license: community
-topic: compression
+topics: [compression]
 keywords: [compression]
 tags: [informational, settings, hypertables, schemas, indexes]
+api:
+  license: community
+  type: view
 ---
 
-## timescaledb_information.compression_settings 
+## timescaledb_information.compression_settings
 
 Get information about compression-related settings for hypertables.
 Each row of the view provides information about individual orderby
 and segmentby columns used by compression.
 
-### Available columns 
+### Available columns
 
 |Name|Type|Description|
 |---|---|---|
@@ -25,8 +27,7 @@ and segmentby columns used by compression.
 | `orderby_asc` | BOOLEAN | True if this is used for order by ASC, False for order by DESC |
 | `orderby_nullsfirst` | BOOLEAN | True if nulls are ordered first for this column, False if nulls are ordered last|
 
-
-### Sample usage 
+### Sample usage
 
 ```sql
 CREATE TABLE hypertab (a_col integer, b_col integer, c_col integer, d_col integer, e_col integer);

--- a/api/continuous_aggregates.md
+++ b/api/continuous_aggregates.md
@@ -1,10 +1,12 @@
 ---
 api_name: timescaledb_information.continuous_aggregates
 excerpt: Get metadata and settings information for continuous aggregates
-license: community
-topic: continuous aggregates
+topics: [continuous aggregates]
 keywords: [continuous aggregates]
 tags: [information, schemas, metadata, definition]
+api:
+  license: community
+  type: view
 ---
 
 ## timescaledb_information.continuous_aggregates

--- a/api/copy_chunk_experimental.md
+++ b/api/copy_chunk_experimental.md
@@ -1,16 +1,19 @@
 ---
 api_name: copy_chunk()
 excerpt: Copy a chunk between data nodes in a distributed hypertable
-license: community
-experimental: true
-topic: multi-node
+topics: [multi-node, distributed hypertables]
 keywords: [multi-node, distributed hypertables]
 tags: [data nodes, chunks, copy]
+api:
+  license: community
+  type: function
+  experimental: true
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 ## copy_chunk() <tag type="community">Community</tag> <tag type="experimental">Experimental</tag>
+
 TimescaleDB allows you to copy existing chunks to a new location within a
 multi-node environment. This allows each data node to work both as a primary for
 some chunks and backup for others. If a data node fails, its chunks already
@@ -27,6 +30,7 @@ exist on other nodes that can take over the responsibility of serving them.
 |`destination_node`|NAME|Data node where the chunk is to be copied|
 
 ### Required settings
+
 When copying a chunk, the destination data node needs a way to
 authenticate with the data node that holds the source chunk. It is
 currently recommended to use a [password file][password-config] on the
@@ -38,11 +42,11 @@ many chunks in parallel, you can increase `max_wal_senders` and
 `max_replication_slots`.
 
 ### Failures
-When a copy operation fails, it sometimes creates objects and metadata on 
+
+When a copy operation fails, it sometimes creates objects and metadata on
 the destination data node. It can also hold a replication slot open on the
 source data node. To clean up these objects and metadata, use
 [`cleanup_copy_chunk_operation`][cleanup_copy_chunk].
-
 
 ### Sample usage
 

--- a/api/corr-counter.md
+++ b/api/corr-counter.md
@@ -1,19 +1,28 @@
 ---
 api_name: corr()
 excerpt: Calculate the correlation coefficient from values in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [correlation coefficient, counters, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # corr() <tag type="toolkit" content="Toolkit" />
+
 The correlation coefficient of the least squares fit line of the adjusted
 counter value and epoch value of the time column. Given that the slope of a line for any counter value must be
 non-negative, this must also always be non-negative and in the range from 0.0 to
@@ -58,6 +67,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/corr-stats.md
+++ b/api/corr-stats.md
@@ -1,13 +1,20 @@
 ---
 api_name: corr()
 excerpt: Calculate the correlation coefficient from values in a 2-dimensional `StatsSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [correlation coefficient, statistics, statistical aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 2D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-2d
@@ -20,8 +27,9 @@ corr(
     summary StatsSummary2D
 ) RETURNS DOUBLE PRECISION
 ```
-The correlation coefficient of the [least squares fit][least-squares] line 
-computed from a two-dimensional statistical aggregate. 
+
+The correlation coefficient of the [least squares fit][least-squares] line
+computed from a two-dimensional statistical aggregate.
 
 For more information about statistical aggregate functions, see the
 [hyperfunctions documentation][hyperfunctions-stats-agg].
@@ -48,7 +56,6 @@ SELECT
 FROM foo
 GROUP BY id, time_bucket('15 min'::interval, ts)
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/count_min_sketch.md
+++ b/api/count_min_sketch.md
@@ -1,13 +1,20 @@
 ---
 api_name: count_min_sketch()
 excerpt: Aggregate data in a `count_min_sketch` for calculation of estimates
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, frequency, count min sketch]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: CountMinSketch
 hyperfunction_type: aggregate
@@ -16,6 +23,7 @@ hyperfunction_type: aggregate
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # count_min_sketch() <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+
 Produces a [Count-Min Sketch][count-min-sketch] in the form of an aggregate that can be passed to the [`approx_count` function][approx-count] to estimate how many times a particular value has appeared in a column.
 
 ```sql
@@ -35,7 +43,6 @@ count_min_sketch(
 |`values`|`TEXT`|Column to aggregate|
 |`error`|`DOUBLE PRECISION`|Error tolerance in estimate, calculated relative to the number of values added to the sketch|
 |`probability`|`DOUBLE PRECISION`|Probability that an estimate falls outside the error bounds|
-
 
 ## Returns
 

--- a/api/counter_agg_point.md
+++ b/api/counter_agg_point.md
@@ -1,19 +1,25 @@
 ---
 api_name: counter_agg()
 excerpt: Aggregate counter data into a `CounterSummary` for further analysis
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, aggregates, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: aggregate
 ---
 
 # counter_agg() <tag type="toolkit" content="Toolkit" />
+
 An aggregate that produces a CounterSummary from timestamps and associated
 values.
 
@@ -59,6 +65,7 @@ extrapolation, but not for other accessor functions.
 <!---Any special notes about the returns-->
 
 ## Sample usage
+
 This example produces a CounterSummary from timestamps and associated values,
 then computes the [`irate_right`][irate] accessor:
 
@@ -76,7 +83,6 @@ SELECT
     irate_right(cs) -- extract instantaneous rate from the CounterSummary
 FROM t;
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/
 [irate]: /api/:currentVersion:/hyperfunctions/counter_aggs/irate/

--- a/api/counter_zero_time.md
+++ b/api/counter_zero_time.md
@@ -1,20 +1,28 @@
 ---
 api_name: counter_zero_time()
 excerpt: Predict the time when a counter was at zero
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [least squares, regression, extrapolate]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # counter_zero_time() <tag type="toolkit" content="Toolkit" />
+
 The time at which the counter value is predicted to have been zero based on the
 least squares fit line computed from the points in the CounterSummary.
 

--- a/api/covariance.md
+++ b/api/covariance.md
@@ -1,13 +1,20 @@
 ---
 api_name: covariance()
 excerpt: Calculate the covariance from values in a 2-dimensional `StatsSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [covariance, statistics, statistical aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 2D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-2d
@@ -21,10 +28,11 @@ covariance(
     method TEXT 
 ) RETURNS DOUBLE PRECISION
 ```
-The covariance of the [least squares fit][least-squares] line 
-computed from a two-dimensional statistical aggregate. 
 
-The `method` determines whether you calculate a 'population' or 'sample' covariance. 
+The covariance of the [least squares fit][least-squares] line
+computed from a two-dimensional statistical aggregate.
+
+The `method` determines whether you calculate a 'population' or 'sample' covariance.
 These values can be provided as their full names, or you can abbreviate them as `pop` or `samp`. These
 are the only four accepted values for the `method` argument. The default is `sample`.
 
@@ -59,7 +67,6 @@ SELECT
 FROM foo
 GROUP BY id, time_bucket('15 min'::interval, ts)
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/create_distributed_hypertable.md
+++ b/api/create_distributed_hypertable.md
@@ -1,10 +1,12 @@
 ---
 api_name: create_distributed_hypertable()
 excerpt: Create a distributed hypertable in a multi-node cluster
-license: community
-topic: distributed hypertables
+topics: [distributed hypertables]
 keywords: [distributed hypertables, multi-node, create]
 tags: [cluster]
+api:
+  license: community
+  type: function
 ---
 
 ## create_distributed_hypertable()  <tag type="community">Community</tag>
@@ -53,11 +55,13 @@ nodes by the 'location' column. Note that the number of space
 partitions is automatically equal to the number of data nodes assigned
 to this hypertable (all configured data nodes in this case, as
 `data_nodes` is not specified).
+
 ```sql
 SELECT create_distributed_hypertable('conditions', 'time', 'location');
 ```
 
 Create a table `conditions` using a specific set of data nodes.
+
 ```sql
 SELECT create_distributed_hypertable('conditions', 'time', 'location',
     data_nodes => '{ "data_node_1", "data_node_2", "data_node_4", "data_node_7" }');
@@ -84,7 +88,7 @@ a larger time interval.
 For example, assume you are ingesting 10&nbsp;GB of data per day and you
 have five data nodes, each with 64&nbsp;GB of memory. If this is the only
 table being served by these data nodes, then you should use a time
-interval of 1 week (7 * 10&nbsp;GB / 5 * 64&nbsp;GB ~= 22% main memory used for
+interval of 1 week (`7 * 10 GB / 5 * 64 GB ~= 22% main memory` used for
 most recent chunks).
 
 If space partitioning is not being used, the `chunk_time_interval`

--- a/api/create_distributed_restore_point.md
+++ b/api/create_distributed_restore_point.md
@@ -1,13 +1,16 @@
 ---
 api_name: create_distributed_restore_point()
 excerpt: Create a consistent restore point for all nodes in a multi-node cluster
-license: community
-topic: distributed hypertables
+topics: [multi-node]
 keywords: [distributed hypertables, restore, backup, multi-node]
 tags: [clusters, write-ahead logs, recovery]
+api:
+  license: community
+  type: function
 ---
 
 # create_distributed_restore_point()
+
 Creates a same-named marker record, for example `restore point`, in the
 write-ahead logs of all nodes in a multi-node TimescaleDB cluster.
 
@@ -40,6 +43,7 @@ privileges.
 ### Errors
 
 An error is given if:
+
 *   The restore point `name` is more than 64 characters
 *   A recovery is in progress
 *   The current WAL level is not set to `replica` or `logical`
@@ -48,8 +52,10 @@ An error is given if:
 *   TimescaleDB's 2PC transactions are not enabled
 
 ## Sample usage
+
 This example create a restore point called `pitr` across three data nodes and
 the access node:
+
 ```sql
 SELECT * FROM create_distributed_restore_point('pitr');
  node_name |  node_type  | restore_point
@@ -60,7 +66,6 @@ SELECT * FROM create_distributed_restore_point('pitr');
  dn3       | data_node   | 0/3694B68
 (4 rows)
 ```
-
 
 [pg-create-restore-point]: https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-BACKUP-TABLE
 [pg-lsn]: https://www.postgresql.org/docs/current/datatype-pg-lsn.html

--- a/api/create_hypertable.md
+++ b/api/create_hypertable.md
@@ -1,9 +1,11 @@
 ---
 api_name: create_hypertable()
 excerpt: Create a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables, create]
+api:
+  license: apache
+  type: function
 ---
 
 # create_hypertable()
@@ -55,6 +57,7 @@ still work on the resulting hypertable.
 
 <highlight type="tip">
  If you use `SELECT * FROM create_hypertable(...)` you get the return value formatted as a table with column headings.
+
 </highlight>
 
 <highlight type="warning">
@@ -89,23 +92,25 @@ The 'time' column supports the following data types:
 |DATE|
 |Integer (SMALLINT, INT, BIGINT)|
 
-<highlight type="tip"> The type flexibility of the 'time' column allows the use
+<highlight type="tip">
+ The type flexibility of the 'time' column allows the use
 of non-time-based values as the primary chunk partitioning column, as long as
 those values can increment.
 </highlight>
 
-<highlight type="tip"> For incompatible data types (for example, `jsonb`) you can
+<highlight type="tip">
+ For incompatible data types (for example, `jsonb`) you can
 specify a function to the `time_partitioning_func` argument which can extract
 a compatible data type
 </highlight>
 
 The units of `chunk_time_interval` should be set as follows:
 
-- For time columns having timestamp or DATE types, the
+*   For time columns having timestamp or DATE types, the
 `chunk_time_interval` should be specified either as an `interval` type
 or an integral value in *microseconds*.
 
-- For integer types, the `chunk_time_interval` **must** be set
+*   For integer types, the `chunk_time_interval` **must** be set
 explicitly, as the database does not otherwise understand the
 semantics of what each integer value represents (a second,
 millisecond, nanosecond, etc.).  So if your time column is the number
@@ -121,25 +126,27 @@ exists. Thus, a custom partitioning function can be used for value
 types that do not have a native PostgreSQL hash function. A
 partitioning function should take a single `anyelement` type argument
 and return a positive `integer` hash value. Note that this hash value
-is _not_ a partition ID, but rather the inserted value's position in
+is *not* a partition ID, but rather the inserted value's position in
 the dimension's key space, which is then divided across the partitions.
-
 
 <highlight type="tip">
  The time column in `create_hypertable` must be defined as `NOT
  NULL`.  If this is not already specified on table creation,
  `create_hypertable` automatically adds this constraint on the
  table when it is executed.
+
 </highlight>
 
 ### Sample usage
 
 Convert table `conditions` to hypertable with just time partitioning on column `time`:
+
 ```sql
 SELECT create_hypertable('conditions', 'time');
 ```
 
 Convert table `conditions` to hypertable, setting `chunk_time_interval` to 24 hours.
+
 ```sql
 SELECT create_hypertable('conditions', 'time', chunk_time_interval => 86400000000);
 SELECT create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '1 day');
@@ -147,6 +154,7 @@ SELECT create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '
 
 Convert table `conditions` to hypertable with time partitioning on `time` and
 space partitioning (4 partitions) on `location`:
+
 ```sql
 SELECT create_hypertable('conditions', 'time', 'location', 4);
 ```
@@ -159,12 +167,14 @@ SELECT create_hypertable('conditions', 'time', 'location', 4, partitioning_func 
 
 Convert table `conditions` to hypertable. Do not raise a warning
 if `conditions` is already a hypertable:
+
 ```sql
 SELECT create_hypertable('conditions', 'time', if_not_exists => TRUE);
 ```
 
 Time partition table `measurements` on a composite column type `report` using a time partitioning function:
 Requires an immutable function that can convert the column value into a supported column value:
+
 ```sql
 CREATE TYPE report AS (reported timestamp with time zone, contents jsonb);
 
@@ -179,6 +189,7 @@ SELECT create_hypertable('measurements', 'report', time_partitioning_func => 're
 
 Time partition table `events`, on a column type `jsonb` (`event`), which has
 a top level key (`started`) containing an ISO 8601 formatted timestamp:
+
 ```sql
 CREATE FUNCTION event_started(jsonb)
   RETURNS timestamptz
@@ -188,7 +199,6 @@ CREATE FUNCTION event_started(jsonb)
 
 SELECT create_hypertable('events', 'event', time_partitioning_func => 'event_started');
 ```
-
 
 #### Best Practices
 

--- a/api/create_index.md
+++ b/api/create_index.md
@@ -1,9 +1,11 @@
 ---
 api_name: CREATE INDEX (Transaction Per Chunk)
 excerpt: Create a hypertable index using a separate transaction for each chunk
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables, indexes, chunks, create]
+api:
+  license: apache
+  type: command
 ---
 
 ## CREATE INDEX (Transaction Per Chunk)
@@ -22,26 +24,29 @@ if a regular `CREATE INDEX` were called on that chunk, however other chunks are
 completely un-blocked.
 
 <highlight type="tip">
-	This version of `CREATE INDEX` can be used as an alternative to
-	`CREATE INDEX CONCURRENTLY`, which is not currently supported on hypertables.
+ This version of `CREATE INDEX` can be used as an alternative to
+ `CREATE INDEX CONCURRENTLY`, which is not currently supported on hypertables.
+
 </highlight>
 
 <highlight type="warning">
 If the operation fails partway through, indexes may not be created on all
 hypertable chunks. If this occurs, the index on the root table of the hypertable
 is marked as invalid (this can be seen by running `\d+` on the hypertable).
-The index still works, and is created on new chunks, but if you 
+The index still works, and is created on new chunks, but if you
 wish to ensure _all_ chunks have a copy of the index, drop and recreate it.
 </highlight>
-
 
 ### Sample usage
 
 Anonymous index
+
 ```SQL
 CREATE INDEX ON conditions(time, device_id) WITH (timescaledb.transaction_per_chunk);
 ```
+
 Other index methods
+
 ```SQL
 CREATE INDEX ON conditions USING brin(time, location)
   WITH (timescaledb.transaction_per_chunk);

--- a/api/create_materialized_view.md
+++ b/api/create_materialized_view.md
@@ -1,17 +1,21 @@
 ---
 api_name: CREATE MATERIALIZED VIEW (Continuous Aggregate)
 excerpt: Create a continuous aggregate on a hypertable
-license: community
-topic: continuous aggregates
+topics: [continuous aggregates]
 keywords: [continuous aggregates, create]
 tags: [materialized view, hypertables]
+api:
+  license: community
+  type: command
 ---
 
 ## CREATE MATERIALIZED VIEW (Continuous Aggregate) <tag type="community">Community</tag>
+
 The `CREATE MATERIALIZED VIEW` statement is used to create continuous
 aggregates.
 
 The syntax is:
+
 ``` sql
 CREATE MATERIALIZED VIEW <view_name> [ ( column_name [, ...] ) ]
   WITH ( timescaledb.continuous [, timescaledb.<option> = <value> ] )
@@ -46,6 +50,7 @@ supported. The `GROUP BY` clause must include a time bucket on the hypertable
 time column, and all aggregates must be parallelizable.
 
 Some important things to remember when constructing your `SELECT` query:
+
 *   Only a single hypertable can be specified in the `FROM` clause of
     the `SELECT` query. You cannot include more hypertables, joins, tables,
     views, or subqueries.
@@ -69,8 +74,8 @@ Some important things to remember when constructing your `SELECT` query:
 The settings for continuous aggregates are in the
 [informational views][info-views].
 
-
 ### Parameters
+
 |Name|Type|Description|
 |-|-|-|
 |`<view_name>`|TEXT|Name (optionally schema-qualified) of continuous aggregate view to create|
@@ -95,7 +100,9 @@ Optional `WITH` clause options:
 For more information, see the [real-time aggregates][real-time-aggregates] section.
 
 ### Sample usage
+
 Create a daily continuous aggregate view:
+
 ```sql
 CREATE MATERIALIZED VIEW continuous_aggregate_daily( timec, minl, sumt, sumh )
 WITH (timescaledb.continuous) AS
@@ -105,6 +112,7 @@ WITH (timescaledb.continuous) AS
 ```
 
 Add a thirty day continuous aggregate on top of the same raw hypertable:
+
 ```sql
 CREATE MATERIALIZED VIEW continuous_aggregate_thirty_day( timec, minl, sumt, sumh )
 WITH (timescaledb.continuous) AS
@@ -114,6 +122,7 @@ WITH (timescaledb.continuous) AS
 ```
 
 Add an hourly continuous aggregate on top of the same raw hypertable:
+
 ```sql
 CREATE MATERIALIZED VIEW continuous_aggregate_hourly( timec, minl, sumt, sumh )
 WITH (timescaledb.continuous) AS

--- a/api/data_nodes.md
+++ b/api/data_nodes.md
@@ -1,13 +1,15 @@
 ---
 api_name: timescaledb_information.data_nodes
 excerpt: Get information on data nodes in a multi-node cluster
-license: community
-topic: multi-node
+topics: [multi-node]
 keywords: [multi-node, information]
 tags: [data nodes, cluster]
+api:
+  license: community
+  type: view
 ---
 
-# timescaledb_information.data_nodes 
+# timescaledb_information.data_nodes
 
 Get information on data nodes. This function is specific to running
 TimescaleDB in a multi-node setup.
@@ -34,11 +36,11 @@ SELECT * FROM timescaledb_information.data_nodes;
 (2 rows)
 ```
 
-## timescaledb_information.hypertables 
+## timescaledb_information.hypertables
 
 Get metadata information about hypertables.
 
-### Available columns 
+### Available columns
 
 |Name|Type|Description|
 |---|---|---|
@@ -53,7 +55,7 @@ Get metadata information about hypertables.
 | `data_nodes` | ARRAY | Nodes on which hypertable is distributed|
 | `tablespaces` | ARRAY | Tablespaces attached to the hypertable |
 
-### Sample usage 
+### Sample usage
 
 Get information about a hypertable.
 

--- a/api/decompress_chunk.md
+++ b/api/decompress_chunk.md
@@ -1,12 +1,15 @@
 ---
 api_name: decompress_chunk()
 excerpt: Decompress a compressed chunk
-license: community
-topic: compression
+topics: [compression]
 keywords: [compression, decompression, chunks]
+api:
+  license: community
+  type: function
 ---
 
 ## decompress_chunk() <tag type="community">Community</tag>
+
 If you need to modify or add data to a chunk that has already been
 compressed, you need to decompress the chunk first. This is especially
 useful for backfilling old data.
@@ -19,6 +22,7 @@ chunks in the next scheduled job.
 </highlight>
 
 ### Required arguments
+
 |Name|Type|Description|
 |-|-|-|
 |`chunk_name`|`REGCLASS`|Name of the chunk to be decompressed.|
@@ -30,12 +34,15 @@ chunks in the next scheduled job.
 |`if_compressed`|`BOOLEAN`|Setting to true skips chunks that are not compressed. Defaults to false.|
 
 ### Sample usage
+
 Decompress a single chunk:
+
 ``` sql
 SELECT decompress_chunk('_timescaledb_internal._hyper_2_2_chunk');
 ```
 
 Decompress all compressed chunks in a hypertable named `metrics`:
+
 ```sql
 SELECT decompress_chunk(c, true) FROM show_chunks('metrics') c;
 ```

--- a/api/delete_data_node.md
+++ b/api/delete_data_node.md
@@ -1,10 +1,12 @@
 ---
 api_name: delete_data_node()
 excerpt: Remove a data node from a database and detach it from all hypertables
-license: community
-topic: multi-node
+topics: [multi-node]
 keywords: [multi-node]
 tags: [distributed hypertables, data nodes, detach, delete]
+api:
+  license: community
+  type: function
 ---
 
 ## delete_data_node() <tag type="community">Community</tag>
@@ -57,6 +59,7 @@ A boolean indicating if the operation was successful or not.
 ### Sample usage
 
 To delete a data node named `dn1`:
+
 ```sql
 SELECT delete_data_node('dn1');
 ```

--- a/api/delete_job.md
+++ b/api/delete_job.md
@@ -1,10 +1,12 @@
 ---
 api_name: delete_job()
 excerpt: Delete a job from the automatic scheduler
-license: community
-topic: jobs
+topics: [jobs]
 keywords: [jobs, delete]
 tags: [background jobs, scheduled jobs, user-defined actions, automation framework]
+api:
+  license: community
+  type: function
 ---
 
 ## delete_job() <tag type="community">Community</tag>
@@ -21,7 +23,9 @@ If the job is currently running, the process is terminated.
 |`job_id`| INTEGER |  TimescaleDB background job id |
 
 ### Sample usage
+
 Delete the job with the job id 1000:
+
 ```sql
 SELECT delete_job(1000);
 ```

--- a/api/delta.md
+++ b/api/delta.md
@@ -1,21 +1,29 @@
 ---
 api_name: delta()
 excerpt: Calculate the change in a counter from values in a `CounterSummary`
-license: community
-toolkit: true
-experimental: false
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [delta]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # delta() <tag type="toolkit" content="Toolkit" />
+
 The change in the counter over the time period. This is the raw or simple delta
 computed by accounting for resets and subtracting the last seen value from the
 first.

--- a/api/detach_data_node.md
+++ b/api/detach_data_node.md
@@ -1,10 +1,12 @@
 ---
 api_name: detach_data_node()
 excerpt: Detach a data node from one or all hypertables
-license: community
-topic: multi-node
+topics: [multi-node]
 keywords: [multi-node, detach]
 tags: [distributed hypertables, cluster, data nodes]
+api:
+  license: community
+  type: function
 ---
 
 ## detach_data_node() <tag type="community">Community</tag>
@@ -13,9 +15,9 @@ Detach a data node from one hypertable or from all hypertables.
 
 Reasons for detaching a data node include:
 
-- A data node should no longer be used by a hypertable and needs to be
+*   A data node should no longer be used by a hypertable and needs to be
 removed from all hypertables that use it
-- You want to have fewer data nodes for a distributed hypertable to
+*   You want to have fewer data nodes for a distributed hypertable to
 partition across
 
 ### Required arguments
@@ -40,9 +42,10 @@ The number of hypertables the data node was detached from.
 #### Errors
 
 Detaching a node is not permitted:
-- If it would result in data loss for the hypertable due to the data node
+
+*   If it would result in data loss for the hypertable due to the data node
 containing chunks that are not replicated on other data nodes
-- If it would result in under-replicated chunks for the distributed hypertable
+*   If it would result in under-replicated chunks for the distributed hypertable
 (without the `force` argument)
 
 <highlight type="tip">

--- a/api/detach_tablespace.md
+++ b/api/detach_tablespace.md
@@ -1,9 +1,11 @@
 ---
 api_name: detach_tablespace()
 excerpt: Detach a tablespace from a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [tablespaces, hypertables, data tiering, detach]
+api:
+  license: apache
+  type: function
 ---
 
 ## detach_tablespace()
@@ -32,14 +34,12 @@ appropriate permissions for. Therefore, without proper permissions,
 the tablespace may still receive new chunks after this command
 is issued.
 
-
 ### Optional arguments
 
 |Name|Type|Description|
 |---|---|---|
 | `hypertable` | REGCLASS | Hypertable to detach a the tablespace from.|
 | `if_attached` | BOOLEAN | Set to true to avoid throwing an error if the tablespace is not attached to the given table. A notice is issued instead. Defaults to false. |
-
 
 When specifying a specific hypertable, the tablespace is only
 detached from the given hypertable and thus may remain attached to

--- a/api/detach_tablespaces.md
+++ b/api/detach_tablespaces.md
@@ -1,9 +1,11 @@
 ---
 api_name: detach_tablespaces()
 excerpt: Detach all tablespaces from a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [tablespaces, hypertables, data tiering, detach]
+api:
+  license: apache
+  type: function
 ---
 
 ## detach_tablespaces()

--- a/api/determination_coeff.md
+++ b/api/determination_coeff.md
@@ -1,13 +1,20 @@
 ---
-api_name: determination_coeff
+api_name: determination_coeff()
 excerpt: Calculate the determination coefficient from values in a 2-dimensional statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [determination coefficient, statistics, statistical aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 2D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-2d
@@ -20,8 +27,9 @@ determination_coeff(
     summary StatsSummary2D
 ) RETURNS DOUBLE PRECISION
 ```
-The coefficient of determination (or the R squared) of the least squares fit line 
-computed from a two-dimensional statistical aggregate. 
+
+The coefficient of determination (or the R squared) of the least squares fit line
+computed from a two-dimensional statistical aggregate.
 
 For more information about statistical aggregate functions, see the
 [hyperfunctions documentation][hyperfunctions-stats-agg].
@@ -48,7 +56,6 @@ SELECT
 FROM foo
 GROUP BY id, time_bucket('15 min'::interval, ts)
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/dimensions.md
+++ b/api/dimensions.md
@@ -1,17 +1,19 @@
 ---
 api_name: timescaledb_information.dimensions
 excerpt: Get information on the dimensions of hypertables
-license: community
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables, information]
 tags: [dimensions, partitions]
+api:
+  license: community
+  type: view
 ---
 
 ## timescaledb_information.dimensions
 
 Get metadata about the dimensions of hypertables, returning one row of metadata
 for each dimension of a hypertable. For a time-and-space-partitioned
-hypertable, for example, two rows of metadata are returned for the 
+hypertable, for example, two rows of metadata are returned for the
 hypertable.
 
 A time-based dimension column has either an integer datatype
@@ -77,6 +79,7 @@ num_partitions    | 2
 ```
 
 Get information about dimensions of a hypertable that has two time-based dimensions.
+
 ``` sql
 CREATE TABLE hyper_2dim (a_col date, b_col timestamp, c_col integer);
 SELECT table_name from create_hypertable('hyper_2dim', 'a_col');

--- a/api/distinct_count.md
+++ b/api/distinct_count.md
@@ -1,20 +1,29 @@
 ---
 api_name: distinct_count()
 excerpt: Estimate the number of distinct values from values in a hyperloglog
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [count, hyperfunctions, toolkit]
 tags: [approximate, distinct, hyperloglog]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: approximate count distinct
+  type: accessor
+  aggregates:
+    - approx_count_distinct()
+    - hyperloglog()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'approximate count distinct'
 hyperfunction_subfamily: hyperloglog
 hyperfunction_type: accessor
 ---
 
 # distinct_count()  <tag type="toolkit">Toolkit</tag>
+
 The `distinct_count` function gets the number of distinct values from a
 hyperloglog.
 
@@ -34,6 +43,7 @@ For more information about approximate count distinct functions, see the
 |distinct_count|BIGINT|The number of distinct elements counted by the hyperloglog.|
 
 ## Sample usage
+
 This example retrieves the distinct values from a hyperloglog
 called `hyperloglog`:
 
@@ -45,6 +55,5 @@ FROM generate_series(1, 100000) data
 ----------------
          100151
 ```
-
 
 [hyperfunctions-approx-count-distincts]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/approx-count-distincts/

--- a/api/distributed_exec.md
+++ b/api/distributed_exec.md
@@ -1,10 +1,12 @@
 ---
 api_name: distributed_exec()
 excerpt: Execute a procedure across all the data nodes of a multi-node cluster
-license: community
-topic: multi-node
+topics: [multi-node]
 keywords: [multi-node]
 tags: [data nodes, cluster, procedure, roles, permissions]
+api:
+  license: community
+  type: procedure
 ---
 
 ## distributed_exec() <tag type="community">Community</tag>

--- a/api/drop_chunks.md
+++ b/api/drop_chunks.md
@@ -1,10 +1,12 @@
 ---
 api_name: drop_chunks()
 excerpt: Delete chunks by time range
-license: apache
-topic: data retention
+topics: [data retention]
 keywords: [data retention, chunks, delete]
 tags: [drop]
+api:
+  license: apache
+  type: function
 ---
 
 ## drop_chunks()
@@ -42,16 +44,15 @@ based on a space partition.
 
 The `older_than` and `newer_than` parameters can be specified in two ways:
 
-- **interval type:** The cut-off point is computed as `now() -
+*   **interval type:** The cut-off point is computed as `now() -
     older_than` and similarly `now() - newer_than`.  An error is
     returned if an INTERVAL is supplied and the time column is not one
     of a `TIMESTAMP`, `TIMESTAMPTZ`, or `DATE`.
 
-- **timestamp, date, or integer type:** The cut-off point is
+*   **timestamp, date, or integer type:** The cut-off point is
     explicitly given as a `TIMESTAMP` / `TIMESTAMPTZ` / `DATE` or as a
     `SMALLINT` / `INT` / `BIGINT`. The choice of timestamp or integer
     must follow the type of the hypertable's time column.
-
 
 <highlight type="warning">
 When using just an interval type, the function assumes that
@@ -68,6 +69,7 @@ intersection between two ranges results in an error.
 ### Sample usage
 
 Drop all chunks from hypertable `conditions` older than 3 months:
+
 ```sql
 SELECT drop_chunks('conditions', INTERVAL '3 months');
 ```
@@ -94,6 +96,7 @@ SELECT drop_chunks('conditions', newer_than => now() + interval '3 months');
 ```
 
 Drop all chunks from hypertable `conditions` before 2017:
+
 ```sql
 SELECT drop_chunks('conditions', '2017-01-01'::date);
 ```
@@ -106,11 +109,13 @@ SELECT drop_chunks('conditions', 1483228800000);
 ```
 
 Drop all chunks older than 3 months ago and newer than 4 months ago from hypertable `conditions`:
+
 ```sql
 SELECT drop_chunks('conditions', older_than => INTERVAL '3 months', newer_than => INTERVAL '4 months')
 ```
 
 Drop all chunks older than 3 months ago across all hypertables:
+
 ```sql
 SELECT drop_chunks(format('%I.%I', hypertable_schema, hypertable_name)::regclass, INTERVAL '3 months')
   FROM timescaledb_information.hypertables;

--- a/api/drop_materialized_view.md
+++ b/api/drop_materialized_view.md
@@ -1,13 +1,16 @@
 ---
 api_name: DROP MATERIALIZED VIEW (Continuous Aggregate)
 excerpt: Drop a continuous aggregate view
-license: community
-topic: continuous aggregates
+topics: [continuous aggregates]
 keywords: [continuous aggregates, delete]
 tags: [materialized views, drop]
+api:
+  license: community
+  type: command
 ---
 
-## DROP MATERIALIZED VIEW (Continuous Aggregate) <tag type="community">Community</tag> 
+## DROP MATERIALIZED VIEW (Continuous Aggregate) <tag type="community">Community</tag>
+
 Continuous aggregate views can be dropped using the `DROP MATERIALIZED VIEW` statement.
 
 This statement deletes the continuous aggregate and all its internal
@@ -21,12 +24,15 @@ derived.
 ``` sql
 DROP MATERIALIZED VIEW <view_name>;
 ```
+
 ### Parameters
+
 |Name|Type|Description|
 |---|---|---|
 | `<view_name>` | TEXT | Name (optionally schema-qualified) of continuous aggregate view to be dropped.|
 
-### Sample usage 
+### Sample usage
+
 Drop existing continuous aggregate.
 
 ```sql

--- a/api/dump_meta_data.md
+++ b/api/dump_meta_data.md
@@ -1,12 +1,14 @@
 ---
 api_name: dump_meta_data.sql
 excerpt: Output metadata for support requests and bug reports
-license: apache
-topic: admin
+topics: [administration]
 keywords: [admin, metadata]
+api:
+  license: apache
+  type: script
 ---
 
-## Dump TimescaleDB meta data 
+## Dump TimescaleDB meta data
 
 To help when asking for support and reporting bugs,
 TimescaleDB includes a SQL script that outputs metadata

--- a/api/duration_in.md
+++ b/api/duration_in.md
@@ -1,14 +1,22 @@
 ---
 api_name: duration_in()
 excerpt: Calculate the total time spent in a given state from values in a state aggregate
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [hyperfunctions, duration, states, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: accessor
+  aggregates:
+    - state_agg()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: StateAgg
 hyperfunction_type: accessor
@@ -17,6 +25,7 @@ hyperfunction_type: accessor
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # duration_in()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
 Use this function to report the total duration for a given state in a [state aggregate][state_agg].
 
 <Experimental />
@@ -35,7 +44,9 @@ Use this function to report the total duration for a given state in a [state agg
 |`duration_in`|`INTERVAL`|The total time spent in the target state. Displayed as `days`, `hh:mm:ss`, or a combination of the two.|
 
 ## Sample usage
+
 This example creates a simple test table:
+
 ```sql
 SET timezone TO 'UTC';
 CREATE TABLE states(time TIMESTAMPTZ, state TEXT);
@@ -49,6 +60,7 @@ INSERT INTO states VALUES
 ```
 
 You can query this table for the time spent in the running state, like this:
+
 ```sql
 SELECT toolkit_experimental.duration_in(
   'running',
@@ -57,6 +69,7 @@ SELECT toolkit_experimental.duration_in(
 ```
 
 Which gives the result:
+
 ```sql
 duration_in  
 ---------------

--- a/api/error.md
+++ b/api/error.md
@@ -1,14 +1,22 @@
 ---
 api_name: error()
 excerpt: Get the maximum relative error for a percentile estimate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [percentiles, hyperfunctions, toolkit]
 tags: [relative error]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: accessor
+  aggregates:
+    - percentile_agg()
+    - uddsketch()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: false
+toolkit: false
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'percentile approximation'
 hyperfunction_type: accessor
@@ -50,12 +58,12 @@ This function can only be used on estimators produced by
 SELECT error(percentile_agg(data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  error
 -------
  0.001
 ```
-
 
 [hyperfunctions-percentile-approx]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/
 [uddsketch]: /api/:currentVersion:/hyperfunctions/percentile-approximation/percentile-aggregation-methods/uddsketch/

--- a/api/extrapolated_delta.md
+++ b/api/extrapolated_delta.md
@@ -1,20 +1,29 @@
 ---
 api_name: extrapolated_delta()
 excerpt: Calculate the extrapolated change in a counter from values in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [change, extrapolate]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # extrapolated_delta() <tag type="toolkit" content="Toolkit" />
+
 The change in the counter during the time period specified by the bounds in the
 CounterSummary. To calculate the extrapolated delta, any counter resets are
 accounted for and the observed values are extrapolated to the bounds using the
@@ -70,6 +79,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/extrapolated_rate.md
+++ b/api/extrapolated_rate.md
@@ -1,20 +1,29 @@
 ---
 api_name: extrapolated_rate()
 excerpt: Calculate the extrapolated rate of change from values in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [rate, counters, hyperfunctions, toolkit]
 tags: [extrapolate]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # extrapolated_rate() <tag type="toolkit" content="Toolkit" />
+
 The rate of change in the counter computed over the time period specified by the
 bounds in the CounterSummary, extrapolating to the edges. It is an
 `extrapolated_delta` divided by the duration in seconds.

--- a/api/first.md
+++ b/api/first.md
@@ -1,9 +1,13 @@
 ---
 api_name: first()
 excerpt: Get the first value in one column when rows are ordered by another column
-license: apache
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [hyperfunctions]
+api:
+  license: apache
+  type: function
+hyperfunction:
+  type: one-step aggregate
 ---
 
 ## first()
@@ -22,6 +26,7 @@ earliest temperature value based on time within an aggregate group.
 ### Sample usage
 
 Get the earliest temperature by device_id:
+
 ```sql
 SELECT device_id, first(temp, time)
 FROM metrics
@@ -29,9 +34,9 @@ GROUP BY device_id;
 ```
 
 <highlight type="warning">
- The `last` and `first` commands do **not** use indexes, and instead
- perform a sequential scan through their groups. They are primarily used
- for ordered selection within a `GROUP BY` aggregate, and not as an
- alternative to an `ORDER BY time DESC LIMIT 1` clause to find the
- latest value (which uses indexes).
+The `last` and `first` commands do **not** use indexes, and instead
+perform a sequential scan through their groups. They are primarily used
+for ordered selection within a `GROUP BY` aggregate, and not as an
+alternative to an `ORDER BY time DESC LIMIT 1` clause to find the
+latest value (which uses indexes).
 </highlight>

--- a/api/freq_agg.md
+++ b/api/freq_agg.md
@@ -1,14 +1,20 @@
 ---
 api_name: freq_agg()
 excerpt: Aggregate frequency data into a frequency aggregate for further analysis
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [frequency, aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: SpaceSavingAggregate
 hyperfunction_type: aggregate
@@ -17,9 +23,10 @@ hyperfunction_type: aggregate
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # freq_agg()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
-The `freq_agg` aggregate uses the [SpaceSaving][spacesaving-algorithm] algorithm 
-to estimate the most common elements of a set. This API takes a sizing parameter and 
-a PostgreSQL column, and returns a FreqAgg object that can be passed to 
+
+The `freq_agg` aggregate uses the [SpaceSaving][spacesaving-algorithm] algorithm
+to estimate the most common elements of a set. This API takes a sizing parameter and
+a PostgreSQL column, and returns a FreqAgg object that can be passed to
 [other freq_agg APIs][frequency-analysis].
 
 <Experimental />
@@ -32,13 +39,16 @@ a PostgreSQL column, and returns a FreqAgg object that can be passed to
 |`value`|`AnyElement`|Column to aggregate|
 
 ## Returns
+
 |Column|Type|Description|
 |-|-|-|
 |`agg`|`SpaceSavingAggregate`|An object storing the most common elements of the given table and their estimated frequency.|
 
 ## Sample usage
+
 This example creates frequency aggregate over a field `ZIP` in a `HomeSales`
 table. This aggregate tracks any `ZIP` value that occurs in at least 5% of rows.
+
 ```sql
 CREATE toolkit_experimental.freq_agg(0.05, ZIP) FROM HomeSales;
 ```

--- a/api/gauge_agg.md
+++ b/api/gauge_agg.md
@@ -1,14 +1,20 @@
 ---
 api_name: gauge_agg()
 excerpt: Aggregate gauge data into a `GaugeSummary` for further analysis
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [gauges, aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: aggregate

--- a/api/get_telemetry_report.md
+++ b/api/get_telemetry_report.md
@@ -1,10 +1,12 @@
 ---
 api_name: get_telemetry_report()
 excerpt: Get the telemetry string that is sent to Timescale servers
-license: apache
-topic: admin
+topics: [administration]
 keywords: [admin]
 tags: [telemetry, report]
+api:
+  license: apache
+  type: function
 ---
 
 ## get_telemetry_report()
@@ -20,11 +22,15 @@ and returns a NULL report.
 | `always_display_report` | BOOLEAN | Set to true to always view the report, even if telemetry is disabled |
 
 ### Sample usage
+
 If telemetry is enabled, view the telemetry report.
+
 ```sql
 SELECT get_telemetry_report();
 ```
+
 If telemetry is disabled, view the telemetry report locally.
+
 ```sql
 SELECT get_telemetry_report(always_display_report := true);
 ```

--- a/api/histogram.md
+++ b/api/histogram.md
@@ -1,12 +1,16 @@
 ---
 api_name: histogram()
 excerpt: Partition the dataset into buckets and get the number of counts in each bucket
-license: apache
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [histogram, hyperfunctions]
+api:
+  license: apache
+  type: function
+hyperfunction:
+  type: one-step aggregate
 ---
 
-## histogram() 
+## histogram()
 
 The `histogram()` function represents the distribution of a set of
 values as an array of equal-width buckets. It partitions the dataset
@@ -30,7 +34,7 @@ starting with `min`, but values equal to the `max` are in the last bucket.
 | `max` | NUMERIC | The histogram's upper bound used in bucketing (exclusive) |
 | `nbuckets` | INTEGER | The integer value for the number of histogram buckets (partitions) |
 
-### Sample usage 
+### Sample usage
 
 A simple bucketing of device's battery levels from the `readings` dataset:
 
@@ -42,6 +46,7 @@ LIMIT 10;
 ```
 
 The expected output:
+
 ```sql
  device_id  |          histogram
 ------------+------------------------------

--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -1,20 +1,26 @@
 ---
 api_name: hyperloglog()
 excerpt: Aggregate data into a hyperloglog for approximate counting
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [count, hyperloglog, hyperfunctions, toolkit]
 tags: [approximate, distinct]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: approximate count distinct
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'approximate count distinct'
 hyperfunction_subfamily: hyperloglog
 hyperfunction_type: aggregate
 ---
 
 # hyperloglog()  <tag type="toolkit">Toolkit</tag>
+
 The `hyperloglog` function constructs and returns a hyperloglog with at least
 the specified number of buckets over the given values.
 
@@ -30,7 +36,7 @@ For more information about approximate count distinct functions, see the
 
 Increasing the `buckets` argument usually provides more accuracy at the expense
 of more memory usage. Because hyperloglog is a probabilistic algorithm, it works
-best on datasets that have many distinct values: at least tens of thousands. 
+best on datasets that have many distinct values: at least tens of thousands.
 
 See [stderror][stderror] for how estimated error rate is related to `buckets`.
 
@@ -43,6 +49,7 @@ See [stderror][stderror] for how estimated error rate is related to `buckets`.
 <!---Any special notes about the returns-->
 
 ## Sample usage
+
 This examples assumes you have a table called `samples`, that contains a column
 called `weights` that holds DOUBLE PRECISION values. This command returns a
 digest over that column:
@@ -57,7 +64,6 @@ other `hyperloglog` functions:
 ``` sql
 CREATE VIEW hll AS SELECT hyperloglog(32768, data) FROM samples;
 ```
-
 
 [hyperfunctions-approx-count-distincts]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/approx-count-distincts/
 [stderror]: /api/:currentVersion:/hyperfunctions/approx_count_distincts/stderror/

--- a/api/hypertable_compression_stats.md
+++ b/api/hypertable_compression_stats.md
@@ -1,13 +1,15 @@
 ---
 api_name: hypertable_compression_stats()
 excerpt: Get hypertable statistics related to compression
-license: community
-topic: compression
+topics: [compression]
 keywords: [compression, hypertables, information]
 tags: [statistics, size]
+api:
+  license: community
+  type: function
 ---
 
-## hypertable_compression_stats() <tag type="community">Community</tag> 
+## hypertable_compression_stats() <tag type="community">Community</tag>
 
 Get statistics related to hypertable compression.
 All sizes are in bytes.
@@ -18,7 +20,8 @@ All sizes are in bytes.
 |---|---|---|
 | `hypertable` | REGCLASS | Hypertable to show stats for. |
 
-### Returns 
+### Returns
+
 |Column|Type|Description|
 |---|---|---|
 |`total_chunks` | BIGINT | the number of chunks used by the hypertable |
@@ -33,7 +36,8 @@ All sizes are in bytes.
 |`after_compression_total_bytes` | BIGINT | Size of the entire table (table+indexes+toast) after compression (NULL if currently uncompressed) |
 |`node_name` | TEXT | nodes on which the hypertable is located, applicable only to distributed hypertables |
 
-### Sample usage 
+### Sample usage
+
 ```sql
 SELECT * FROM hypertable_compression_stats('conditions');
 
@@ -52,6 +56,7 @@ node_name                      |
 ```
 
 Use `pg_size_pretty` get the output in a more human friendly format.
+
 ```sql
 SELECT pg_size_pretty(after_compression_total_bytes) as total
   FROM hypertable_compression_stats('conditions');

--- a/api/hypertable_detailed_size.md
+++ b/api/hypertable_detailed_size.md
@@ -1,10 +1,12 @@
 ---
 api_name: hypertable_detailed_size()
 excerpt: Get detailed information about disk space used by a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables, information]
 tags: [statistics, size, disk space]
+api:
+  license: apache
+  type: function
 ---
 
 ## hypertable_detailed_size()  
@@ -22,7 +24,8 @@ including the access node.
 |---|---|---|
 | `hypertable` | REGCLASS | Hypertable to show detailed size of. |
 
-### Returns 
+### Returns
+
 |Column|Type|Description|
 |---|---|---|
 |table_bytes|BIGINT| Disk space used by main_table (like pg_relation_size(main_table))|
@@ -36,8 +39,10 @@ If executed on a relation that is not a hypertable, the function
 returns `NULL`.
 </highlight>
 
-### Sample usage 
+### Sample usage
+
 Get size information for a hypertable.
+
 ```sql
 -- disttable is a distributed hypertable --
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;

--- a/api/hypertable_index_size.md
+++ b/api/hypertable_index_size.md
@@ -1,10 +1,12 @@
 ---
 api_name: hypertable_index_size()
 excerpt: Get the disk space used by a hypertable index
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables, indexes, information]
 tags: [disk space, size]
+api:
+  license: apache
+  type: function
 ---
 
 ## hypertable_index_size()  
@@ -19,7 +21,8 @@ reported in bytes.
 |---|---|---|
 | `index_name` | REGCLASS | Name of the index on a  hypertable |
 
-### Returns 
+### Returns
+
 |Column|Type|Description|
 |---|---|---|
 |hypertable_index_size|BIGINT| Returns the disk space used by the index |
@@ -28,7 +31,7 @@ reported in bytes.
 NULL is returned if the function is executed on a non-hypertable relation.
 </highlight>
 
-### Sample usage 
+### Sample usage
 
 Get size of a specific index on a hypertable.
 

--- a/api/hypertable_size.md
+++ b/api/hypertable_size.md
@@ -1,10 +1,12 @@
 ---
 api_name: hypertable_size()
 excerpt: Get the total disk space used by a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables, information]
 tags: [disk space, size]
+api:
+  license: apache
+  type: function
 ---
 
 ## hypertable_size()  
@@ -21,7 +23,8 @@ output of `hypertable_detailed_size` function.
 |---|---|---|
 | `hypertable` | REGCLASS | Hypertable to show size of. |
 
-### Returns 
+### Returns
+
 |Name|Type|Description|
 |---|---|---|
 |hypertable_size| BIGINT | Total disk space used by the specified hypertable, including all indexes and TOAST data. |
@@ -30,8 +33,10 @@ output of `hypertable_detailed_size` function.
 `NULL` is returned if the function is executed on a non-hypertable relation.
 </highlight>
 
-### Sample usage 
+### Sample usage
+
 Get size information for a hypertable.
+
 ```sql
 SELECT hypertable_size('devices') ;
 
@@ -41,6 +46,7 @@ SELECT hypertable_size('devices') ;
 ```
 
 Get size information for all hypertables.
+
 ```sql
 SELECT hypertable_name, hypertable_size(format('%I.%I', hypertable_schema, hypertable_name)::regclass)
   FROM timescaledb_information.hypertables;

--- a/api/hypertables.md
+++ b/api/hypertables.md
@@ -1,17 +1,19 @@
 ---
 api_name: timescaledb_information.hypertables
 excerpt: Get metadata about hypertables
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables, information]
 tags: [schemas, tablespaces, data nodes, dimensions]
+api:
+  license: apache
+  type: view
 ---
 
-## timescaledb_information.hypertables 
+## timescaledb_information.hypertables
 
 Get metadata information about hypertables.
 
-### Available columns 
+### Available columns
 
 |Name|Type|Description|
 |---|---|---|
@@ -26,7 +28,7 @@ Get metadata information about hypertables.
 | `data_nodes` | TEXT | Nodes on which hypertable is distributed|
 | `tablespaces` | TEXT | Tablespaces attached to the hypertable |
 
-### Sample usage 
+### Sample usage
 
 Get information about a hypertable.
 

--- a/api/idelta.md
+++ b/api/idelta.md
@@ -1,20 +1,29 @@
 ---
-api_name: 'idelta_left() | idelta_right()'
+api_name: idelta_left() | idelta_right()
 excerpt: Calculate the instantaneous change from values in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [delta, change]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # idelta_left() and idelta_right() <tag type="toolkit" content="Toolkit" />
+
 The instantaneous change in the counter at the left (earlier) and right (later)
 side of the time range.
 
@@ -22,6 +31,7 @@ For more information about counter aggregation functions, see the
 [hyperfunctions documentation][hyperfunctions-counter-agg].
 
 ## idelta_left()
+
 The instantaneous change in the counter at the left (earlier) side of the time
 range. Essentially, the first value subtracted from the second value seen in the
 time range (handling resets appropriately). This can be especially useful for
@@ -63,6 +73,7 @@ FROM (
 ```
 
 ## idelta_right()
+
 The instantaneous change in the counter at the right (later) side of the time
 range. Essentially, the penultimate value subtracted from the last value seen in
 the time range (handling resets appropriately). This can be especially useful
@@ -102,6 +113,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/intercept-counter.md
+++ b/api/intercept-counter.md
@@ -1,20 +1,29 @@
 ---
 api_name: intercept()
 excerpt: Calculate the intercept from values in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [intercept, least squares, regression]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # intercept() <tag type="toolkit" content="Toolkit" />
+
 The intercept of the [least squares fit][least-squares] line computed from the adjusted counter
 values and times input in the CounterSummary. This corresponds to the projected
 value at the PostgreSQL epoch (2000-01-01 00:00:00+00). This is useful for
@@ -57,7 +66,6 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/
 [least-squares]:https://en.wikipedia.org/wiki/Least_squares

--- a/api/intercept-stats.md
+++ b/api/intercept-stats.md
@@ -1,14 +1,21 @@
 ---
 api_name: intercept()
 excerpt: Calculate the intercept from values in a 2-dimensional statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
 tags: [intercept, least squares, regression]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 2D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-2d
@@ -22,8 +29,8 @@ intercept(
 ) RETURNS DOUBLE PRECISION
 ```
 
-The y intercept of the [least squares fit][least-squares] line computed 
-from a two-dimensional statistical aggregate. 
+The y intercept of the [least squares fit][least-squares] line computed
+from a two-dimensional statistical aggregate.
 
 For more information about statistical aggregate functions, see the
 [hyperfunctions documentation][hyperfunctions-stats-agg].
@@ -50,7 +57,6 @@ SELECT
 FROM foo
 GROUP BY id, time_bucket('15 min'::interval, ts)
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/interpolate.md
+++ b/api/interpolate.md
@@ -1,20 +1,24 @@
 ---
 api_name: interpolate()
 excerpt: Linearly interpolate missing values when gapfilling
-license: community
-toolkit: false
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [gapfill, interpolate, hyperfunctions, toolkit]
 tags: [missing values]
+api:
+  license: community
+  type: function
+hyperfunction:
+  family: gapfilling and interpolation
+  type: interpolator
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: false
 hyperfunction_family: 'gapfilling and interpolation'
 hyperfunction_subfamily: interpolation
 hyperfunction_type: other
 ---
 
 # interpolate() <tag type="community">Community</tag>
+
 The `interpolate` function does linear interpolation for missing values. It can
 only be used in an aggregation query with
 [time_bucket_gapfill][time_bucket_gapfill].
@@ -52,8 +56,10 @@ data type in the `time_bucket_gapfill` call. The data type of `value` needs to
 be the same as the `value` data type of the `interpolate` call.
 
 ## Sample usage
+
 Get the temperature every day for each device over the last week, interpolating
 for missing readings:
+
 ```sql
 SELECT
   time_bucket_gapfill('1 day', time, now() - INTERVAL '1 week', now()) AS day,
@@ -80,6 +86,7 @@ ORDER BY day;
 Get the average temperature every day for each device over the last seven days,
 interpolating for missing readings, with lookup queries for values before and
 after the gapfill time range:
+
 ```sql
 SELECT
   time_bucket_gapfill('1 day', time, now() - INTERVAL '1 week', now()) AS day,
@@ -105,7 +112,6 @@ ORDER BY day;
  2019-01-16 01:00:00+01 |         1 |   9.0 |         9.0
 (7 row)
 ```
-
 
 [hyperfunctions-gapfilling]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/gapfilling-interpolation/
 [time_bucket_gapfill]: /api/:currentVersion:/hyperfunctions/gapfilling-interpolation/time_bucket_gapfill/

--- a/api/interpolated_average.md
+++ b/api/interpolated_average.md
@@ -1,14 +1,22 @@
 ---
 api_name: interpolated_average()
 excerpt: Calculate the time-weighted average of values within an interval, interpolating the interval bounds
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, average, time-weighted, TimeWeightSummary, interpolated]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: time-weighted averages
+  type: accessor
+  aggregates:
+    - time_weight()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'time-weighted averages'
 hyperfunction_subfamily: 'time-weighted averages'
 hyperfunction_type: accessor
@@ -27,16 +35,16 @@ interpolated_average(
 ```
 
 A function to compute a time-weighted average over the interval, defined as `start`
-plus `interval`, given a `prev` and `next` time-weight summary from which to 
-compute the boundary points. This is intended to allow a precise time-weighted 
-average over intervals even when the points representing the intervals are grouped 
-into discrete time-weight summaries. PostgreSQL window functions such as 
-`LEAD` and `LAG` can be used to determine the `prev` and `next` arguments, 
+plus `interval`, given a `prev` and `next` time-weight summary from which to
+compute the boundary points. This is intended to allow a precise time-weighted
+average over intervals even when the points representing the intervals are grouped
+into discrete time-weight summaries. PostgreSQL window functions such as
+`LEAD` and `LAG` can be used to determine the `prev` and `next` arguments,
 as used in the examples in this section.
-	
-Note that if either `prev` or `next` are `NULL`, the first or last point in the 
-summary is treated as the edge of the interval. The interpolated point is 
-determined using LOCF or linear interpolation, depending on which interpolation 
+
+Note that if either `prev` or `next` are `NULL`, the first or last point in the
+summary is treated as the edge of the interval. The interpolated point is
+determined using LOCF or linear interpolation, depending on which interpolation
 style the time-weight summary was created with.
 
 *   For more information about time-weighted average functions, see the
@@ -87,7 +95,6 @@ FROM (
     GROUP BY id, time
 ) t
 ```
-
 
 [hyperfunctions-time-weight-average]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/time-weighted-averages/
 [hyperfunctions-time-weight]: /api/:currentVersion:/hyperfunctions/time-weighted-averages/time_weight/

--- a/api/interpolated_delta.md
+++ b/api/interpolated_delta.md
@@ -1,20 +1,30 @@
 ---
 api_name: interpolated_delta()
 excerpt: Calculate the change in a counter, interpolated over some time period
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, delta, counters, CounterSummary, interpolated]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # interpolated_delta() <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit">Experimental</tag>
+
 Calculate the change in a counter over a time period. Data points at the exact
 boundaries of the time period aren't needed. The function interpolates the
 counter values at the boundaries from adjacent CounterSummaries if needed.
@@ -46,6 +56,7 @@ For more information about counter aggregation functions, see the
 |-|-|-|
 |`prev`|`CounterSummary`|The `CounterSummary` from the prior interval, used to interpolate the value at `start`. If `NULL`, the first timestamp in `summary` is used as the start of the interval.|
 |`next`|`CounterSummary`|The `CounterSummary` from the following interval, used to interpolate the value at `start` + `interval`. If `NULL`, the last timestamp in `summary` is used as the end of the interval.|
+
 ## Returns
 
 |Name|Type|Description|
@@ -74,6 +85,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/interpolated_duration_in.md
+++ b/api/interpolated_duration_in.md
@@ -1,14 +1,22 @@
 ---
 api_name: interpolated_duration_in()
 excerpt: Calculate the total time spent in a given state, interpolating values at interval boundaries if they don't exist
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, duration, state, state aggregates, interpolated]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: accessor
+  aggregates:
+    - state_agg()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: StateAgg
 hyperfunction_type: accessor
@@ -17,6 +25,7 @@ hyperfunction_type: accessor
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # interpolated_duration_in()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
 Calculate the total duration in a given state from a [state aggregate][state_agg].
 Unlike [`duration_in`][duration_in], you can use this function across multiple state
 aggregates that cover different time buckets. Any missing values at the time bucket
@@ -58,7 +67,9 @@ interpolated_duration_in(
 |`interpolated_duration_in`|`INTERVAL`|The total time spent in the target state. Displayed as `days`, `hh:mm:ss`, or a combination of the two.|
 
 ## Sample usage
+
 This example creates a simple test table:
+
 ```sql
 SET timezone TO 'UTC';
 CREATE TABLE states(time TIMESTAMPTZ, state TEXT);
@@ -72,6 +83,7 @@ INSERT INTO states VALUES
 ```
 
 You can query this table for the time spent in the running state, like this:
+
 ```sql
 SELECT 
   time,
@@ -93,6 +105,7 @@ SELECT
 ```
 
 Which gives the result:
+
 ```sql
           time          | interpolated_duration_in 
 ------------------------+--------------------------

--- a/api/interpolated_rate.md
+++ b/api/interpolated_rate.md
@@ -1,20 +1,30 @@
 ---
 api_name: interpolated_rate()
 excerpt: Calculate the rate of change in a counter, interpolated over some time period
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, rate, counters, CounterSummary, interpolated]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: function
+  accessors:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # interpolated_rate() <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit">Experimental</tag>
+
 Calculate the rate of change in a counter over a time period. Data points at the exact
 boundaries of the time period aren't needed. The function linerally interpolates the
 counter values at the boundaries from adjacent `CounterSummaries` if they are unknown.

--- a/api/into_values-freq_agg.md
+++ b/api/into_values-freq_agg.md
@@ -1,14 +1,23 @@
 ---
 api_name: into_values()
 excerpt: Calculate all frequency estimates from a frequency aggregate or top N aggregate
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [frequency, top N, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: accessor
+  aggregates:
+    - freq_agg()
+    - topn_agg()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: SpaceSavingAggregate
 hyperfunction_type: accessor
@@ -17,6 +26,7 @@ hyperfunction_type: accessor
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # into_values()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
 This function returns the data accumulated in a
 [frequency aggregate][freq_agg] or [top N aggregate][topn_agg].
 The aggregate operates over `AnyElement` types, so this method
@@ -39,14 +49,17 @@ requires a type parameter to determine the type of the output.
 |`max_freq`|`DOUBLE PRECISION`|The maximum frequency of the value in the originating data|
 
 ## Sample usage
-This test uses a table of randomly generated data. The values used are the integer 
+
+This test uses a table of randomly generated data. The values used are the integer
 square roots of a random number in the range (0,400).
+
 ```sql
 CREATE TABLE value_test(value INTEGER);
 INSERT INTO value_test SELECT floor(sqrt(random() * 400)) FROM generate_series(1,100000);
 ```
 
 This returns values representing more than 5% of the input:
+
 ```sql
 SELECT value, min_freq, max_freq
 FROM toolkit_experimental.into_values(
@@ -54,6 +67,7 @@ FROM toolkit_experimental.into_values(
 ```
 
 The output for this query looks like this, with some variation due to randomness:
+
 ```sql
  value | min_freq | max_freq 
 -------+----------+----------

--- a/api/into_values-state_agg.md
+++ b/api/into_values-state_agg.md
@@ -1,14 +1,22 @@
 ---
 api_name: into_values()
 excerpt: Calculate all state durations from a state aggregate
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [duration, states, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: accessor
+  aggregates:
+    - state_agg()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: StateAgg
 hyperfunction_type: accessor
@@ -17,7 +25,9 @@ hyperfunction_type: accessor
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # into_values()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
 Returns the data accumulated in a [state aggregate][state_agg].  
+
 ```sql
 into_values (
     agg StateAgg
@@ -40,16 +50,19 @@ into_values (
 |`duration`|`BIGINT`|The duration of time spent in that state|
 
 ## Sample usage
+
 Create a state aggregate from the table `states_test`. The time column is named
 `time`, and the `state` column contains text values corresponding to different
 states of a system. Use `into_values` to display the data from the state
 aggregate:
+
 ```sql
 SELECT state, duration FROM toolkit_experimental.into_values(
      (SELECT toolkit_experimental.state_agg(time, state) FROM states_test));
 ```
 
 Example output:
+
 ```
 state | duration
 ------+-----------

--- a/api/irate.md
+++ b/api/irate.md
@@ -1,20 +1,29 @@
 ---
-api_name: 'irate_left() | irate_right()'
+api_name: irate_left() | irate_right()
 excerpt: Calculate the instantaneous rate of change from values in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [rate]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # irate_left() and irate_right() <tag type="toolkit" content="Toolkit" />
+
 The instantaneous rate of change of the counter at the left (earlier) and right
 (later) side of the time range.
 
@@ -22,6 +31,7 @@ For more information about counter aggregation functions, see the
 [hyperfunctions documentation][hyperfunctions-counter-agg].
 
 ## irate_left()
+
 The instantaneous rate of change of the counter at the left (earlier) side of
 the time range. Essentially, the `idelta_left` divided by the duration between the
 first and second observed points in the CounterSummary. This can be especially
@@ -63,6 +73,7 @@ FROM (
 ```
 
 ## irate_right()
+
 The instantaneous rate of change of the counter at the right (later) side of the
 time range. Essentially, the `idelta_right` divided by the duration between the
 first and second observed points in the CounterSummary. This can be especially
@@ -102,6 +113,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/job_stats.md
+++ b/api/job_stats.md
@@ -1,23 +1,25 @@
 ---
 api_name: timescaledb_information.job_stats
 excerpt: Get information and statistics about automatically run jobs
-license: community
-topic: jobs
+topics: [jobs]
 keywords: [jobs, information]
 tags: [background jobs, scheduled jobs, automation framework, scheduled views, statistics]
+api:
+  license: community
+  type: view
 ---
 
-## timescaledb_information.job_stats 
+## timescaledb_information.job_stats
 
 Shows information and statistics about jobs run by the automation framework.
-This includes jobs set up for user defined actions and jobs run by policies 
+This includes jobs set up for user defined actions and jobs run by policies
 created to manage data retention, continuous aggregates, compression, and
-other automation policies.  (See [policies][actions]). 
+other automation policies.  (See [policies][actions]).
 The statistics include information useful for administering jobs and determining
 whether they ought be rescheduled, such as: when and whether the background job
 used to implement the policy succeeded and when it is scheduled to run next.
 
-### Available columns 
+### Available columns
 
 |Name|Type|Description|
 |---|---|---|
@@ -34,7 +36,7 @@ used to implement the policy succeeded and when it is scheduled to run next.
 |`total_successes` | BIGINT | The total number of times this job succeeded |
 |`total_failures` | BIGINT | The total number of times this job failed |
 
-### Sample usage 
+### Sample usage
 
 Get job success/failure information for a specific hypertable.
 
@@ -52,6 +54,7 @@ SELECT job_id, total_runs, total_failures, total_successes
 ```
 
 Get information about continuous aggregate policy related statistics
+
 ``` sql
 SELECT  js.* FROM
   timescaledb_information.job_stats js, timescaledb_information.continuous_aggregates cagg

--- a/api/jobs.md
+++ b/api/jobs.md
@@ -1,13 +1,16 @@
 ---
 api_name: timescaledb_information.jobs
 excerpt: Get information about all jobs registered with the automatic scheduler
-license: community
-topic: jobs
+topics: [jobs]
 keywords: [jobs, information]
 tags: [background jobs, scheduled jobs, user-defined actions, automation framework]
+api:
+  license: community
+  type: view
 ---
 
 ## timescaledb_information.jobs
+
 Shows information about all jobs registered with the automation framework.
 
 ### Arguments
@@ -32,6 +35,7 @@ Shows information about all jobs registered with the automation framework.
 ### Sample use
 
 Shows a job associated with the refresh policy for continuous aggregates:
+
 ```sql
 SELECT * FROM timescaledb_information.jobs;
 job_id            | 1001
@@ -73,6 +77,7 @@ hypertable_name   | conditions
 ```
 
 Find jobs that are run by user defined actions:
+
 ```sql
 SELECT * FROM timescaledb_information.jobs where application_name like 'User-Define%';
 -[ RECORD 1 ]-----+------------------------------

--- a/api/kurtosis.md
+++ b/api/kurtosis.md
@@ -1,14 +1,21 @@
 ---
-api_name: 'kurtosis() | kurtosis_y() | kurtosis_x()'
+api_name: kurtosis() | kurtosis_y() | kurtosis_x()
 excerpt: Calculate the kurtosis from values in a statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
 tags: [skew]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 1D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-1d
@@ -19,19 +26,21 @@ hyperfunction_type: accessor-1d
 ```SQL
 kurtosis(summary StatsSummary1D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 kurtosis_y(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 kurtosis_x(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
 
 Calculate the [kurtosis][kurtosis], or the fourth statistical moment, of the values contained
-in a statistical aggregate. In a two-dimensional [`stats_agg`][stats-agg] use 
-the `_y`/ `_x` form to access the `kurtosis` of the dependent and independent variables. 
+in a statistical aggregate. In a two-dimensional [`stats_agg`][stats-agg] use
+the `_y`/ `_x` form to access the `kurtosis` of the dependent and independent variables.
 
-The `method` determines whether you calculate a population or sample kurtosis. These 
-values can be provided as their full names, or you can abbreviate them as `pop` or `samp`. 
+The `method` determines whether you calculate a population or sample kurtosis. These
+values can be provided as their full names, or you can abbreviate them as `pop` or `samp`.
 These are the only four accepted values for the `method` argument. The default is `sample`.
 
 For more information about statistical aggregate functions, see the
@@ -61,12 +70,12 @@ For more information about statistical aggregate functions, see the
 SELECT kurtosis_y(stats_agg(data, data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
   kurtosis_y 
 ------------
     1.78195
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/last.md
+++ b/api/last.md
@@ -1,9 +1,13 @@
 ---
 api_name: last()
 excerpt: Get the last value in one column when rows are ordered by another column
-license: apache
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [hyperfunctions]
+api:
+  license: apache
+  type: function
+hyperfunction:
+  type: one-step aggregate
 ---
 
 ## last()
@@ -22,6 +26,7 @@ latest temperature value based on time within an aggregate group.
 ### Sample usage
 
 Get the temperature every 5 minutes for each device over the past day:
+
 ```sql
 SELECT device_id, time_bucket('5 minutes', time) AS interval,
   last(temp, time)
@@ -32,9 +37,9 @@ ORDER BY interval DESC;
 ```
 
 <highlight type="warning">
- The `last` and `first` commands do **not** use indexes, and instead
- perform a sequential scan through their groups. They are primarily used
- for ordered selection within a `GROUP BY` aggregate, and not as an
- alternative to an `ORDER BY time DESC LIMIT 1` clause to find the
- latest value (which uses indexes).
+The `last` and `first` commands do **not** use indexes, and instead
+perform a sequential scan through their groups. They are primarily used
+for ordered selection within a `GROUP BY` aggregate, and not as an
+alternative to an `ORDER BY time DESC LIMIT 1` clause to find the
+latest value (which uses indexes).
 </highlight>

--- a/api/locf.md
+++ b/api/locf.md
@@ -1,20 +1,24 @@
 ---
 api_name: locf()
 excerpt: Carry the last-seen value forward when gapfilling
-license: community
-toolkit: false
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [gapfill, interpolate, hyperfunctions, toolkit]
 tags: [missing values]
+api:
+  license: community
+  type: function
+hyperfunction:
+  family: gapfilling and interpolation
+  type: interpolator
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: false
 hyperfunction_family: 'gapfilling and interpolation'
 hyperfunction_subfamily: interpolation
 hyperfunction_type: other
 ---
 
 # locf() <tag type="community">Community</tag>
+
 The `locf` (last observation carried forward) function allows you to carry the
 last seen value in an aggregation group forward. It can only be used in an
 aggregation query with
@@ -48,8 +52,10 @@ expression is only evaluated when no previous value is returned by the outer
 query. For example, when the first bucket in the queried time range is empty.
 
 ## Sample usage
+
 Get the average temperature every day for each device over the last seven days,
 carrying forward the last value for missing readings:
+
 ```sql
 SELECT
   time_bucket_gapfill('1 day', time, now() - INTERVAL '1 week', now()) AS day,
@@ -75,6 +81,7 @@ ORDER BY day;
 
 Get the average temperature every day for each device over the last seven days,
 carrying forward the last value for missing readings with out-of-bounds lookup:
+
 ```sql
 SELECT
   time_bucket_gapfill('1 day', time, now() - INTERVAL '1 week', now()) AS day,

--- a/api/lttb.md
+++ b/api/lttb.md
@@ -1,23 +1,30 @@
 ---
 api_name: lttb()
 excerpt: Downsample a time series using the Largest Triangle Three Buckets method
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [downsample, smooth, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: downsample
+  type: one-step aggregate
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'downsample'
 hyperfunction_subfamily: 'downsample'
 hyperfunction_type: other
 ---
 
 # lttb()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
-[Largest Triangle Three Buckets][gh-lttb] is a downsampling method that 
-tries to retain visual similarity between the downsampled data and the 
-original dataset. The TimescaleDB Toolkit implementation of this takes 
+
+[Largest Triangle Three Buckets][gh-lttb] is a downsampling method that
+tries to retain visual similarity between the downsampled data and the
+original dataset. The TimescaleDB Toolkit implementation of this takes
 `(timestamp, value)` pairs, sorts them if needed, and downsamples them.
 
 ## Required arguments
@@ -35,7 +42,9 @@ original dataset. The TimescaleDB Toolkit implementation of this takes
 |`sortedtimevector`|`SortedTimevector`|A [`timevector`][hyperfunctions-timevectors] object containing the downsampled points. It can be unpacked via `unnest`.|
 
 ## Sample usage
+
 This example creates a dramatically downsampled data set from a `sample_data` table:
+
 ```sql
 SELECT time, value
 FROM toolkit_experimental.unnest((
@@ -44,6 +53,7 @@ FROM toolkit_experimental.unnest((
 ```
 
 The output for this query:
+
 ```sql
           time          |       value
 ------------------------+--------------------
@@ -52,7 +62,6 @@ The output for this query:
  2020-03-03 00:00:00+00 | 14.982710485116087
  2020-04-20 00:00:00+00 | 10.022128489940254
 ```
-
 
 [gh-lttb]: https://github.com/sveinn-steinarsson/flot-downsample
 [hyperfunctions-timevectors]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/function-pipelines/#timevectors

--- a/api/max_val.md
+++ b/api/max_val.md
@@ -1,14 +1,21 @@
 ---
 api_name: max_val()
 excerpt: Calculate the maximum from values in a `tdigest`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [tdigest, hyperfunctions, toolkit]
 tags: [percentiles, maximum]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: accessor
+  aggregates:
+    - tdigest()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: false
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'percentile approximation'
 hyperfunction_type: accessor
@@ -33,11 +40,13 @@ aggregates. You can calculate a single percentile estimator by extracting the
     [hyperfunctions documentation][hyperfunctions-percentile-approx].
 
 ### Required arguments
+
 |Name|Type|Description|
 |-|-|-|
 |`digest`|`TDigest`|The digest to extract the max value from|
 
 ### Returns
+
 |Column|Type|Description|
 |-|-|-|
 |`max_val`|`DOUBLE PRECISION`|The maximum value entered into the t-digest.|
@@ -54,7 +63,6 @@ FROM generate_series(1, 100) data;
 ---------
      100
 ```
-
 
 [advanced-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/advanced-agg/
 [hyperfunctions-percentile-approx]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/

--- a/api/mean.md
+++ b/api/mean.md
@@ -1,14 +1,23 @@
 ---
 api_name: mean()
 excerpt: Calculate the mean from values in a percentile aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [hyperfunctions, toolkit]
 tags: [average, percentiles]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: accessor
+  aggregates:
+    - percentile_agg()
+    - tdigest()
+    - uddsketch()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: false
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'percentile approximation'
 hyperfunction_type: accessor
@@ -19,6 +28,7 @@ hyperfunction_type: accessor
 ```SQL
 mean(sketch UddSketch) RETURNS DOUBLE PRECISION
 ```
+
 ```SQL
 mean(digest tdigest) RETURNS DOUBLE PRECISION
 ```
@@ -53,12 +63,12 @@ separate `avg` aggregate.
 SELECT mean(percentile_agg(data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  mean
 ------
  50
 ```
-
 
 [advanced-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/advanced-agg/
 [hyperfunctions-percentile-approx]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/

--- a/api/min_frequency-max_frequency.md
+++ b/api/min_frequency-max_frequency.md
@@ -1,22 +1,34 @@
 ---
-api_name: 'min_frequency() | max_frequency()'
+api_name: min_frequency() | max_frequency()
 excerpt: Calculate the minimum or maximum estimated frequencies of a value from a frequency aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [frequency, hyperfunctions, toolkit]
 tags: [minimum, maximum]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: accessor
+  aggregates:
+    - freq_agg()
+    - topn_agg()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: SpaceSavingAggregate
 hyperfunction_type: accessor
 ---
 
 # min_frequency() and max_frequency() <tag type="toolkit" content="Toolkit" /><tag type="experimental" content="Experimental" />
+
 Returns the minimum or maximum estimated frequencies of a value within a
 dataset.
+
 ```sql
 max_frequency (
     agg SpaceSavingAggregate,
@@ -49,8 +61,10 @@ that appear with lower-than-threshold frequency are not tracked. Calling
 </highlight>
 
 ## Sample usage
+
 Find the minimum frequency of the value `3` in a column named `value` within the
 table `value_test`:
+
 ```sql
 SELECT toolkit_experimental.min_frequency(
     (SELECT toolkit_experimental.freq_agg(0.05, value) FROM value_test),
@@ -60,6 +74,7 @@ SELECT toolkit_experimental.min_frequency(
 
 Find the maximum frequency of the value `foo` in a column named `value` within
 the table `value_test`:
+
 ```sql
 SELECT toolkit_experimental.max_frequency(
     (SELECT toolkit_experimental.freq_agg(0.05, value) FROM value_test),

--- a/api/min_val.md
+++ b/api/min_val.md
@@ -1,14 +1,21 @@
 ---
 api_name: min_val()
 excerpt: Calculate the minimum from values in a `tdigest`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [tdigest, hyperfunctions, toolkit]
 tags: [minimum, percentiles]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: accessor
+  aggregates:
+    - tdigest()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: false
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'percentile approximation'
 hyperfunction_type: accessor
@@ -32,6 +39,7 @@ compute a single percentile estimator and do not need to specify a separate
     [hyperfunctions documentation][hyperfunctions-percentile-approx].
 
 ## Required arguments
+
 |Name|Type|Description|
 |-|-|-|
 |`digest`|`TDigest`|The digest to extract the min value from|
@@ -54,7 +62,6 @@ FROM generate_series(1, 100) data;
 -----------
          1
 ```
-
 
 [hyperfunctions-percentile-approx]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/
 [advanced-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/advanced-agg/

--- a/api/move_chunk.md
+++ b/api/move_chunk.md
@@ -1,12 +1,15 @@
 ---
 api_name: move_chunk()
 excerpt: Move a chunk and its indexes to a different tablespace
-license: community
-topic: hypertables
+topics: [hypertables]
 keywords: [chunks, hypertables, tablespaces, move, data tiering]
+api:
+  license: community
+  type: function
 ---
 
 ## move_chunk() <tag type="community">Community</tag>
+
 TimescaleDB allows you to move data and indexes to different tablespaces. This
 allows you to move data to more cost-effective storage as it ages.
 
@@ -38,7 +41,6 @@ to use the `move_chunk()` call.
 |`index_destination_tablespace`|NAME|Target tablespace for index associated with the chunk you are moving|
 |`reorder_index`|REGCLASS|The name of the index (on either the hypertable or chunk) to order by|
 |`verbose`|BOOLEAN|Setting to true displays messages about the progress of the move_chunk command. Defaults to false.|
-
 
 ### Sample usage
 

--- a/api/move_chunk_experimental.md
+++ b/api/move_chunk_experimental.md
@@ -1,15 +1,19 @@
 ---
 api_name: move_chunk()
 excerpt: Move a chunk to a different data node in a multi-node cluster
-license: community
-topic: multi-node
+topics: [multi-node, distributed hypertables]
 keywords: [multi-node, chunks]
 tags: [data nodes, cluster, rebalance, rebalancing]
+api:
+  license: community
+  type: function
+  experimental: true
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 ## move_chunk() <tag type="community">Community</tag> <tag type="experimental">Experimental</tag>
+
 TimescaleDB allows you to move chunks to other data nodes. Moving
 chunks is useful in order to rebalance a multi-node cluster or remove
 a data node from the cluster.
@@ -25,6 +29,7 @@ a data node from the cluster.
 |`destination_node`|NAME|Data node where the chunk is to be copied|
 
 ### Required settings
+
 When moving a chunk, the destination data node needs a way to
 authenticate with the data node that holds the source chunk. It is
 currently recommended to use a [password file][password-config] on the
@@ -36,7 +41,8 @@ many chunks in parallel, you can increase `max_wal_senders` and
 `max_replication_slots`.
 
 ### Failures
-When a move operation fails, it sometimes creates objects and metadata on 
+
+When a move operation fails, it sometimes creates objects and metadata on
 the destination data node. It can also hold a replication slot open on the
 source data node. To clean up these objects and metadata, use
 [`cleanup_copy_chunk_operation`][cleanup_copy_chunk].
@@ -49,4 +55,3 @@ CALL timescaledb_experimental.move_chunk('_timescaledb_internal._dist_hyper_1_1_
 
 [password-config]: /timescaledb/:currentVersion:/how-to-guides/multinode-timescaledb/multinode-auth/#v1-set-the-password-encryption-method-for-access-node-and-data-nodes
 [cleanup_copy_chunk]: /api/:currentVersion:/distributed-hypertables/cleanup_copy_chunk_operation_experimental
-

--- a/api/num_changes.md
+++ b/api/num_changes.md
@@ -1,20 +1,29 @@
 ---
 api_name: num_changes()
 excerpt: Calculate the number of times a value changed within the time period of a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [count, change]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # num_changes() <tag type="toolkit" content="Toolkit" />
+
 The number of times the value changed within the period over which the
 CounterSummary is calculated. This is determined by evaluating consecutive
 points. Any change in the value is counted, including counter resets where the
@@ -58,6 +67,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/num_elements.md
+++ b/api/num_elements.md
@@ -1,20 +1,29 @@
 ---
 api_name: num_elements()
 excerpt: Calculate the number of points with distinct times from values in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [distinct, count]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  subfamily: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # num_elements() <tag type="toolkit" content="Toolkit" />
+
 The total number of points seen while calculating the CounterSummary. Only
 points with distinct times are counted, as duplicate times are usually discarded
 in these calculations.
@@ -56,6 +65,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/num_resets.md
+++ b/api/num_resets.md
@@ -1,20 +1,28 @@
 ---
 api_name: num_resets()
 excerpt: Calculate the total number of times a counter is reset
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [resets, count]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # num_resets() <tag type="toolkit" content="Toolkit" />
+
 The total number of times the counter is reset while calculating the
 CounterSummary.
 
@@ -55,6 +63,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/num_vals-pct.md
+++ b/api/num_vals-pct.md
@@ -1,14 +1,23 @@
 ---
 api_name: num_vals()
 excerpt: Calculate the number of values contained in a percentile estimate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [percentiles, hyperfunctions, toolkit]
 tags: [number, count]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: accessor
+  aggregates:
+    - percentile_agg()
+    - tdigest()
+    - uddsketch()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: false
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'percentile approximation'
 hyperfunction_type: accessor
@@ -19,6 +28,7 @@ hyperfunction_type: accessor
 ```SQL
 num_vals(StatsSummary1D) RETURNS DOUBLE PRECISION
 ```
+
 ```SQL
 num_vals(digest tdigest) RETURNS DOUBLE PRECISION
 ```
@@ -28,7 +38,6 @@ when you need both a count and a percentile estimate as part of a continuous
 aggregate. You can compute a single percentile estimator by extracting the
 `num_vals` from the percentile estimator. You do not need to specify a separate
 `count` aggregate.
-
 
 *   For more information about percentile approximation functions, see the
     [hyperfunctions documentation][hyperfunctions-percentile-approx].
@@ -51,12 +60,12 @@ aggregate. You can compute a single percentile estimator by extracting the
 SELECT num_vals(percentile_agg(data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  num_vals
 -----------
        101
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [hyperfunctions-percentile-approx]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/

--- a/api/num_vals-stats.md
+++ b/api/num_vals-stats.md
@@ -1,14 +1,21 @@
 ---
 api_name: num_vals()
 excerpt: Calculate the number of values contained in a statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
 tags: [count, number]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 1D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-1d
@@ -19,6 +26,7 @@ hyperfunction_type: accessor-1d
 ```SQL
 num_vals(summary StatsSummary1D) RETURNS BIGINT
 ```
+
 ```SQL
 num_vals(summary StatsSummary2D) RETURNS BIGINT
 ```
@@ -48,12 +56,12 @@ For more information about statistical aggregate functions, see the
 SELECT num_vals(stats_agg(data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  num_vals
 -----------
        101
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/percentile_agg.md
+++ b/api/percentile_agg.md
@@ -1,13 +1,18 @@
 ---
 api_name: percentile_agg()
 excerpt: Aggregate data into a percentile aggregate for further analysis
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [percentiles, aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'percentile approximation'
 hyperfunction_type: aggregate
@@ -52,13 +57,16 @@ The `percentile_agg` function uses the UddSketch algorithm, so it returns the
 `UddSketch` data structure for use in further calls.
 
 ## Sample usage
+
 Get the approximate first percentile using the `percentile_agg()` plus the
 [`approx_percentile`][approx_percentile] accessor function:
+
 ```SQL
 SELECT
     approx_percentile(0.01, percentile_agg(data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
 approx_percentile
 -------------------
@@ -77,7 +85,6 @@ AS SELECT
 FROM foo
 GROUP BY 1;
 ```
-
 
 [approx_percentile]: /api/:currentVersion:/hyperfunctions/percentile-approximation/approx_percentile/
 [rollup]: /api/:currentVersion:/hyperfunctions/percentile-approximation/rollup-percentile/

--- a/api/rate.md
+++ b/api/rate.md
@@ -1,20 +1,29 @@
 ---
 api_name: rate()
 excerpt: Calculate the rate of change from values in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [rate, change]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # rate() <tag type="toolkit" content="Toolkit" />
+
 The rate of change of the counter over the observed time period. This is the raw
 or simple rate, equivalent to `delta(summary)` or `time_delta(summary)`. After
 accounting for resets, the last value is subtracted from the first value and
@@ -56,6 +65,5 @@ FROM (
     GROUP BY id
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/recompress_chunk.md
+++ b/api/recompress_chunk.md
@@ -1,14 +1,18 @@
 ---
 api_name: recompress_chunk()
 excerpt: Recompress a chunk that had new data inserted after compression
-license: community
-topic: compression
+topics: [compression]
 keywords: [compression, recompression, chunks]
 tags: [hypertables]
+api:
+  license: community
+  type: function
 ---
 
 # recompress_chunk() <tag type="community" content="Community" />
+
 Recompresses a compressed chunk that had more data inserted after compression.
+
 ```sql
 recompress_chunk(
     chunk REGCLASS,
@@ -16,9 +20,9 @@ recompress_chunk(
 )
 ```
 
-You can also recompress chunks by 
-[running the job associated with your compression policy][run-job]. 
-`recompress_chunk` gives you more fine-grained control by 
+You can also recompress chunks by
+[running the job associated with your compression policy][run-job].
+`recompress_chunk` gives you more fine-grained control by
 allowing you to target a specific chunk.
 
 <highlight type="important">
@@ -44,17 +48,21 @@ chunk for the first time, use [`compress_chunk`](/api/latest/compression/compres
 |`if_not_compressed`|`BOOLEAN`|If `true`, prints a notice instead of erroring if the chunk is already compressed. Defaults to `false`.|
 
 ## Sample usage
+
 Recompress the chunk `timescaledb_internal._hyper_1_2_chunk`:
+
 ```sql
 CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 ```
 
 ## Troubleshooting
+
 In TimescaleDB 2.6.0 and above, `recompress_chunk` is implemented as a procedure.
 Previously, it was implemented as a function. If you are upgrading to
-TimescaleDB 2.6.0 or above, the`recompress_chunk` 
+TimescaleDB 2.6.0 or above, the`recompress_chunk`
 function could cause an error. For example, trying to run `SELECT
 recompress_chunk(i.show_chunks, true) FROM...` gives the following error:
+
 ```sql
 ERROR:  recompress_chunk(regclass, boolean) is a procedure
 ```
@@ -62,6 +70,7 @@ ERROR:  recompress_chunk(regclass, boolean) is a procedure
 To fix the error, use `CALL` instead of `SELECT`. You might also need to write a
 procedure to replace the full functionality in your `SELECT` statement. For
 example:
+
 ```sql
 DO $$
 DECLARE chunk regclass;

--- a/api/refresh_continuous_aggregate.md
+++ b/api/refresh_continuous_aggregate.md
@@ -1,9 +1,11 @@
 ---
 api_name: refresh_continuous_aggregate()
 excerpt: Manually refresh a continuous aggregate
-license: community
-topic: continuous aggregates
+topics: [continuous aggregates]
 keywords: [continuous aggregates, refresh]
+api:
+  license: community
+  type: function
 ---
 
 ## refresh_continuous_aggregate() <tag type="community">Community</tag>
@@ -29,7 +31,6 @@ date or timestamp type. Note that a continuous aggregate using the
 `window_start` and `window_end` is specified in the local time zone,
 any time zone shift relative UTC needs to be accounted for when
 refreshing in order to align with bucket boundaries.
-
 
 ### Required arguments
 

--- a/api/remove_compression_policy.md
+++ b/api/remove_compression_policy.md
@@ -1,13 +1,16 @@
 ---
 api_name: remove_compression_policy()
 excerpt: Remove a compression policy from a hypertable
-license: community
-topic: compression
+topics: [compression, jobs]
 keywords: [compression, policies, remove]
 tags: [delete, drop]
+api:
+  license: community
+  type: function
 ---
 
 ## remove_compression_policy() <tag type="community" content="community" />
+
 If you need to remove the compression policy. To restart policy-based
 compression you need to add the policy again. To view the policies that
 already exist, see [informational views][informational-views].
@@ -19,17 +22,21 @@ already exist, see [informational views][informational-views].
 |`hypertable`|REGCLASS|Name of the hypertable or continuous aggregate the policy should be removed from|
 
 ### Optional arguments
+
 |Name|Type|Description|
 |---|---|---|
 | `if_exists` | BOOLEAN | Setting to true causes the command to fail with a notice instead of an error if a compression policy does not exist on the hypertable. Defaults to false.|
 
 ### Sample usage
+
 Remove the compression policy from the 'cpu' table:
+
 ``` sql
 SELECT remove_compression_policy('cpu');
 ```
 
 Remove the compression policy from the 'cpu_weekly' continuous aggregate:
+
 ``` sql
 SELECT remove_compression_policy('cpu_weekly');
 ```

--- a/api/remove_continuous_aggregate_policy.md
+++ b/api/remove_continuous_aggregate_policy.md
@@ -1,13 +1,16 @@
 ---
 api_name: remove_continuous_aggregate_policy()
 excerpt: Remove a refresh policy from a continuous aggregate
-license: community
-topic: continuous aggregates
+topics: [continuous aggregates, jobs]
 keywords: [continuous aggregates, policies, remove]
 tags: [delete, drop]
+api:
+  license: community
+  type: function
 ---
 
-## remove_continuous_aggregate_policy() <tag type="community">Community</tag> 
+## remove_continuous_aggregate_policy() <tag type="community">Community</tag>
+
 Remove refresh policy for a continuous aggregate. To view the policies that
 already exist, see [informational views][informational-views].
 
@@ -17,11 +20,12 @@ already exist, see [informational views][informational-views].
 |---|---|---|
 | `continuous_aggregate` | REGCLASS | Name of the continuous aggregate the policy should be removed from |
 
-### Sample usage 
+### Sample usage
+
 Remove the refresh policy from the 'cpu_view' continuous aggregate:
+
 ``` sql
 SELECT remove_continuous_aggregate_policy('cpu_view');
 ```
 
 [informational-views]: /api/:currentVersion:/informational-views/jobs/
-

--- a/api/remove_reorder_policy.md
+++ b/api/remove_reorder_policy.md
@@ -1,13 +1,16 @@
 ---
 api_name: remove_reorder_policy()
 excerpt: Remove a reorder policy from a hypertable
-license: community
-topic: hypertables
+topics: [hypertables, jobs]
 keywords: [reorder, policies, remove]
 tags: [delete, drop]
+api:
+  license: community
+  type: function
 ---
 
-## remove_reorder_policy() <tag type="community">Community</tag> 
+## remove_reorder_policy() <tag type="community">Community</tag>
+
 Remove a policy to reorder a particular hypertable.
 
 ### Required arguments
@@ -16,16 +19,13 @@ Remove a policy to reorder a particular hypertable.
 |---|---|---|
 | `hypertable` | REGCLASS | Name of the hypertable from which to remove the policy. |
 
-
 ### Optional arguments
 
 |Name|Type|Description|
 |---|---|---|
 | `if_exists` | BOOLEAN |  Set to true to avoid throwing an error if the reorder_policy does not exist. A notice is issued instead. Defaults to false. |
 
-
-### Sample usage 
-
+### Sample usage
 
 ```sql
 SELECT remove_reorder_policy('conditions', if_exists => true);

--- a/api/remove_retention_policy.md
+++ b/api/remove_retention_policy.md
@@ -1,13 +1,16 @@
 ---
 api_name: remove_retention_policy()
 excerpt: Remove a retention policy from a hypertable
-license: community
-topic: data retention
+topics: [data retention, jobs]
 keywords: [data retention, policies, remove]
 tags: [delete, drop]
+api:
+  license: community
+  type: function
 ---
 
-## remove_retention_policy() <tag type="community">Community</tag> 
+## remove_retention_policy() <tag type="community">Community</tag>
+
 Remove a policy to drop chunks of a particular hypertable.
 
 ### Required arguments
@@ -22,12 +25,10 @@ Remove a policy to drop chunks of a particular hypertable.
 |---|---|---|
 | `if_exists` | BOOLEAN |  Set to true to avoid throwing an error if the policy does not exist. Defaults to false.|
 
-
-### Sample usage 
+### Sample usage
 
 ```sql
 SELECT remove_retention_policy('conditions');
 ```
 
 Removes the existing data retention policy for the `conditions` table.
-

--- a/api/reorder_chunk.md
+++ b/api/reorder_chunk.md
@@ -1,9 +1,11 @@
 ---
 api_name: reorder_chunk()
 excerpt: Reorder rows in a chunk
-license: community
-topic: hypertables
+topics: [hypertables]
 keywords: [chunks, hypertables, reorder]
+api:
+  license: community
+  type: function
 ---
 
 ## reorder_chunk() <tag type="community">Community</tag>
@@ -41,7 +43,6 @@ using [add_reorder_policy][add_reorder_policy] is often much more convenient.
 ### Returns
 
 This function returns void.
-
 
 ### Sample usage
 

--- a/api/rolling-stats.md
+++ b/api/rolling-stats.md
@@ -1,13 +1,20 @@
 ---
 api_name: rolling()
 excerpt: Roll up multiple statistical aggregates to calculate rolling window aggregates
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [rollup, statistics, statistical aggregates, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: rollup
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: rollup
@@ -20,6 +27,7 @@ rolling(
     ss StatsSummary1D
 ) RETURNS StatsSummary1D
 ```
+
 ```SQL
 rolling(
     ss StatsSummary2D
@@ -29,15 +37,15 @@ rolling(
 This combines multiple outputs from the [`stats_agg()` function][stats_agg] function.
 It works with both one and two dimensional statistical aggregates. It is optimized
 for use in a [window function][postgres-window-functions] context for computing tumbling window
-statistical aggregates. 
+statistical aggregates.
 
-This is especially useful for computing tumbling window aggregates from a continuous aggregate. 
+This is especially useful for computing tumbling window aggregates from a continuous aggregate.
 It uses inverse transition and combine functions to do more efficient windowed aggregates, with the
-possibility that more floating point errors can occur in unusual scenarios. 
+possibility that more floating point errors can occur in unusual scenarios.
 
-It also works for re-aggregation in a non-window context, but the [`rollup` function][rollup-func] 
+It also works for re-aggregation in a non-window context, but the [`rollup` function][rollup-func]
 is more clear. The `rollup` function also work for windowed aggregates, less efficiently but without
-the risk of extra floating point error. 
+the risk of extra floating point error.
 
 For more information about statistical aggregation functions, see the
 [hyperfunctions documentation][hyperfunctions-stats-aggs].
@@ -55,7 +63,9 @@ For more information about statistical aggregation functions, see the
 |`rolling`|`StatsSummary1D`/`StatsSummary2D`|A StatsSummary object that can be passed to further APIs|
 
 ## Sample usage
+
 Create a tumbling window daily aggregate from an hourly continuous aggregate, then use accessors:
+
 ```SQL
 CREATE MATERIALIZED VIEW foo_hourly
 WITH (timescaledb.continuous)
@@ -71,7 +81,6 @@ SELECT
     stddev(rolling(stats) OVER (ORDER BY bucket RANGE '1 day' PRECEDING))
 FROM foo_hourly;
 ```
-
 
 [stats_agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/
 [hyperfunctions-stats-aggs]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/

--- a/api/rollup-counter.md
+++ b/api/rollup-counter.md
@@ -1,13 +1,21 @@
 ---
 api_name: rollup()
 excerpt: Roll up multiple `CounterSummary` aggregates
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 hyperfunctions: [counters, rollup, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: rollup
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: rollup
@@ -40,7 +48,6 @@ For more information about counter aggregation functions, see the
 |-|-|-|
 |`counter_agg`|CounterSummary|A CounterSummary object that can be passed to accessor functions or other objects in the counter aggregate API|
 
-
 ## Sample usage
 
 ```SQL
@@ -61,6 +68,5 @@ SELECT
     delta(counter_summary) / (SELECT delta(full_cs) FROM q LIMIT 1)  as normalized -- get the fraction of the delta that happened each day compared to the full change of the counter
 FROM t;
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/rollup-hyperloglog.md
+++ b/api/rollup-hyperloglog.md
@@ -1,14 +1,22 @@
 ---
 api_name: rollup()
 excerpt: Roll up multiple hyperloglogs
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [rollup, hyperloglog, hyperfunctions, toolkit]
 tags: [approximate, count, distinct]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: approximate count distinct
+  type: rollup
+  aggregates:
+    - approx_count_distinct()
+    - hyperloglog()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'approximate count distinct'
 hyperfunction_subfamily: hyperloglog
 hyperfunction_type: rollup
@@ -40,7 +48,6 @@ For more information about approximate count distinct functions, see the
 |-|-|-|
 |`hyperloglog`|`Hyperloglog`|A hyperloglog containing the count of the union of the input hyperloglogs.|
 
-
 ## Sample usage
 
 ```SQL
@@ -55,6 +62,5 @@ FROM (
 ----------------
          150147
 ```
-
 
 [hyperfunctions-approx-count-distincts]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/approx-count-distincts/

--- a/api/rollup-percentile.md
+++ b/api/rollup-percentile.md
@@ -1,14 +1,23 @@
 ---
 api_name: rollup()
 excerpt: Roll up multiple percentile aggregates, `uddsketch`es, or `tdigest`s
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [rollup, percentiles, hyperfunctions, toolkit]
 tags: [uddsketch, tdigest]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: rollup
+  aggregates:
+    - percentile_agg()
+    - tdigest()
+    - uddsketch()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'percentile approximation'
 hyperfunction_type: rollup
@@ -21,6 +30,7 @@ rollup(
     sketch uddsketch
 ) RETURNS UddSketch
 ```
+
 ```SQL
 rollup(
     digest tdigest
@@ -62,8 +72,10 @@ additional errors compared to calculating the estimator directly on the
 underlying data.
 
 ## Sample usage
+
 Re-aggregate an hourly continuous aggregate into daily buckets, the usage with
 `uddsketch` & `tdigest` is exactly the same:
+
 ```SQL
 CREATE MATERIALIZED VIEW foo_hourly
 WITH (timescaledb.continuous)

--- a/api/rollup-stats.md
+++ b/api/rollup-stats.md
@@ -1,13 +1,20 @@
 ---
 api_name: rollup()
 excerpt: Roll up multiple statistical aggregates
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [rollup, statistics, statistical aggregates, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: rollup
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: rollup
@@ -20,6 +27,7 @@ rollup(
     ss StatsSummary1D
 ) RETURNS StatsSummary1D
 ```
+
 ```SQL
 rollup(
     ss StatsSummary2D
@@ -51,7 +59,9 @@ For more information about statistical aggregation functions, see the
 |`rollup`|`StatsSummary1D`/`StatsSummary2D`|A StatsSummary object which may be passed to further APIs|
 
 ## Sample usage
+
 Re-aggregate an hourly continuous aggregate into daily buckets, then use accessors:
+
 ```SQL
 CREATE MATERIALIZED VIEW foo_hourly
 WITH (timescaledb.continuous)
@@ -68,7 +78,6 @@ SELECT
 FROM foo_hourly
 GROUP BY 1;
 ```
-
 
 [stats_agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/
 [hyperfunctions-stats-aggs]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/

--- a/api/rollup-timeweight.md
+++ b/api/rollup-timeweight.md
@@ -1,13 +1,20 @@
 ---
 api_name: rollup()
 excerpt: Roll up multiple `TimeWeightSummaries`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [rollup, time-weighted, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: time-weighted averages
+  type: rollup
+  aggregates:
+    - time_weight()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'time-weighted averages'
 hyperfunction_subfamily: 'time-weighted averages'
 hyperfunction_type: rollup
@@ -40,7 +47,6 @@ For more information about time-weighted average functions, see the
 |---|---|---|
 |`time_weight`|`TimeWeightSummary`|A TimeWeightSummary object that can be passed to other functions within the time weighting API|
 
-
 ## Sample usage
 
 ```SQL
@@ -61,6 +67,5 @@ SELECT
     average(tw) / (SELECT average(full_tw) FROM q LIMIT 1)  as normalized -- get the normalized average
 FROM t;
 ```
-
 
 [hyperfunctions-time-weight-average]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/time-weighted-averages/

--- a/api/run_job.md
+++ b/api/run_job.md
@@ -1,10 +1,12 @@
 ---
 api_name: run_job()
 excerpt: Manually run a job
-license: community
-topic: jobs
+topics: [jobs]
 keywords: [jobs, run]
 tags: [background jobs, scheduled jobs, automation framework]
+api:
+  license: community
+  type: function
 ---
 
 ## run_job() <tag type="community">Community</tag>
@@ -26,7 +28,9 @@ Any background worker job can be run in the foreground when executed with
 |`job_id`| (INTEGER)  TimescaleDB background job ID |
 
 #### Sample usage
+
 Set log level shown to client to `DEBUG1` and run the job with the job ID 1000:
+
 ```sql
 SET client_min_messages TO DEBUG1;
 CALL run_job(1000);

--- a/api/saturating_add.md
+++ b/api/saturating_add.md
@@ -1,19 +1,27 @@
 ---
 api_name: saturating_add()
 excerpt: Adds two numbers, saturating at the numeric bounds instead of overflowing
-license: community
-toolkit: true
-api_experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, saturating math]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: saturating math
+  type: one-step operation
+# fields below will be deprecated
 api_category: hyperfunction
-hyperfunction_toolkit: true
+api_experimental: true
+toolkit: true
 hyperfunction_family: 'saturating math'
 hyperfunction_subfamily: saturating math
 hyperfunction_type: one-step
 ---
 
 # saturating_add()  <tag type="toolkit">Toolkit</tag><tag type="toolkit-experimental" content="Experimental" />
+
 The `saturating_add` function adds two numbers, saturating at -2147483648 and 2147483647 instead of overflowing.
 
 For more information about saturating math functions, see the
@@ -31,6 +39,5 @@ For more information about saturating math functions, see the
 |Column|Type|Description|
 |-|-|-|
 |`saturating_add`|`INT`| The result of `x+y`, saturating at the numeric bounds instead of overflowing. The numeric bounds are the upper and lower bounds of the 32-bit signed integers.|
-
 
 [saturating-math-docs]: /api/:currentVersion:/hyperfunctions/saturating_math/

--- a/api/saturating_add_pos.md
+++ b/api/saturating_add_pos.md
@@ -1,19 +1,27 @@
 ---
 api_name: saturating_add_pos()
 excerpt: Adds two numbers, saturating at 0 for the minimum bound
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, saturating math]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: saturating match
+  type: one-step operation
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'saturating math'
 hyperfunction_subfamily: saturating math
 hyperfunction_type: one-step
 ---
 
 # saturating_add_pos()  <tag type="toolkit">Toolkit</tag><tag type="toolkit-experimental" content="Experimental" />
+
 The `saturating_add_pos` function adds two numbers, saturating at 0 and 2147483647 instead of overflowing.
 
 For more information about saturating math functions, see the
@@ -31,6 +39,5 @@ For more information about saturating math functions, see the
 |Column|Type|Description|
 |-|-|-|
 |`saturating_add_pos`|`INT`| The result of x+y, saturating at 0 for the minimum bound |
-
 
 [saturating-math-docs]: /api/:currentVersion:/hyperfunctions/saturating_math/

--- a/api/saturating_math.md
+++ b/api/saturating_math.md
@@ -1,3 +1,9 @@
+---
+title: Saturating math
+excerpt: Perform saturating math on integers to keep results within bounds
+keywords: [hyperfunctions, saturating math]
+---
+
 # Saturating math
 
 The saturating math hyperfunctions help you perform saturating math on integers.

--- a/api/saturating_mul.md
+++ b/api/saturating_mul.md
@@ -1,19 +1,27 @@
 ---
 api_name: saturating_mul()
 excerpt: Multiples two numbers, saturating at the numeric bounds instead of overflowing
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, saturating math]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: saturating math
+  type: one-step operation
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'saturating math'
 hyperfunction_subfamily: saturating math
 hyperfunction_type: one-step
 ---
 
 # saturating_mul()  <tag type="toolkit">Toolkit</tag><tag type="toolkit-experimental" content="Experimental" />
+
 The `saturating_mul` function multiples two numbers, saturating at -2147483648 and 2147483647 instead of overflowing.
 
 For more information about saturating math functions, see the
@@ -31,6 +39,5 @@ For more information about saturating math functions, see the
 |Column|Type|Description|
 |-|-|-|
 |saturating_mul |INT| The result of `x*y`, saturating at the numeric bounds instead of overflowing|
-
 
 [saturating-math-docs]: /api/:currentVersion:/hyperfunctions/saturating_math/

--- a/api/saturating_sub.md
+++ b/api/saturating_sub.md
@@ -1,19 +1,27 @@
 ---
 api_name: saturating_sub()
 excerpt: Subtracts one number from another, saturating at the numeric bounds instead of overflowing
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, saturating math]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: saturating math
+  type: one-step operation
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'saturating math'
 hyperfunction_subfamily: saturating math
 hyperfunction_type: one-step
 ---
 
 # saturating_sub()  <tag type="toolkit">Toolkit</tag><tag type="toolkit-experimental" content="Experimental" />
+
 The `saturating_sub` function subtracts the second number from the first, saturating at -2147483648 and 2147483647 instead of overflowing.
 
 For more information about saturating math functions, see the
@@ -31,6 +39,5 @@ For more information about saturating math functions, see the
 |Column|Type|Description|
 |-|-|-|
 |`saturating_sub` |`INT`| The result of `x-y`, saturating at the numeric bounds instead of overflowing |
-
 
 [saturating-math-docs]: /api/:currentVersion:/hyperfunctions/saturating_math/

--- a/api/saturating_sub_pos.md
+++ b/api/saturating_sub_pos.md
@@ -1,19 +1,27 @@
 ---
 api_name: saturating_sub_pos()
 excerpt: Subtracts one number from another, saturating at 0 for the minimum bound
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 tags: [hyperfunctions, saturating math]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: saturating match
+  type: one-step operation
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'saturating math'
 hyperfunction_subfamily: saturating math
 hyperfunction_type: one-step
 ---
 
 # saturating_sub_pos()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit" content="Experimental" />
+
 The `saturating_sub_pos` subtracts the second number from the first, saturating at 0 and 2147483647 instead of overflowing.
 
 For more information about saturating math functions, see the
@@ -31,6 +39,5 @@ For more information about saturating math functions, see the
 |Column|Type|Description|
 |-|-|-|
 |`saturating_sub_pos` |`INT|` The result of `x-y`, saturating at 0 for the minimum bound |
-
 
 [saturating-math-docs]: /api/:currentVersion:/hyperfunctions/saturating_math/

--- a/api/set_chunk_time_interval.md
+++ b/api/set_chunk_time_interval.md
@@ -1,13 +1,16 @@
 ---
 api_name: set_chunk_time_interval()
 excerpt: Change the chunk time interval of a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [chunks, hypertables]
 tags: [time ranges, time intervals]
+api:
+  license: apache
+  type: function
 ---
 
 ## set_chunk_time_interval()
+
 Sets the `chunk_time_interval` on a hypertable. The new interval is used
 when new chunks are created, and time intervals on existing chunks are
 not changed.
@@ -44,9 +47,10 @@ For more information, see the [`create_hypertable` section][create-hypertable].
 You need to use `dimension_name` argument only if your hypertable has multiple
 time dimensions.
 
-
 ### Sample usage
+
 For a TIMESTAMP column, set `chunk_time_interval` to 24 hours:
+
 ```sql
 SELECT set_chunk_time_interval('conditions', INTERVAL '24 hours');
 SELECT set_chunk_time_interval('conditions', 86400000000);
@@ -54,9 +58,9 @@ SELECT set_chunk_time_interval('conditions', 86400000000);
 
 For a time column expressed as the number of milliseconds since the
 UNIX epoch, set `chunk_time_interval` to 24 hours:
+
 ```sql
 SELECT set_chunk_time_interval('conditions', 86400000);
 ```
-
 
 [create-hypertable]: /api/:currentVersion:/hypertable/create_hypertable

--- a/api/set_integer_now_func.md
+++ b/api/set_integer_now_func.md
@@ -1,13 +1,16 @@
 ---
 api_name: set_integer_now_fun()
 excerpt: Define the relationship between integer time values and actual time
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables]
 tags: [integer time values]
+api:
+  license: apache
+  type: function
 ---
 
-## set_integer_now_func() 
+## set_integer_now_func()
+
 This function is only relevant for hypertables with integer (as opposed to
 TIMESTAMP/TIMESTAMPTZ/DATE) time values. For such hypertables, it sets a
 function that returns the `now()` value (current time) in the units of the time
@@ -29,7 +32,7 @@ chunk.
 |---|---|---|
 | `replace_if_exists` | BOOLEAN | Whether to override the function if one is already set. Defaults to false.|
 
-### Sample usage 
+### Sample usage
 
 To set the integer now function for a hypertable with a time column in unix
 time (number of seconds since the unix epoch, UTC).

--- a/api/set_number_partitions.md
+++ b/api/set_number_partitions.md
@@ -1,9 +1,11 @@
 ---
 api_name: set_number_partitions()
 excerpt: Set the number of space partitions for a hypertable
-license: community
-topic: hypertables
+topics: [hypertables]
 keywords: [hypertables, partitions]
+api:
+  license: community
+  type: function
 ---
 
 ## set_number_partitions() <tag type="community">Community</tag>

--- a/api/set_replication_factor.md
+++ b/api/set_replication_factor.md
@@ -1,13 +1,16 @@
 ---
 api_name: set_replication_factor()
 excerpt: Set the replication factor for a distributed hypertable
-license: community
-topic: distributed hypertables
+topics: [distributed hypertables]
 keywords: [distributed hypertables, multi-node, replication]
 tags: [cluster]
+api:
+  license: community
+  type: function
 ---
 
 ## set_replication_factor() <tag type="community">Community</tag>
+
 Sets the replication factor of a distributed hypertable to the given value.
 Changing the replication factor does not affect the number of replicas for existing chunks.
 Chunks created after changing the replication factor are replicated
@@ -28,9 +31,10 @@ the function prints a warning.
 #### Errors
 
 An error is given if:
-- `hypertable` is not a distributed hypertable.
-- `replication_factor` is less than `1`, which cannot be set on a distributed hypertable.
-- `replication_factor` is bigger than the number of attached data nodes.
+
+*   `hypertable` is not a distributed hypertable.
+*   `replication_factor` is less than `1`, which cannot be set on a distributed hypertable.
+*   `replication_factor` is bigger than the number of attached data nodes.
 
 If a bigger replication factor is desired, it is necessary to attach more data nodes
 by using [attach_data_node][attach_data_node].
@@ -38,17 +42,20 @@ by using [attach_data_node][attach_data_node].
 ### Sample usage
 
 Update the replication factor for a distributed hypertable to `2`:
+
 ```sql
 SELECT set_replication_factor('conditions', 2);
 ```
 
 Example of the warning if any existing chunk of the distributed hypertable has less than 2 replicas:
+
 ```
 WARNING:  hypertable "conditions" is under-replicated
 DETAIL:  Some chunks have less than 2 replicas.
 ```
 
 Example of providing too big of a replication factor for a hypertable with 2 attached data nodes:
+
 ```sql
 SELECT set_replication_factor('conditions', 3);
 ERROR:  too big replication factor for hypertable "conditions"

--- a/api/show_chunks.md
+++ b/api/show_chunks.md
@@ -1,13 +1,16 @@
 ---
 api_name: show_chunks()
 excerpt: Show the chunks belonging to a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [chunks, hypertables]
 tags: [show, get]
+api:
+  license: apache
+  type: function
 ---
 
 ## show_chunks()
+
 Get list of chunks associated with a hypertable.
 
 Function accepts the following required and optional arguments. These arguments
@@ -21,7 +24,6 @@ have the same semantics as the `drop_chunks` [function][drop_chunks].
 
 ### Optional arguments
 
-
 |Name|Type|Description|
 |---|---|---|
 | `older_than` | ANY | Specification of cut-off point where any full chunks older than this timestamp should be shown. |
@@ -29,12 +31,12 @@ have the same semantics as the `drop_chunks` [function][drop_chunks].
 
 The `older_than` and `newer_than` parameters can be specified in two ways:
 
-- **interval type:** The cut-off point is computed as `now() -
+*   **interval type:** The cut-off point is computed as `now() -
     older_than` and similarly `now() - newer_than`.  An error is returned if an INTERVAL is supplied
     and the time column is not one of a TIMESTAMP, TIMESTAMPTZ, or
     DATE.
 
-- **timestamp, date, or integer type:** The cut-off point is
+*   **timestamp, date, or integer type:** The cut-off point is
     explicitly given as a TIMESTAMP / TIMESTAMPTZ / DATE or as a
     SMALLINT / INT / BIGINT. The choice of timestamp or integer must follow the type of the hypertable's time column.
 
@@ -47,16 +49,19 @@ intersection between two ranges results in an error.
 ### Sample usage
 
 Get list of all chunks associated with a table:
+
 ```sql
 SELECT show_chunks('conditions');
 ```
 
 Get all chunks from hypertable `conditions` older than 3 months:
+
 ```sql
 SELECT show_chunks('conditions', older_than => INTERVAL '3 months');
 ```
 
 Get all chunks from hypertable `conditions` before 2017:
+
 ```sql
 SELECT show_chunks('conditions', older_than => DATE '2017-01-01');
 ```

--- a/api/show_tablespaces.md
+++ b/api/show_tablespaces.md
@@ -1,13 +1,15 @@
 ---
 api_name: show_tablespaces()
 excerpt: Show the tablespaces attached to a hypertable
-license: apache
-topic: hypertables
+topics: [hypertables]
 keywords: [tablespaces, hypertables]
 tags: [show, get]
+api:
+  license: apache
+  type: function
 ---
 
-## show_tablespaces() 
+## show_tablespaces()
 
 Show the tablespaces attached to a hypertable.
 
@@ -17,8 +19,7 @@ Show the tablespaces attached to a hypertable.
 |---|---|---|
 | `hypertable` | REGCLASS | Hypertable to show attached tablespaces for.|
 
-
-### Sample usage 
+### Sample usage
 
 ```sql
 SELECT * FROM show_tablespaces('conditions');

--- a/api/skewness.md
+++ b/api/skewness.md
@@ -1,13 +1,20 @@
 ---
-api_name: 'skewness() | skewness_y() | skewness_x()'
+api_name: skewness() | skewness_y() | skewness_x()
 excerpt: Calculate the skewness from values in a statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+type:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 1D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-1d
@@ -18,20 +25,22 @@ hyperfunction_type: accessor-1d
 ```SQL
 skewness(summary StatsSummary1D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 skewness_y(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 skewness_x(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
 
 Calculate the [skewness][skewness], or the third statisical moment, of the values contained
-in a statistical aggregate. In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x` 
-form to access the `skewness` of the dependent and independent variables. 
+in a statistical aggregate. In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x`
+form to access the `skewness` of the dependent and independent variables.
 
-The `method` determines whether you calculate a population or sample skewness. 
-These values can be provided as their full names, or you can abbreviate them as `pop` 
-or `samp`. These are the only four accepted values for the `method` argument. The 
+The `method` determines whether you calculate a population or sample skewness.
+These values can be provided as their full names, or you can abbreviate them as `pop`
+or `samp`. These are the only four accepted values for the `method` argument. The
 default is `sample`.
 
 For more information about statistical aggregate functions, see the
@@ -61,12 +70,12 @@ For more information about statistical aggregate functions, see the
 SELECT skewness_x(stats_agg(data, data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  skewness_x 
 ------------
           0
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/slope-counter.md
+++ b/api/slope-counter.md
@@ -1,20 +1,29 @@
 ---
 api_name: slope()
 excerpt: Calculate the slope from values in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
 tags: [least squares, regression]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
 
 # slope() <tag type="toolkit" content="Toolkit" />
+
 The slope of the least squares fit line computed from the adjusted counter
 values and times input in the CounterSummary. Because the times are input as
 seconds, the slope provides a per-second rate of change estimate based on the
@@ -59,6 +68,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/slope-stats.md
+++ b/api/slope-stats.md
@@ -1,14 +1,21 @@
 ---
 api_name: slope()
 excerpt: Calculate the slope from values in a 2-dimensional statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
 tags: [least squares, regression]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 2D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-2d
@@ -21,8 +28,9 @@ slope(
     summary StatsSummary2D
 ) RETURNS DOUBLE PRECISION
 ```
+
 The slope of the [least squares fit][least-squares] line computed from
-a two-dimensional statistical aggregate. 
+a two-dimensional statistical aggregate.
 
 For more information about statistical aggregate functions, see the
 [hyperfunctions documentation][hyperfunctions-stats-agg].
@@ -49,7 +57,6 @@ SELECT
 FROM foo
 GROUP BY id, time_bucket('15 min'::interval, ts)
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/state_agg.md
+++ b/api/state_agg.md
@@ -1,14 +1,20 @@
 ---
 api_name: state_agg()
 excerpt: Aggregate state data into a state aggregate for further analysis
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [states, aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: StateAgg
 hyperfunction_type: aggregate
@@ -17,9 +23,10 @@ hyperfunction_type: aggregate
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # state_agg()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
-The `state_agg` aggregate measures the amount of time spent in each 
-distinct value of a state field. It is designed to work with a relatively small 
-number of states and might not perform well on queries where states are 
+
+The `state_agg` aggregate measures the amount of time spent in each
+distinct value of a state field. It is designed to work with a relatively small
+number of states and might not perform well on queries where states are
 mostly distinct across rows.
 
 <Experimental />
@@ -38,8 +45,10 @@ mostly distinct across rows.
 |`stateagg`|`stateagg`|An object storing the total time spent in each state.|
 
 ## Sample usage
+
 This example creates a state aggregate over a `status` column in a `devices`
 table, with a timestamp column `time`.
+
 ```sql
 CREATE toolkit_experimental.state_agg(time, status) FROM devices;
 ```

--- a/api/stats_agg.md
+++ b/api/stats_agg.md
@@ -1,31 +1,38 @@
 ---
 api_name: stats_agg()
 excerpt: Aggregate statistical data into a statistical aggregate for further analysis
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: aggregate
 ---
 
 # stats_agg() <tag type="toolkit" content="Toolkit" />
-An aggregate that produces a StatsSummary from `DOUBLE PRECISION` values. 
 
-Statistical aggregates can be done on either one or two variables. 
-For a single variable, only one-dimensional aggregates are calculated. 
-For two variables, one-dimensional aggregates are calculated for 
-each variable, and linear regression is performed on both together. 
+An aggregate that produces a StatsSummary from `DOUBLE PRECISION` values.
+
+Statistical aggregates can be done on either one or two variables.
+For a single variable, only one-dimensional aggregates are calculated.
+For two variables, one-dimensional aggregates are calculated for
+each variable, and linear regression is performed on both together.
 
 For more information about statistical aggregation functions, see the
 [hyperfunctions documentation][hyperfunctions-stats-agg].
 
 ## 1D statistical aggregates
-When you perform a statistical aggregate on a single variable, a 
+
+When you perform a statistical aggregate on a single variable, a
 one-dimensional aggregate is calculated.
 
 ### Required arguments
@@ -35,14 +42,14 @@ one-dimensional aggregate is calculated.
 |value|DOUBLE PRECISION|The variable to use for the statistical aggregate|
 
 The `value` argument is currently only accepted as a DOUBLE PRECISION number.
-If you store a value as a different numeric type you can cast to DOUBLE PRECISION 
+If you store a value as a different numeric type you can cast to DOUBLE PRECISION
 on input to the function.
 
 <highlight type="note">
 The `value` can be NULL, but the aggregate is not evaluated
-on NULL values. This means that if the aggregate receives only a NULL value, it 
-returns NULL, it does not return an error. If non-NULL values are also received, the NULL 
-values are ignored. 
+on NULL values. This means that if the aggregate receives only a NULL value, it
+returns NULL, it does not return an error. If non-NULL values are also received, the NULL
+values are ignored.
 </highlight>
 
 ### Returns
@@ -52,9 +59,10 @@ values are ignored.
 |`stats_agg`|`StatsSummary1D`|A one-dimensional StatsSummary object that can be passed to accessor functions or other objects in the stats aggregate API|
 
 ## 2D statistical aggregates
-When you perform a statistical aggregate on two variables, 
-one-dimensional aggregates are calculated for each variable, 
-and linear regression is performed on both together. 
+
+When you perform a statistical aggregate on two variables,
+one-dimensional aggregates are calculated for each variable,
+and linear regression is performed on both together.
 
 ### Required arguments
 
@@ -64,18 +72,18 @@ and linear regression is performed on both together.
 |`X`|`DOUBLE PRECISION`|The independent variable to use for the statistical aggregate|
 
 The `Y` and `X`  arguments are currently only accepted as DOUBLE PRECISION numbers.
-If you store a value as a different numeric type you can cast to DOUBLE PRECISION 
+If you store a value as a different numeric type you can cast to DOUBLE PRECISION
 on input to the function.
 
 Note that the function is called with the dependent variable first (`stats_agg(Y, X)`), which
-could seem unusual because the independent variable is often first in non-SQL contexts. 
-However, this function follows PostgreSQL and the SQL standard, which puts the dependent 
-variable first in [linear regression type functions][pg-stats-aggs]. 
+could seem unusual because the independent variable is often first in non-SQL contexts.
+However, this function follows PostgreSQL and the SQL standard, which puts the dependent
+variable first in [linear regression type functions][pg-stats-aggs].
 
 <highlight type="note">
 Note that `value` can be NULL, but the aggregate is not evaluated
-on NULL values. This means that if the aggregate receives only a NULL value, it 
-returns NULL, it does not return an error. If non-NULL values are also received, the NULL 
+on NULL values. This means that if the aggregate receives only a NULL value, it
+returns NULL, it does not return an error. If non-NULL values are also received, the NULL
 values are ignored. Both `Y` and `X` must be non-NULL for the row to be included.
 </highlight>
 
@@ -86,9 +94,11 @@ values are ignored. Both `Y` and `X` must be non-NULL for the row to be included
 |`stats_agg`|`StatsSummary2D`|A two-dimensional StatsSummary object that can be passed to accessor functions or other objects in the stats aggregate API|
 
 ## Sample usage
-This example produces one and two dimensional `StatsSummaries` in the 
-CTE (`WITH t as (...)`, and then uses the `average` and `slope` accessors 
-for each type to calculate the corresponding values from each function: 
+
+This example produces one and two dimensional `StatsSummaries` in the
+CTE (`WITH t as (...)`, and then uses the `average` and `slope` accessors
+for each type to calculate the corresponding values from each function:
+
 ``` sql
 WITH t as (
     SELECT
@@ -105,7 +115,6 @@ SELECT
     slope(stats2D) -- slope and other regression functions only work on 2D aggregates
 FROM t;
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [pg-stats-aggs]: https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-AGGREGATE-STATISTICS-TABLE

--- a/api/stddev.md
+++ b/api/stddev.md
@@ -1,14 +1,21 @@
 ---
-api_name: 'stddev() | stddev_y() | stddev_x()'
+api_name: stddev() | stddev_y() | stddev_x()
 excerpt: Calculate the standard deviation from values in a statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
 tags: [standard deviation]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 1D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-1d
@@ -19,18 +26,20 @@ hyperfunction_type: accessor-1d
 ```SQL
 stddev(summary StatsSummary1D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 stddev_y(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 stddev_x(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
 
 Get the standard deviation of the values contained in a statistical aggregate.
-In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x` form to access the 
-`stddev` of the dependent and independent variables. 
+In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x` form to access the
+`stddev` of the dependent and independent variables.
 
-The `method` determines whether you calculate a 'population' or 'sample' standard deviation. 
+The `method` determines whether you calculate a 'population' or 'sample' standard deviation.
 These values may be provided as their full names or may be abbreviated 'pop' or 'samp'. These
 are the only four accepted values for the `method` argument. The default is 'sample'.
 
@@ -61,12 +70,12 @@ For more information about statistical aggregate functions, see the
 SELECT stddev_y(stats_agg(data, data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  stddev_y 
 ----------
   29.3002
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/stderror.md
+++ b/api/stderror.md
@@ -1,20 +1,29 @@
 ---
 api_name: stderror()
 excerpt: Estimate the relative standard error of a hyperloglog
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [hyperloglog, hyperfunctions, toolkit]
 tags: [standard error, percentiles]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: approximate count distinct
+  type: accessor
+  aggregates:
+    - approx_count_distinct()
+    - hyperloglog()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'approximate count distinct'
 hyperfunction_subfamily: hyperloglog
 hyperfunction_type: accessor
 ---
 
 # stderror()  <tag type="toolkit">Toolkit</tag>
+
 The `stderror` function returns an estimate of the relative standard error of the hyperloglog, based on the hyperloglog error formula. Approximate results are:
 
 |precision|registers (bucket size)|error|bytes|
@@ -53,6 +62,7 @@ For more information about approximate count distinct functions, see the
 <!---Any special notes about the returns-->
 
 ## Sample usage
+
 This examples retrieves the standard error from a hyperloglog called `hyperloglog`:
 
 ``` sql
@@ -64,6 +74,5 @@ FROM generate_series(1, 100000) data
  0.005745242597140698
 
 ```
-
 
 [hyperfunctions-approx-count-distincts]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/approx-count-distincts/

--- a/api/sum-stats.md
+++ b/api/sum-stats.md
@@ -1,14 +1,21 @@
 ---
-api_name: 'sum() | sum_y() | sum_x()'
+api_name: sum() | sum_y() | sum_x()
 excerpt: Calculate the sum from values in a statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
 tags: [sum]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 1D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-1d
@@ -19,18 +26,19 @@ hyperfunction_type: accessor-1d
 ```SQL
 sum(summary StatsSummary1D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 sum_y(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 sum_x(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
 
 Get the  sum of the values contained in a statistical aggregate.
 
-In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x` form to access the 
-`sum` of the dependent and independent variables. 
-
+In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x` form to access the
+`sum` of the dependent and independent variables.
 
 For more information about statistical aggregate functions, see the
 [hyperfunctions documentation][hyperfunctions-stats-agg].
@@ -53,12 +61,12 @@ For more information about statistical aggregate functions, see the
 SELECT sum_y(stats_agg(data, data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  sum_y 
 -------
   5050
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/tdigest.md
+++ b/api/tdigest.md
@@ -1,20 +1,26 @@
 ---
 api_name: tdigest()
 excerpt: Aggregate data in a `tdigest` for further calculation of percentile estimates
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [percentiles, aggregate, hyperfunctions, toolkit]
 tags: [tdigest]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'advanced aggregation'
 hyperfunction_type: aggregate
 ---
 
 # tdigest() <tag type="toolkit">Toolkit</tag>
+
 ```SQL
 tdigest(
     buckets INTEGER,
@@ -48,7 +54,6 @@ have subtle differences if the call is being parallelized by PostgreSQL.
 *   For some more technical details and usage examples of this algorithm,
     see the [developer documentation][gh-tdigest].
 
-
 ### Required arguments
 
 |Name| Type |Description|
@@ -63,20 +68,22 @@ have subtle differences if the call is being parallelized by PostgreSQL.
 |||A  `tdigest` object which can be passed to other  `tdigest` APIs|
 
 ### Sample usage
+
 This example uses a table called `samples`, with a column called `weights`, that
 holds `DOUBLE PRECISION` values. This query returns a digest over that column:
+
 ```SQL
 SELECT tdigest(100, data) FROM samples;
 ```
 
 This example builds a view from the aggregate that can be passed to other
 `tdigest` functions:
+
 ```SQL
 CREATE VIEW digest AS
     SELECT tdigest(100, data)
     FROM samples;
 ```
-
 
 [hyperfunctions-percentile-approx]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/percentile-approx/
 [gh-tdigest]: https://github.com/timescale/timescaledb-toolkit/blob/main/docs/tdigest.md

--- a/api/time_bucket.md
+++ b/api/time_bucket.md
@@ -1,13 +1,18 @@
 ---
 api_name: time_bucket()
 excerpt: Bucket rows by time interval to calculate aggregates
-license: apache
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [aggregate, hyperfunctions]
 tags: [time buckets, date_trunc]
+api:
+  license: apache
+  type: function
+hyperfunction:
+  type: bucket
 ---
 
 # time_bucket()
+
 The `time_bucket` function is similar to the standard PostgreSQL `date_trunc`
 function. Unlike `date_trunc`, it allows for arbitrary time intervals instead of
 second, minute, and hour intervals. The return value is the bucket's
@@ -62,6 +67,7 @@ function instead.
 ## Sample usage
 
 Simple five minute averaging:
+
 ```sql
 SELECT time_bucket('5 minutes', time) AS five_min, avg(cpu)
 FROM metrics
@@ -70,6 +76,7 @@ ORDER BY five_min DESC LIMIT 10;
 ```
 
 To report the middle of the bucket, instead of the left edge:
+
 ```sql
 SELECT time_bucket('5 minutes', time) + '2.5 minutes'
   AS five_min, avg(cpu)
@@ -80,6 +87,7 @@ ORDER BY five_min DESC LIMIT 10;
 
 For rounding, move the alignment so that the middle of the bucket is at the
 five minute mark, and report the middle of the bucket:
+
 ```sql
 SELECT time_bucket('5 minutes', time, '-2.5 minutes'::INTERVAL) + '2.5 minutes'
   AS five_min, avg(cpu)
@@ -87,12 +95,14 @@ FROM metrics
 GROUP BY five_min
 ORDER BY five_min DESC LIMIT 10;
 ```
+
 In this example, add the explicit cast to ensure that PostgreSQL chooses the
 correct function.
 
 To shift the alignment of the buckets you can use the origin parameter passed as
 a timestamp, timestamptz, or date type. This example shifts the start of the
 week to a Sunday, instead of the default of Monday:
+
 ```sql
 SELECT time_bucket('1 week', timetz, TIMESTAMPTZ '2017-12-31')
   AS one_week, avg(cpu)
@@ -109,6 +119,7 @@ calculated relative to this origin. So, in this example, any Sunday could have
 been used. Note that because `time < TIMESTAMPTZ '2018-01-03'` is used in this
 example, the last bucket would have only 4 days of data. This cast to TIMESTAMP
 converts the time to local time according to the server's timezone setting.
+
 ```sql
 SELECT time_bucket(INTERVAL '2 hours', timetz::TIMESTAMP)
   AS five_min, avg(cpu)

--- a/api/time_bucket_gapfill.md
+++ b/api/time_bucket_gapfill.md
@@ -1,20 +1,24 @@
 ---
 api_name: time_bucket_gapfill()
 excerpt: Bucket rows by time interval while filling gaps in data
-license: community
-toolkit: false
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [gapfill, interpolate, aggregate, hyperfunctions, toolkit]
 tags: [time buckets]
+api:
+  license: community
+  type: function
+hyperfunction:
+  family: gapfilling and interpolation
+  type: bucket
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
 hyperfunction_family: 'gapfilling and interpolation'
 hyperfunction_subfamily: gapfill
 hyperfunction_type: other
 ---
 
 # time_bucket_gapfill() <tag type="community">Community</tag>
+
 The `time_bucket_gapfill` function works similar to `time_bucket` but also
 activates gap filling for the interval between `start` and `finish`. It can only
 be used with an aggregation query. Values outside of `start` and `finish` pass
@@ -83,7 +87,9 @@ data, and does not perform constraint exclusion to exclude chunks from further
 processing, which is less performant.
 
 ### Sample usage
+
 Get the metric value every day over the last seven days:
+
 ```sql
 SELECT
   time_bucket_gapfill('1 day', time) AS day,
@@ -108,6 +114,7 @@ ORDER BY day;
 
 Get the metric value every day over the last seven days, carrying forward the
 previous seen value if none is available in an interval:
+
 ```sql
 SELECT
   time_bucket_gapfill('1 day', time) AS day,
@@ -132,6 +139,7 @@ ORDER BY day;
 
 Get the metric value every day over the last seven days, interpolating missing
 values:
+
 ```sql
 SELECT
   time_bucket_gapfill('1 day', time) AS day,
@@ -153,6 +161,5 @@ ORDER BY day;
  2019-01-15 01:00:00+01 |         1 |   8.0 |         8.0
  2019-01-16 01:00:00+01 |         1 |   9.0 |         9.0
 ```
-
 
 [hyperfunctions-gapfilling]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/gapfilling-interpolation/

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -1,14 +1,19 @@
 ---
 api_name: timescaledb_experimental.time_bucket_ng()
 excerpt: Bucket rows by time interval with support for time zones, months, and years
-license: apache
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [aggregate, hyperfunctions]
 tags: [time buckets]
+api:
+  license: apache
+  type: function
+  experimental: true
+hyperfunction:
+  type: bucket
 ---
 
 ## timescaledb_experimental.time_bucket_ng() <tag type="experimental">Experimental</tag>
+
 The `time_bucket_ng()` (next generation) experimental function is an updated
 version of  the original [`time_bucket()`][time_bucket] function. While
 `time_bucket` works only with small units of time,  `time_bucket_ng()`
@@ -68,7 +73,6 @@ can't be used with continuous aggregates. Best practice is to use
 
 The function returns the bucket's start time. The return value type is the
 same as `ts`.
-
 
 ### Sample usage
 

--- a/api/time_delta.md
+++ b/api/time_delta.md
@@ -1,18 +1,28 @@
 ---
 api_name: time_delta()
 excerpt: Calculate the difference between the start and end times from data in a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: accessor
 ---
+
 # time_delta() <tag type="toolkit" content="Toolkit" />
+
 The observed change in time. Calculated by subtracting the first observed time
 from the last observed time over the period aggregated. Measured in seconds.
 
@@ -53,6 +63,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/time_weight.md
+++ b/api/time_weight.md
@@ -1,13 +1,18 @@
 ---
 api_name: time_weight()
 excerpt: Aggregate data in a `TimeWeightSummary` for further time-weighted analysis
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [time-weighted, aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: time-weighted averages
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'time-weighted averages'
 hyperfunction_subfamily: 'time-weighted averages'
 hyperfunction_type: aggregate
@@ -35,7 +40,6 @@ For more information about time-weighted average functions, see the
 |`method`|`TEXT`| The weighting method we should use, options are `linear` or `LOCF`, not case sensitive|
 |`ts`|`TIMESTAMPTZ`|The time at each point|
 |`value`|`DOUBLE PRECISION`|The value at each point to use for the time-weighted average|
-
 
 Note that `ts` and `value` can be `null`, however the aggregate is not evaluated
 on `null` values and returns `null`, but does not error on `null` inputs.
@@ -68,10 +72,12 @@ FROM t;
 ```
 
 ## Advanced usage notes
+
 Most cases work out of the box, but for power users, or those who want to
 dive deeper, we've included a bit more context below.
 
 ### Interpolation methods details
+
 Discrete time values don't always allow for an obvious calculation of the time-weighted average. In order to calculate a time-weighted average, you need to choose
 how to weight each value. The two methods currently available in TimescaleDB
 Toolkit are last observation
@@ -87,6 +93,7 @@ interpolation approach is used to account for irregularly sampled data where the
 sensor doesn't provide any guarantees.
 
 ### Parallelism and ordering
+
 The time-weighted average calculations we perform require a strict ordering of
 inputs and therefore the calculations are not parallelizable in the strict
 Postgres sense. This is because when Postgres does parallelism it hands out rows
@@ -144,6 +151,5 @@ SELECT measure_id,
 FROM t
 GROUP BY measure_id;
 ```
-
 
 [hyperfunctions-time-weight-average]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/time-weighted-averages/

--- a/api/timescaledb_post_restore.md
+++ b/api/timescaledb_post_restore.md
@@ -1,13 +1,16 @@
 ---
 api_name: timescaledb_post_restore()
 excerpt: Resume normal operations after restoring a database
-license: apache
-topic: admin
+topics: [administration]
 keywords: [admin]
 tags: [restore, backup, background workers]
+api:
+  license: apache
+  type: function
 ---
 
-## timescaledb_post_restore() 
+## timescaledb_post_restore()
+
 Perform the proper operations after restoring the database has completed.
 Specifically this resets the `timescaledb.restoring` GUC and restarts any
 background workers. See [backup/restore docs][backup-restore] for more information.

--- a/api/timescaledb_pre_restore.md
+++ b/api/timescaledb_pre_restore.md
@@ -1,13 +1,15 @@
 ---
 api_name: timescaledb_pre_restore()
 excerpt: Prepare a database for data restoration
-license: apache
-topic: admin
+topics: [administration]
 keywords: [admin]
 tags: [restore, backup, background workers]
+api:
+  license: apache
+  type: function
 ---
 
-## timescaledb_pre_restore() 
+## timescaledb_pre_restore()
 
 Perform the proper operations to allow restoring of the database via `pg_restore` to commence.
 Specifically this sets the `timescaledb.restoring` GUC to `on` and stops any
@@ -15,14 +17,16 @@ background workers which may have been performing tasks until the [`timescaledb_
 function is run following the restore. See [backup/restore docs][backup-restore] for more information.
 
 <highlight type="warning">
- Using this function when doing an upgrade could cause issues in TimescaleDB 
+ Using this function when doing an upgrade could cause issues in TimescaleDB
  versions before 1.7.1.
+
 </highlight>
 
 <highlight type="warning">
  After running `SELECT timescaledb_pre_restore()` you must run the
-  [`timescaledb_post_restore`](/api/latest/administration/timescaledb_post_restore/) function before using 
+  [`timescaledb_post_restore`](/api/latest/administration/timescaledb_post_restore/) function before using
   the database normally.
+
 </highlight>
 
 ### Sample usage  

--- a/api/topn.md
+++ b/api/topn.md
@@ -1,14 +1,22 @@
 ---
 api_name: topn()
 excerpt: Calculate the top N most common values from data in a frequency or top N aggregate
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [frequency, top N, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: accessor
+  aggregates:
+    - topn_agg()
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: SpaceSavingAggregate
 hyperfunction_type: accessor
@@ -17,14 +25,17 @@ hyperfunction_type: accessor
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # topn()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
 Returns the most common values accumulated in a [frequency aggregate][freq_agg]
 or [top N aggregate][topn_agg].
+
 ```sql
 topn (
     agg FrequencyAggregate,
     n INTEGER
 ) RETURNS topn AnyElement
 ```
+
 ```sql
 topn (
     agg TopnAggregate,
@@ -61,9 +72,10 @@ calculate top N.
 |`topn`|`AnyElement`|The `n` most-frequent values in the aggregate.|
 
 In some cases, the function might return fewer than `n` values. This happens if:
-* The underlying frequency aggregate doesn't contain `n` elements with the
+
+*   The underlying frequency aggregate doesn't contain `n` elements with the
   minimum frequency
-* The data isn't skewed enough to support `n` values from a top N aggregate
+*   The data isn't skewed enough to support `n` values from a top N aggregate
 
 <highlight type="warning">
 Requesting more values from a top N aggregate than it was created for will return an
@@ -72,14 +84,17 @@ error. To get more values, adjust the target `n` in
 </highlight>
 
 ## Sample usage
-This test uses a table of randomly generated data. The values used are the 
+
+This test uses a table of randomly generated data. The values used are the
 integer square roots of a random number in the range (0,400).
+
 ```sql
 CREATE TABLE value_test(value INTEGER);
 INSERT INTO value_test SELECT floor(sqrt(random() * 400)) FROM generate_series(1,100000);
 ```
 
 This returns the 5 most common values seen in the table:
+
 ```sql
 SELECT toolkit_experimental.topn(
     toolkit_experimental.freq_agg(0.05, value), 
@@ -88,6 +103,7 @@ FROM value_test;
 ```
 
 The output for this query:
+
 ```sql
  topn 
 ------

--- a/api/topn_agg.md
+++ b/api/topn_agg.md
@@ -1,14 +1,20 @@
 ---
 api_name: topn_agg()
 excerpt: Aggregate data in a top N aggregate for further calculation of most frequent values
-license: community
-toolkit: true
-experimental: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [frequency, top N, aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: frequency analysis
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
 api_experimental: true
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'frequency analysis'
 hyperfunction_subfamily: SpaceSavingAggregate
 hyperfunction_type: aggregate
@@ -17,8 +23,10 @@ hyperfunction_type: aggregate
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # topn_agg() <tag type="toolkit" content="Toolkit" /><tag type="experimental" content="Experimental" />
+
 Produces an aggregate that can be passed to the [`topn` function][topn] to
 calculate the `n` most-frequent values in a column.
+
 ```sql
 topn_agg (
     n INTEGER,
@@ -36,6 +44,7 @@ topn_agg (
 |`value`|`AnyElement`|Column to aggregate|
 
 ## Optional arguments
+
 |Name|Type|Description|
 |-|-|-|
 |`skew`|`DOUBLE PRECISION`|The estimated skew of the data, defined as the `s` parameter of a zeta distribution. Must be greater than `1.0`. Defaults to `1.1`.|
@@ -62,14 +71,17 @@ distribution:
 |`agg`|`SpaceSavingAggregate`|An object storing the most-frequent values of the given column and their estimated frequency.|
 
 ## Sample usage
+
 Create a topN aggregate over the `country` column of the `users` table. Targets
 the top 10 most-frequent values:
+
 ```sql
 CREATE toolkit_experimental.topn_agg(10, country) FROM users;
 ```
 
 Create a topN aggregate over the `type` column of the `devices` table. Estimates
 the skew of the data to be 1.05, and targets the 5 most-frequent values:
+
 ```sql
 CREATE toolkit_experimental.topn_agg(5, 1.05, type) FROM devices;
 ```
@@ -77,6 +89,7 @@ CREATE toolkit_experimental.topn_agg(5, 1.05, type) FROM devices;
 Get the 20 most frequent `zip_code` values of the `employees` table. Uses
 `topn_agg` as an intermediate step. `topn_agg` creates an aggregate for use in
 the `topn` function:
+
 ```sql
 SELECT topn(topn_agg(20, zip_code)) FROM employees;
 ```

--- a/api/uddsketch.md
+++ b/api/uddsketch.md
@@ -1,14 +1,19 @@
 ---
 api_name: uddsketch()
 excerpt: Aggregate data in a `uddsketch` for further calculation of percentile estimates
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [percentiles, hyperfunctions, toolkit]
 tags: [uddsketch]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: percentile approximation
+  type: aggregate
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'percentile approximation'
 hyperfunction_subfamily: 'advanced aggregation'
 hyperfunction_type: aggregate
@@ -46,6 +51,7 @@ percentile approximation functions.
     see the [developer documentation][gh-uddsketch].
 
 ## Required arguments
+
 |Name| Type |Description|
 |-|-|-|
 |`size`|`INTEGER`|Maximum number of buckets in the sketch. Providing a larger value here makes it more likely that the aggregate is able to maintain the desired error, but  potentially increases the memory usage.|
@@ -58,17 +64,19 @@ percentile approximation functions.
 |-|-|-|
 |`uddsketch`|`UddSketch`|A UddSketch object which can be passed to other UddSketch APIs|
 
-
 ## Sample usage
+
 This example uses a table called `samples` with a column called `data` that
 holds `DOUBLE PRECISION` values. This query returns a Uddsketch over that
 column:
+
 ```SQL
 SELECT uddsketch(100, 0.01, data) FROM samples;
 ```
 
 This example builds a view from the aggregate that you can pass to other
 Uddsketch functions:
+
 ```SQL
 CREATE VIEW sketch AS
     SELECT uddsketch(100, 0.01, data)

--- a/api/variance.md
+++ b/api/variance.md
@@ -1,13 +1,20 @@
 ---
-api_name: 'variance() | variance_y() | variance_x()'
+api_name: variance() | variance_y() | variance_x()
 excerpt: Calculate the variance of values from a statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 1D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-1d
@@ -18,20 +25,22 @@ hyperfunction_type: accessor-1d
 ```SQL
 variance(summary StatsSummary1D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 variance_y(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
+
 ```SQL
 variance_x(summary StatsSummary2D, method TEXT) RETURNS BIGINT
 ```
 
 Get the variance of the values contained in a statistical aggregate.
-In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x` form to access the 
-`variance` of the dependent and independent variables. 
+In a two-dimensional [`stats_agg`][stats-agg] use the `_y`/ `_x` form to access the
+`variance` of the dependent and independent variables.
 
-The `method` determines whether you calculate a population or sample variance. 
-These values can be provided as their full names, or you can abbreviate them to `pop` 
-or `samp`. These are the only four accepted values for the `method` argument. The 
+The `method` determines whether you calculate a population or sample variance.
+These values can be provided as their full names, or you can abbreviate them to `pop`
+or `samp`. These are the only four accepted values for the `method` argument. The
 default is `sample`.
 
 For more information about statistical aggregate functions, see the
@@ -61,12 +70,12 @@ For more information about statistical aggregate functions, see the
 SELECT variance_y(stats_agg(data, data))
 FROM generate_series(0, 100) data;
 ```
+
 ```output
  variance_y 
 ------------
       858.5
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/api/with_bounds.md
+++ b/api/with_bounds.md
@@ -1,19 +1,28 @@
 ---
 api_name: with_bounds()
 excerpt: Add bounds to a `CounterSummary`
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [counters, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: mutator
+  aggregates:
+    - counter_agg()
+    - gauge_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'metric aggregation'
 hyperfunction_subfamily: 'counter and gauge aggregation'
 hyperfunction_type: mutator
 ---
 
 # with_bounds() <tag type="toolkit" content="Toolkit" />
+
 A utility function to add bounds to an already-computed CounterSummary. The
 bounds represent the outer limits of the timestamps allowed for this
 CounterSummary as well as the edges of the range to extrapolate to in functions
@@ -63,6 +72,5 @@ FROM (
     GROUP BY id, time_bucket('15 min'::interval, ts)
 ) t
 ```
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/

--- a/api/x_intercept.md
+++ b/api/x_intercept.md
@@ -1,14 +1,21 @@
 ---
 api_name: x_intercept()
 excerpt: Calculate the x-intercept for values in a 2-dimensional statistical aggregate
-license: community
-toolkit: true
-topic: hyperfunctions
+topics: [hyperfunctions]
 keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
 tags: [least squares, regression]
+api:
+  license: community
+  type: function
+  toolkit: true
+hyperfunction:
+  family: statistical aggregates
+  type: accessor, 2D
+  aggregates:
+    - stats_agg()
+# fields below will be deprecated
 api_category: hyperfunction
-api_experimental: false
-hyperfunction_toolkit: true
+toolkit: true
 hyperfunction_family: 'statistical aggregates'
 hyperfunction_subfamily: 'statistical aggregates'
 hyperfunction_type: accessor-2d
@@ -51,7 +58,6 @@ SELECT
 FROM foo
 GROUP BY id, time_bucket('15 min'::interval, ts)
 ```
-
 
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [stats-agg]: /api/:currentVersion:/hyperfunctions/stats_aggs/stats_agg/

--- a/timescaledb/how-to-guides/hyperfunctions/about-hyperfunctions.md
+++ b/timescaledb/how-to-guides/hyperfunctions/about-hyperfunctions.md
@@ -7,6 +7,7 @@ keywords: [hyperfunctions, Toolkit, analytics]
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # About Timescale hyperfunctions
+
 Timescale hyperfunctions are a specialized set of functions that allow you to
 analyze time-series data. You can use hyperfunctions to analyze anything you
 have stored as time-series data, including IoT devices, IT systems, marketing
@@ -32,62 +33,79 @@ marked 'experimental' are still under development.
 ### Approximate count distincts
 
 <hyperfunctionTable
-	hyperfunctionFamily='approximate count distinct'
-	includeExperimental
+ hyperfunctionFamily='approximate count distinct'
+ includeExperimental
+ sortByType
+/>
+
+### Saturating math
+
+<hyperfunctionTable
+ hyperfunctionFamily='saturating math'
+ includeExperimental
+ sortByType
 />
 
 ### Statistical aggregates
 
 <hyperfunctionTable
-	hyperfunctionFamily='statistical aggregates'
-	includeExperimental
+ hyperfunctionFamily='statistical aggregates'
+ includeExperimental
+ sortByType
 />
 
 ### Gapfilling and interpolation
 
 <hyperfunctionTable
-	hyperfunctionFamily='gapfilling and interpolation'
-	includeExperimental
+ hyperfunctionFamily='gapfilling and interpolation'
+ includeExperimental
+ sortByType
 />
 
 ### Percentile approximation
 
 <hyperfunctionTable
-	hyperfunctionFamily='percentile approximation'
-	includeExperimental
+ hyperfunctionFamily='percentile approximation'
+ includeExperimental
+ sortByType
 />
 
 ### Metric aggregation
 
 <hyperfunctionTable
-	hyperfunctionFamily='metric aggregation'
-	includeExperimental
+ hyperfunctionFamily='metric aggregation'
+ includeExperimental
+ sortByType
 />
 
 ### Time-weighted averages
 
 <hyperfunctionTable
-	hyperfunctionFamily='time-weighted averages'
-	includeExperimental
+ hyperfunctionFamily='time-weighted averages'
+ includeExperimental
+ sortByType
 />
 
 ### Downsample
 
 <hyperfunctionTable
-	hyperfunctionFamily='downsample'
-	includeExperimental
+ hyperfunctionFamily='downsample'
+ includeExperimental
+ sortByType
 />
 
 ### Frequency analysis
 
 <hyperfunctionTable
-	hyperfunctionFamily='frequency analysis'
-	includeExperimental
+ hyperfunctionFamily='frequency analysis'
+ includeExperimental
+ sortByType
 />
 
 For more information about each of the API calls listed in this table, see our [hyperfunction API documentation][api-hyperfunctions].
 
 ## Function pipelines
+
 Function pipelines are an experimental feature, designed to radically improve
 the developer ergonomics of analyzing data in PostgreSQL and SQL, by applying
 principles from functional programming and popular tools like Python's Pandas,
@@ -98,11 +116,12 @@ can get quite unwieldy. For example, this query gets data from the last day from
 the measurements table, sorts the data by the time column, calculates the delta
 between the values, takes the absolute value of the delta, and then takes the
 sum of the result of the previous steps:
+
 ```SQL
 SELECT device id,
 sum(abs_delta) as volatility
 FROM (
-	SELECT device_id,
+ SELECT device_id,
 abs(val - lag(val) OVER last_day) as abs_delta
 FROM measurements
 WHERE ts >= now()-'1 day'::interval) calc_delta
@@ -110,6 +129,7 @@ GROUP BY device_id;
 ```
 
 You can express the same query with a function pipeline like this:
+
 ```SQL
 SELECT device_id,
  timevector(ts, val) -> sort() -> delta() -> abs() -> sum() as volatility
@@ -125,6 +145,7 @@ For more information about how function pipelines work, read our
 [blog post][blog-function-pipelines].
 
 ## Toolkit feature development
+
 Timescale Toolkit features are developed in the open. As features are developed
 they are categorized as experimental, beta, stable, or deprecated. This
 documentation covers the stable features, but more information on our
@@ -132,6 +153,7 @@ experimental features in development can be found in the
 [Toolkit repository][gh-docs].
 
 ## Contribute to Timescale Toolkit
+
 We want and need your feedback! What are the frustrating parts of analyzing
 time-series data? What takes far more code than you feel it should? What runs
 slowly, or only runs quickly after many rewrites? We want to solve


### PR DESCRIPTION
Clean up API frontmatter. Namespace API- and hyperfunction-specific
fields so things are easier to find.

Convert `topic` (singular) to `topics` (plural) to accommodate APIs that
relate to multiple topics (for example, both compression and jobs).

Mark fields that will be deprecated (as soon as the hyperfunction tables
component is updated).

Convert the hyperfunction tables in `About hyperfunctions` to be sorted
by type:
*   Makes it easier to find things and makes the structure of families
    clearer
*   There is currently a bug with the non-sorted tables

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
