### PR TITLE
Fix frontmatter inconsistency

### DIFF
--- a/cloud/migrate-to-cloud/index.md
+++ b/cloud/migrate-to-cloud/index.md
@@ -1,12 +1,13 @@
 ---
 title: Migrate your TimescaleDB database to Timescale Cloud
 excerpt: Migrate from self-hosted TimescaleDB or Managed Service for TimescaleDB
-product: [cloud]
+product: cloud
 keywords: [migrate, self-hosted, mst]
 tags: [ingest]
 ---
 
 # Migrate your TimescaleDB database to Timescale Cloud
+
 You can migrate your data to Timescale Cloud from self-hosted TimescaleDB or
 Managed Service for TimescaleDB. This allows you to use Timescale Cloud's
 exclusive features, including separate scaling for compute and storage
@@ -26,6 +27,7 @@ There are two methods for migrating your data:
     continuous aggregates, and policies.
 
 ## Choose a migration method
+
 Which method you choose depends on your database size, network upload and
 download speeds, existing continuous aggregates, and tolerance for failure
 recovery.
@@ -42,7 +44,7 @@ Migrating your schema and data separately does not retain continuous aggregates
 calculated using already-deleted data. For example, if you delete raw data after
 a month but retain downsampled data in a continuous aggregate for a year, the
 continuous aggregate loses any data older than a month upon migration. If you
-must keep continuous aggregates calculated using deleted data, migrate your 
+must keep continuous aggregates calculated using deleted data, migrate your
 entire database at once regardless of database size.
 </highlight>
 
@@ -51,6 +53,7 @@ to estimate the time required. If the time estimate is very long, stop the
 migration and switch to the other method.
 
 ## Migrate an active database
+
 If your database is actively ingesting data, take precautions to ensure that
 Timescale Cloud contains the data that is ingested while the migration is
 happening. Begin by running ingest in parallel on the source database and

--- a/cloud/migrate-to-cloud/schema-then-data.md
+++ b/cloud/migrate-to-cloud/schema-then-data.md
@@ -1,12 +1,13 @@
 ---
 title: Migrate schema and data separately
 excerpt: Migrate your TimescaleDB data and schema to Timescale Cloud
-product: [cloud]
+product: cloud
 keywords: [migrate]
 tags: [ingest]
 ---
 
 # Migrate schema and data separately
+
 Migrate larger databases by migrating your schema first, then migrating the
 data. This method copies each table or chunk separately, which allows you to
 restart midway if one copy operation fails.
