### PR TITLE
Fix nesting in core concepts compression section

### DIFF
--- a/timescaledb/overview/core-concepts/compression/architecture.md
+++ b/timescaledb/overview/core-concepts/compression/architecture.md
@@ -254,7 +254,7 @@ compression][improving-compression].
 [compression-algorithms]: #type-specific-compression-algorithms
 [compression-algorithms-blog]: https://www.timescale.com/blog/time-series-compression-algorithms-explained/
 [data-retention]: /timescaledb/:currentVersion:/how-to-guides/data-retention/
-[decompress]: https://docs.timescale.com/timescaledb/latest/how-to-guides/compression/decompress-chunks/
+[decompress]: /timescaledb/:currentVersion:/how-to-guides/compression/decompress-chunks/
 [improving-compression]: /timescaledb/:currentVersion:/how-to-guides/compression/improve-compression.md
 [indexes]: #indexes-on-compressed-chunks
 [ordering-and-segmenting]: #data-ordering-and-segmenting

--- a/timescaledb/overview/page-index/page-index.js
+++ b/timescaledb/overview/page-index/page-index.js
@@ -45,6 +45,15 @@ module.exports = [
             tags: ["compression", "hypertables", "timescaledb"],
             keywords: ["hypertables", "compression", "TimescaleDB"],
             excerpt: "Using compression on hypertables",
+            children: [
+              {
+                title: "Compression architecture",
+                href: "architecture",
+                tags: ["compression", "hypertables", "timescaledb"],
+                keywords: ["hypertables", "compression", "TimescaleDB"],
+                excerpt: "Understanding compression architecture",
+              }
+            ],
           },
           {
             title: "Continuous aggregates",


### PR DESCRIPTION
# Description

404 report indicated dead links in the Compression section. Upon investigation, it looks as though the index was not pointing to the nested page properly. Hopefully this fixes it 🤞 

# Links

Fixes https://github.com/timescale/docs/issues/1440
Fixes https://github.com/timescale/docs/issues/1434
Fixes https://github.com/timescale/docs/issues/1437
Fixes https://github.com/timescale/docs/issues/1447

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
