### PR TITLE
Fix the Timescale Cloud excerpt

### DIFF
--- a/cloud/page-index/page-index.js
+++ b/cloud/page-index/page-index.js
@@ -4,10 +4,10 @@ module.exports = [
     filePath: "index.md",
     href: "cloud",
     name: "About Timescale Cloud",
-    excerpt: "Timescale Cloud is a fully managed, hosted TimescaleDB service",
+    excerpt:
+      "Timescale Cloud is a cloud-native TimescaleDB as a service that is easy to get started and powerful enough for the most demanding scenarios",
     tags: ["tsc"],
     keywords: ["Timescale Cloud"],
-    excerpt: "Timescale Cloud documentation",
     children: [
       {
         title: "Services",
@@ -164,8 +164,13 @@ module.exports = [
       {
         title: "Integrations",
         href: "integrations",
-        tags: ['integrations', 'tsc', 'datadog', 'cloudwatch'],
-        keywords: ['integrations', 'DataDog', 'AWS CloudWatch', 'Timescale Cloud'],
+        tags: ["integrations", "tsc", "datadog", "cloudwatch"],
+        keywords: [
+          "integrations",
+          "DataDog",
+          "AWS CloudWatch",
+          "Timescale Cloud",
+        ],
         excerpt: "Export telemetry data to a third-party monitoring service",
       },
       {


### PR DESCRIPTION
The Timescale Cloud excerpt was defined twice, and the less-descriptive
definition was being used. Remove the duplicate definition and refine
the remaining one to better promote the benefits of Cloud

# Links

Fixes https://github.com/timescale/docs-private/issues/43

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