@@ -28,6 +29,7 @@ method](https://docs.timescale.com/cloud/latest/migrate-to-cloud/).
 </highlight>
 
 The procedure to migrate your database requires these steps:
+
 *   [Migrate schema pre-data](#migrate-schema-pre-data)
 *   [Restore hypertables in Timescale Cloud](#restore-hypertables-in-timescale-cloud)
 *   [Copy data from the source database](#copy-data-from-the-source-database)
@@ -39,7 +41,7 @@ The procedure to migrate your database requires these steps:
 
 <highlight type="warning">
 Depending on your database size and network speed, steps that involve copying
-data can take a very long time. You can continue reading from your source 
+data can take a very long time. You can continue reading from your source
 database during this time, though performance could be slower. To avoid this
 problem, fork your database and migrate your data from the fork. If you write to
 the tables in your source database during the migration, the new writes might
@@ -48,7 +50,9 @@ not be transferred to Timescale Cloud. To avoid this problem, see the section on
 </highlight>
 
 ## Prerequisites
+
 Before you begin, check that you have:
+
 *   Installed the PostgreSQL [`pg_dump`][pg_dump] and [`pg_restore`][pg_restore]
     utilities.
 *   Installed a client for connecting to PostgreSQL. These instructions use
@@ -69,6 +73,7 @@ Before you begin, check that you have:
     [upgrading TimescaleDB section][upgrading-timescaledb].
 
 ## Migrate schema pre-data
+
 Migrate your pre-data from your source database to Timescale Cloud. This
 includes table and schema definitions, as well as information on sequences,
 owners, and settings. This doesn't include Timescale-specific schemas.
@@ -76,18 +81,22 @@ owners, and settings. This doesn't include Timescale-specific schemas.
 <procedure>
 
 ### Migrating schema pre-data
+
 1.  Dump the schema pre-data from your source database into a `dump_pre_data.bak` file, using
     your source database connection details. Exclude Timescale-specific schemas.
     If you are prompted for a password, use your source database credentials:
+
     ```bash
     pg_dump -U <SOURCE_DB_USERNAME> -W \
     -h <SOURCE_DB_HOST> -p <SOURCE_DB_PORT> -Fc -v \
     --section=pre-data --exclude-schema="_timescaledb*" \
     -f dump_pre_data.bak <DATABASE_NAME>
     ```
+
 1.  Restore the dumped data from the `dump_pre_data.bak` file into your Timescale Cloud
     database, using your Timescale Cloud connection details. To avoid
     permissions errors, include the `--no-owner` flag:
+
     ```bash
     pg_restore -U tsdbadmin -W \
     -h <CLOUD_HOST> -p <CLOUD_PORT> --no-owner -Fc \
@@ -97,6 +106,7 @@ owners, and settings. This doesn't include Timescale-specific schemas.
 </procedure>
 
 ### Troubleshooting
+
 If you see any of these errors during the migration process, you can safely
 ignore them. The migration still occurs successfully.
 
@@ -125,6 +135,7 @@ pg_restore: WARNING:  no privileges were granted for "<..>"
 ```
 
 ## Restore hypertables in Timescale Cloud
+
 After pre-data migration, your hypertables from your source database become
 regular PostgreSQL tables in Cloud. Recreate your hypertables in Cloud to
 restore them.
@@ -132,11 +143,15 @@ restore them.
 <procedure>
 
 ### Restoring hypertables in Timescale Cloud
+
 1.  Connect to your Timescale Cloud database:
+
     ```sql
     psql "postgres://tsdbadmin:<CLOUD_PASSWORD>@<CLOUD_HOST>:<CLOUD_PORT>/tsdb?sslmode=require"
     ```
+
 1.  Restore the hypertable:
+
     ```sql
     SELECT create_hypertable(
        '<TABLE_NAME>', '<TIME_COLUMN_NAME>',
@@ -147,20 +162,26 @@ restore them.
 </procedure>
 
 ## Copy data from the source database
+
 After restoring your hypertables, return to your source database to copy your
 data, table by table.
 
 <procedure>
 
 ### Copying data from your source database
+
 1.  Connect to your source database:
+
     ```bash
     psql "postgres://<SOURCE_DB_USERNAME>:<SOURCE_DB_PASSWORD>@<SOURCE_DB_HOST>:<SOURCE_DB_PORT>/<SOURCE_DB_NAME>?sslmode=require"
     ```
+
 1.  Dump the data from the first table into a `.csv` file:
+
     ```sql
     \COPY (SELECT * FROM <TABLE_NAME>) TO <TABLE_NAME>.csv CSV
     ```
+
     Repeat for each table and hypertable you want to migrate.
 
 </procedure>
@@ -172,9 +193,11 @@ Split each table by time range, and copy each range individually. For example:
 ```sql
 \COPY (SELECT * FROM <TABLE_NAME> WHERE time > '2021-11-01' AND time < '2011-11-02') TO <TABLE_NAME_DATE_RANGE>.csv CSV
 ```
+
 </highlight>
 
 ## Restore data into Timescale Cloud
+
 When you have copied your data into `.csv` files, you can restore it to
 Timescale Cloud by copying from the `.csv` files. There are two methods: using
 regular PostgreSQL [`COPY`][copy], or using the TimescaleDB
@@ -183,7 +206,7 @@ regular PostgreSQL [`COPY`][copy], or using the TimescaleDB
 is not included by default. You must install the function.
 
 <highlight type="important">
-Because `COPY` decompresses data, any compressed data in your source 
+Because `COPY` decompresses data, any compressed data in your source
 database is now stored uncompressed in your `.csv` files. If you
 provisioned your Timescale Cloud storage for your compressed data, the
 uncompressed data may take too much storage. To avoid this problem, periodically
@@ -194,13 +217,17 @@ the [compression section](https://docs.timescale.com/timescaledb/latest/how-to-g
 <procedure>
 
 ### Restoring data into Timescale Cloud with timescaledb-parallel-copy
+
 1.  At the command prompt, install `timescaledb-parallel-copy`:
+
     ```bash
     go get github.com/timescale/timescaledb-parallel-copy/cmd/timescaledb-parallel-copy
     ```
+
 1.  Use `timescaledb-parallel-copy` to import data into
     your Cloud database. Set `<NUM_WORKERS>` to twice the number of CPUs in your
     database. For example, if you have 4 CPUs, `<NUM_WORKERS>` should be `8`.
+
     ```bash
     timescaledb-parallel-copy \
     --connection "host=<CLOUD_HOST> \
@@ -213,6 +240,7 @@ the [compression section](https://docs.timescale.com/timescaledb/latest/how-to-g
     --workers <NUM_WORKERS> \
     --reporting-period 30s
     ```
+
     Repeat for each table and hypertable you want to migrate.
 
 </procedure>
@@ -220,38 +248,48 @@ the [compression section](https://docs.timescale.com/timescaledb/latest/how-to-g
 <procedure>
 
 ### Restoring data into Timescale Cloud with COPY
+
 1.  Connect to your Timescale Cloud database:
+
     ```sql
     psql "postgres://tsdbadmin:<CLOUD_PASSWORD>@<CLOUD_HOST>:<CLOUD_PORT>/tsdb?sslmode=require"
     ```
+
 1.  Restore the data to your Timescale Cloud database:
+
     ```sql
     \COPY <TABLE_NAME> FROM '<TABLE_NAME>.csv' WITH (FORMAT CSV);
     ```
+
     Repeat for each table and hypertable you want to migrate.
 
 </procedure>
 
 ## Migrate schema post-data
+
 When you have migrated your table and hypertable data, migrate your PostgreSQL
 schema post-data. This includes information about constraints.
 
 <procedure>
 
 ### Migrating schema post-data
+
 1.  At the command prompt, dump the schema post-data from your source database
     into a `dump_post_data.bak` file, using your source database connection details. Exclude
     Timescale-specific schemas. If you are prompted for a password, use your
     source database credentials:
+
     ```bash
     pg_dump -U <SOURCE_DB_USERNAME> -W \
     -h <SOURCE_DB_HOST> -p <SOURCE_DB_PORT> -Fc -v \
     --section=post-data --exclude-schema="_timescaledb*" \
     -f dump_post_data.bak <DATABASE_NAME>
     ```
+
 1.  Restore the dumped schema post-data from the `dump_post_data.bak` file into your Timescale
     Cloud database, using your Timescale Cloud connection details. To avoid
     permissions errors, include the `--no-owner` flag:
+
     ```bash
     pg_restore -U tsdbadmin -W \
     -h <CLOUD_HOST> -p <CLOUD_PORT> --no-owner -Fc \
@@ -261,6 +299,7 @@ schema post-data. This includes information about constraints.
 </procedure>
 
 ### Troubleshooting
+
 If you see these errors during the migration process, you can safely ignore
 them. The migration still occurs successfully.
 
@@ -273,6 +312,7 @@ pg_restore: error: could not execute query: ERROR:  trigger "ts_insert_blocker" 
 ```
 
 ## Recreate continuous aggregates
+
 By default, continuous aggregates aren't migrated when you transfer your schema
 and data separately. Restore them by recreating the continuous aggregate
 definitions and recomputing the results on your Cloud database. The recomputed
@@ -282,11 +322,15 @@ don't include deleted raw data.
 <procedure>
 
 ### Recreating continuous aggregates
+
 1.  Connect to your source database:
+
     ```bash
     psql "postgres://<SOURCE_DB_USERNAME>:<SOURCE_DB_PASSWORD>@<SOURCE_DB_HOST>:<SOURCE_DB_PORT>/<SOURCE_DB_NAME>?sslmode=require"
     ```
+
 1.  Get a list of your existing continuous aggregate definitions:
+
     ```sql
     SELECT view_name, view_definition FROM timescaledb_information.continuous_aggregates;
     ```
@@ -304,11 +348,15 @@ don't include deleted raw data.
                     |     GROUP BY (time_bucket('01:00:00'::interval, fill_measurements."time")), fill_measurements.sensor_id;
     (1 row)
     ```
+
 1.  Connect to your Timescale Cloud database:
+
     ```bash
     psql "postgres://tsdbadmin:<CLOUD_PASSWORD>@<CLOUD_HOST>:<CLOUD_PORT>/tsdb?sslmode=require"
     ```
+
 1.  Recreate each continuous aggregate definition:
+
     ```sql
     CREATE MATERIALIZED VIEW <VIEW_NAME>
     WITH (timescaledb.continuous) AS
@@ -318,28 +366,36 @@ don't include deleted raw data.
 </procedure>
 
 ## Recreate policies
+
 By default, policies aren't migrated when you transfer your schema and data
 separately. Recreate them on your Cloud database.
 
 <procedure>
 
 ### Recreating policies
+
 1.  Connect to your source database:
+
     ```sql
     psql "postgres://<SOURCE_DB_USERNAME>:<SOURCE_DB_PASSWORD>@<SOURCE_DB_HOST>:<SOURCE_DB_PORT>/<SOURCE_DB_NAME>?sslmode=require"
     ```
+
 1.  Get a list of your existing policies. This query returns a list of all your
     policies, including continuous aggregate refresh policies, retention
     policies, compression policies, and reorder policies:
+
     ```sql
     SELECT application_name, schedule_interval, retry_period,
         config, hypertable_name
         FROM timescaledb_information.jobs WHERE owner = '<SOURCE_DB_USERNAME>';
     ```
+
 1.  Connect to your Timescale Cloud database:
+
     ```sql
     psql "postgres://tsdbadmin:<CLOUD_PASSWORD>@<CLOUD_HOST>:<CLOUD_PORT>/tsdb?sslmode=require"
     ```
+
 1.  Recreate each policy. For more information about recreating policies, see
     the sections on [continuous-aggregate refresh policies][cagg-policy],
     [retention policies][retention-policy], [compression
@@ -348,8 +404,10 @@ separately. Recreate them on your Cloud database.
 </procedure>
 
 ## Update table statistics
+
 Update your table statistics by running [`ANALYZE`][analyze] on your entire
 dataset:
+
 ```sql
 ANALYZE;
 ```
@@ -359,7 +417,7 @@ ANALYZE;
 If you see errors of the following form when you run `ANALYZE`, you can safely
 ignore them:
 
-```
+```bash
 WARNING:  skipping "<TABLE OR INDEX>" --- only superuser can analyze it
 ```
 
@@ -369,9 +427,7 @@ accessed. Skipping them does not affect statistics on your data.
 [analyze]: https://www.postgresql.org/docs/10/sql-analyze.html
 [cagg-policy]: /timescaledb/:currentVersion:/how-to-guides/continuous-aggregates/refresh-policies/
 [copy]: https://www.postgresql.org/docs/9.2/sql-copy.html
-[compression]: /timescaledb/:currentVersion:/how-to-guides/compression/
 [compression-policy]: /getting-started/:currentVersion:/compress-data/
-[choosing-method]: /cloud/:currentVersion:/migrate-to-cloud/
 [extensions]: /cloud/:currentVersion:/customize-configuration/#postgresql-extensions
 [install-timescale-cloud]: /install/:currentVersion:/installation-cloud/
 [pg_dump]: https://www.postgresql.org/docs/current/app-pgdump.html

--- a/cloud/service-explorer.md
+++ b/cloud/service-explorer.md
@@ -1,11 +1,12 @@
 ---
 title: Service explorer
 excerpt: Get insight into the performance and structure of your database
-product: [cloud]
+product: cloud
 keywords: [services, hypertables, schemas, indexes, policies]
 ---
 
-# Service Explorer
+# Service explorer
+
 Timescale Cloud Service Explorer provides a rich administrative dashboard for
 understanding the state of your database instance. The Explorer gives you
 insight into the performance of your database, giving you greater confidence and
@@ -22,6 +23,7 @@ the `Services` section, clicking the service you want to explore, and selecting
 the `Explorer` tab.
 
 ## General information
+
 In the `General information` section of the Explorer, you can see a high-level
 summary of your TimescaleDB database, including all your hypertables and
 relational tables. It summarizes your overall compression ratios, and other
@@ -30,9 +32,12 @@ features like TimescaleDB's native compression, continuous aggregates, or other
 automation policies and actions, it provides pointers to tutorials and
 documentation to help you get started.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-explorer.png" alt="Timescale Cloud Explorer, General Information section"/>
+<img class="main-content__illustration"
+src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-explorer.png"
+alt="Timescale Cloud Explorer, General Information section"/>
 
 ## Tables
+
 In the `Tables` section of the Explorer, you can see a detailed look into all
 your tables, including information about table schemas, table indexes, and
 foreign keys. For your hypertables, it shows details about chunks, continuous
@@ -40,17 +45,22 @@ aggregates, and policies such as data retention policies and data reordering.
 You can also inspect individual hypertables, including their sizes, dimension
 ranges, and compression status.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-explorer-tables.png" alt="Timescale Cloud Explorer, Tables section"/>
+<img class="main-content__illustration"
+src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-explorer-tables.png"
+alt="Timescale Cloud Explorer, Tables section"/>
 
 For more information about hypertables, see our
 [hypertables section][hypertables].
 
 ## Continuous aggregates
+
 In the `Continuous aggregate` section, you can see all your continuous
 aggregates, including top-level information such as their size, whether they are
 configured for real-time aggregation, and their refresh periods.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-explorer-caggs.png" alt="Timescale Cloud Explorer, Continuous aggregates section"/>
+<img class="main-content__illustration"
+src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-explorer-caggs.png"
+alt="Timescale Cloud Explorer, Continuous aggregates section"/>
 
 For more information about continuous aggregates, see our
 [continuous aggregates section][caggs].

--- a/cloud/service-logs.md
+++ b/cloud/service-logs.md
@@ -1,14 +1,15 @@
 ---
 title: Service logs
 excerpt: View your Timescale Cloud service logs
-product: [cloud]
+product: cloud
 keywords: [logs, services]
 ---
 
 # Service logs
+
 From the `Services` page, click the service you are interested in and navigate
 to the `Logs` tab. This section contains your service's logging data.
 
-<img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-services-logs.png" alt="Timescale Cloud Services Logs"/>
-
-[cloud-login]: https://console.cloud.timescale.com/
+<img class="main-content__illustration"
+src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-services-logs.png"
+alt="Timescale Cloud Services Logs"/>


### PR DESCRIPTION
Fix a frontmatter inconsistency where the `product` field was sometimes
a string and sometimes an array, causing Gatsby to ignore the field when
creating its schema.

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
