### PR TITLE
Move info on restarting workers from KB

### DIFF
--- a/_partials/_cloud-mst-restart-workers.mdx
+++ b/_partials/_cloud-mst-restart-workers.mdx
@@ -1,0 +1,8 @@
+On Timescale Cloud and Managed Service for TimescaleDB, restart background
+workers by doing one of the following:
+
+*   Run `SELECT timescaledb_pre_restore()`, followed by `SELECT
+    timescaledb_post_restore()`.
+*   Power the service off and on again. This might cause a downtime of a few
+    minutes while the service restores from backup and replays the write-ahead
+    log.

--- a/_troubleshooting/timescaledb/scheduled-jobs-stop-running.md
+++ b/_troubleshooting/timescaledb/scheduled-jobs-stop-running.md
@@ -14,17 +14,13 @@ keywords: [jobs, policies, user-defined actions]
 tags: [jobs, scheduled jobs, background jobs, background workers, automation framework, policies, user-defined actions]
 ---
 
-<!---
-* Keep this section in alphabetical order
-* Use this format for writing troubleshooting sections:
- - Cause: What causes the problem?
- - Consequence: What does the user see when they hit this problem?
- - Fix/Workaround: What can the user do to fix or work around the problem? Provide a "Resolving" Procedure if required.
- - Result: When the user applies the fix, what is the result when the same action is applied?
-* Copy this comment at the top of every troubleshooting page
--->
+import CloudMSTRestartWorkers from 'versionContent/_partials/_cloud-mst-restart-workers.mdx';
 
-If your scheduled jobs stop running, try restarting the background workers:
-```
+Your scheduled jobs might stop running for various reasons. On self-hosted
+TimescaleDB, you can fix this by restarting background workers:
+
+```sql
 SELECT _timescaledb_internal.start_background_workers();
 ```
+
+<CloudMSTRestartWorkers />

--- a/cloud/troubleshooting.md
+++ b/cloud/troubleshooting.md
@@ -5,6 +5,8 @@ product: cloud
 keywords: [troubleshooting]
 ---
 
+import CloudMSTRestartWorkers from 'versionContent/_partials/_cloud-mst-restart-workers.mdx';
+
 # Troubleshooting
 
 This section covers some common errors or problems you might run into while
@@ -29,5 +31,12 @@ compatibility with older clients.
 
 For information on changing your authentication type, see the documentation on
 [resetting your service password][password-reset].
+
+## Scheduled jobs stop running
+
+Your scheduled jobs might stop running for various reasons. You can restart them
+by restarting your background workers.
+
+<CloudMSTRestartWorkers />
 
 [password-reset]: /cloud/:currentVersion:/service-operations/general/#reset-service-password

--- a/mst/troubleshooting.md
+++ b/mst/troubleshooting.md
@@ -5,6 +5,8 @@ product: mst
 keywords: [troubleshooting]
 ---
 
+import CloudMSTRestartWorkers from 'versionContent/_partials/_cloud-mst-restart-workers.mdx';
+
 # Troubleshooting
 
 This section covers some common errors or problems you might run into while
@@ -54,6 +56,13 @@ using [continuous aggregates][howto-caggs], or
 [configuring data retention][howto-dataretention] to reduce the amount of
 resources your database uses. If you still need help, reach out to our [support
 team][timescale-support] to have a conversation.
+
+## Scheduled jobs stop running
+
+Your scheduled jobs might stop running for various reasons. You can restart them
+by restarting your background workers.
+
+<CloudMSTRestartWorkers />
 
 [howto-compression]: /timescaledb/:currentVersion:/how-to-guides/compression
 [howto-caggs]: /timescaledb/:currentVersion:/how-to-guides/continuous-aggregates

--- a/timescaledb/how-to-guides/troubleshoot-timescaledb.md
+++ b/timescaledb/how-to-guides/troubleshoot-timescaledb.md
@@ -4,31 +4,34 @@ excerpt: Troubleshoot common problems that occur when using TimescaleDB
 keywords: [troubleshooting]
 ---
 
+import CloudMSTRestartWorkers from 'versionContent/_partials/_cloud-mst-restart-workers.mdx';
+
 # Troubleshooting
 
 If you run into problems when using TimescaleDB, there are a few things that you
-can do. There are some solutions to common errors below as well as ways to output
-diagnostic information about your setup. If you need more guidance, you can join
-the support [slack group][slack] or post an issue on the TimescaleDB [github][].
+can do. There are some solutions to common errors below as well as ways to
+output diagnostic information about your setup. If you need more guidance, you
+can join the support [slack group][slack] or post an issue on the TimescaleDB
+[github][].
 
 ## Common errors
 
-### Error updating TimescaleDB when using a third-party PostgreSQL admin tool
+### Error updating TimescaleDB when using a third-party PostgreSQL administration tool
 
-The update command `ALTER EXTENSION timescaledb UPDATE` must be the first command
-executed upon connection to a database. Some admin tools execute command before
-this, which can disrupt the process. It may be necessary for you to manually update
-the database with `psql`.  See our [update docs][update-db] for details.
+The update command `ALTER EXTENSION timescaledb UPDATE` must be the first
+command executed upon connection to a database. Some administration tools
+execute commands before this, which can disrupt the process. It may be necessary
+for you to manually update the database with `psql`.  See the [update
+docs][update-db] for details.
 
-###  Log error: could not access file "timescaledb"
+### Log error: could not access file "timescaledb"
 
-If your PostgreSQL logs have this error preventing it from starting up,
-you should double check that the TimescaleDB files have been installed
-to the correct location. Our installation methods use `pg_config` to
-get PostgreSQL's location. However if you have multiple versions of
-PostgreSQL installed on the same machine, the location `pg_config`
-points to may not be for the version you expect. To check which
-version TimescaleDB used:
+If your PostgreSQL logs have this error preventing it from starting up, you
+should double check that the TimescaleDB files have been installed to the
+correct location. The installation methods use `pg_config` to get PostgreSQL's
+location. However if you have multiple versions of PostgreSQL installed on the
+same machine, the location `pg_config` points to may not be for the version you
+expect. To check which version TimescaleDB used:
 
 ```bash
 $ pg_config --version
