### PR TITLE
Add ap-southeast-2 (Sydney) to the region list

### DIFF
--- a/cloud/index.md
+++ b/cloud/index.md
@@ -43,6 +43,7 @@ and extensions.
 
 ### Available in multiple AWS regions
 Choose your preferred AWS region for each service. Supported regions include:
+*   `ap-southeast-2`, APAC (Sydney)
 *   `eu-central-1`, Europe (Frankfurt)
 *   `eu-west-1`, Europe (Ireland)
 *   `us-east-1`, US East (North Virginia)


### PR DESCRIPTION
# Description

Adding the `ap-southeast-2` region to the list of available regions on Cloud ☁️ 

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

(me)

- [x] Is the content technically accurate?
- [x] Is the content complete?
- [x] Is the content presented in a logical order? (alpha)
- [x] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