@@ -44,35 +47,42 @@ $ pg_config --bindir
 /usr/local/Cellar/postgresql/11.0/bin
 ```
 
-If either of those steps is not the version you are expecting, you need
-to either (a) uninstall the incorrect version of PostgreSQL if you can or
-(b) update your `PATH` environmental variable to have the correct
-path of `pg_config` listed first, that is, by prepending the full path:
+If either of those steps is not the version you are expecting, you need to
+either uninstall the incorrect version of PostgreSQL if you can, or update your
+`PATH` environmental variable to have the correct path of `pg_config` listed
+first, that is, by prepending the full path:
 
 ```bash
-$ export PATH = /usr/local/Cellar/postgresql/11.0/bin:$PATH
+export PATH = /usr/local/Cellar/postgresql/11.0/bin:$PATH
 ```
+
 Then, reinstall TimescaleDB and it should find the correct installation
 path.
 
 ### ERROR: could not access file "timescaledb-\<version\>": No such file or directory
 
 If the error occurs immediately after updating your version of TimescaleDB and
-the file mentioned is from the previous version, it is probably due to an incomplete
-update process. Within the greater PostgreSQL server instance, each
+the file mentioned is from the previous version, it is probably due to an
+incomplete update process. Within the greater PostgreSQL server instance, each
 database that has TimescaleDB installed needs to be updated with the SQL command
-`ALTER EXTENSION timescaledb UPDATE;` while connected to that database. Otherwise,
-the database will be looking for the previous version of the timescaledb files.
+`ALTER EXTENSION timescaledb UPDATE;` while connected to that database.
+Otherwise, the database looks for the previous version of the timescaledb files.
 
 See [our update docs][update-db] for more info.
 
 ### Scheduled jobs stop running
-If your scheduled jobs stop running, try restarting the background workers:
-```
+
+Your scheduled jobs might stop running for various reasons. On self-hosted
+TimescaleDB, you can fix this by restarting background workers:
+
+```sql
 SELECT _timescaledb_internal.start_background_workers();
 ```
 
+<CloudMSTRestartWorkers />
+
 ### Failed to start a background worker
+
 You might see this error message in the logs if background workers aren't
 properly configured:
 
@@ -91,7 +101,7 @@ For more information, see the [worker configuration docs][worker-config].
 
 ## Getting more information
 
-###  EXPLAINing query performance
+### EXPLAINing query performance
 
 PostgreSQL's EXPLAIN feature allows users to understand the underlying query
 plan that PostgreSQL uses to execute a query. There are multiple ways that
@@ -121,6 +131,7 @@ or via [slack][], providing the EXPLAIN output of a
 query is immensely helpful.
 
 ### View logs in Docker
+
 If you have TimescaleDB installed in a Docker container, you can view your logs
 using Docker, instead of looking in `/var/lib/logs` or `/var/logs`. For more
 information, see the [Docker documentation on logs][docker-logs].

--- a/timescaledb/how-to-guides/troubleshoot-timescaledb.md
+++ b/timescaledb/how-to-guides/troubleshoot-timescaledb.md
@@ -9,20 +9,20 @@ import CloudMSTRestartWorkers from 'versionContent/_partials/_cloud-mst-restart-
 # Troubleshooting
 
 If you run into problems when using TimescaleDB, there are a few things that you
-can do. There are some solutions to common errors below as well as ways to
+can do. There are some solutions to common errors in this section as well as ways to
 output diagnostic information about your setup. If you need more guidance, you
-can join the support [slack group][slack] or post an issue on the TimescaleDB
-[github][].
+can join the community [Slack group][slack] or post an issue on the TimescaleDB
+[GitHub][github].
 
 ## Common errors
 
 ### Error updating TimescaleDB when using a third-party PostgreSQL administration tool
 
-The update command `ALTER EXTENSION timescaledb UPDATE` must be the first
+The `ALTER EXTENSION timescaledb UPDATE` command must be the first
 command executed upon connection to a database. Some administration tools
-execute commands before this, which can disrupt the process. It may be necessary
-for you to manually update the database with `psql`.  See the [update
-docs][update-db] for details.
+execute commands before this, which can disrupt the process. You might
+need to manually update the database with `psql`.  See the 
+[update docs][update-db] for details.
 
 ### Log error: could not access file "timescaledb"
 
@@ -66,7 +66,7 @@ the file mentioned is from the previous version, it is probably due to an
 incomplete update process. Within the greater PostgreSQL server instance, each
 database that has TimescaleDB installed needs to be updated with the SQL command
 `ALTER EXTENSION timescaledb UPDATE;` while connected to that database.
-Otherwise, the database looks for the previous version of the timescaledb files.
+Otherwise, the database looks for the previous version of the `timescaledb` files.
 
 See [our update docs][update-db] for more info.
 


### PR DESCRIPTION
Move info on restarting background workers from the Knowledge Base. This
is useful for Cloud as well (and we don't have the fact that
`start_background_workers` doesn't work on these platforms documented),
so add it to general troubleshooting and Cloud troubleshooting.

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
