### PR TITLE
Add Timescale Cloud signup flow to GSG

### DIFF
--- a/_partials/_cloud-connect.mdx
+++ b/_partials/_cloud-connect.mdx
@@ -1,0 +1,40 @@
+When you have a service up and running, you can connect to it from your local
+system using the `psql` command-line utility. If you've used PostgreSQL before,
+you might already have `psql` installed. If not, check out the [installing
+psql][install-psql] section.
+
+<procedure>
+
+### Connecting to your service from the command prompt
+
+1.  Sign in to the [Timescale Cloud portal][tsc-portal].
+1.  In the `Services` tab, find the service you want to connect to, and check
+    it is marked as `Running`.
+1.  Click the name of the service you want to connect to see the connection
+    information. Take a note of the `Service URL`.
+1.  Navigate to the `Operations` tab, and click `Reset password`. You can choose
+    your own password for the service, or allow Timescale Cloud to generate a
+    secure password for you. Take a note of your new password.
+1.  On your local system, at the command prompt, connect to the service using
+    the service URL. When you are prompted for the password, enter the password
+    you just created:
+
+    ```bash
+    psql -x "postgres://tsdbadmin@t9aggksc24.gspnhi29bv.tsdb.cloud.timescale.com:33251/tsdb?sslmode=require"
+    Password for user tsdbadmin:
+    ```
+
+    If your connection is successful, you'll see a message like this, followed
+    by the `psql` prompt:
+
+    ```
+    psql (13.3, server 12.8 (Ubuntu 12.8-1.pgdg21.04+1))
+    SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
+    Type "help" for help.
+    tsdb=>
+    ```
+
+</procedure>
+
+[install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
+[tsc-portal]: https://console.cloud.timescale.com/

--- a/_partials/_cloud-create-service.mdx
+++ b/_partials/_cloud-create-service.mdx
@@ -1,0 +1,53 @@
+A service in Timescale Cloud is a cloud instance which contains your database.
+Each service contains a single database, named `tsdb`.
+
+<procedure>
+
+### Creating your first service
+
+<ol>
+  <li>
+    <p>
+      Sign in to the{" "}
+      <a href="https://console.cloud.timescale.com/">Timescale Cloud portal</a>.
+    </p>
+  </li>
+  <li>
+    <p>
+      Click <code>Create service</code>.
+    </p>
+  </li>
+  <li>
+    <p>
+      You can choose to build your service with or without demo data.{" "}
+      {props.demoData ? (
+        <>
+          If this is your first service, we recommend that you choose the option{" "}
+          <code>With demo data</code>, because it is the best way to see how
+          Timescale Cloud works in the real world.
+        </>
+      ) : (
+        <>
+          Choose <code>Without demo data</code> to continue with this tutorial.
+        </>
+      )}
+    </p>
+  </li>
+  {props.demoData && (
+    <li>
+      <p>
+        Click <code>Start demo</code> to create your service with demo data, and
+        launch the <code>Allmilk Factory</code> interactive demo. You can exit
+        the demo at any time, and revisit it from the same point later on. You
+        can also re-run the demo after you have completed it.
+      </p>
+      <img
+        class="main-content__illustration"
+        src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-new-service.png"
+        alt="Create a new service in the Timescale Cloud portal"
+      />
+    </li>
+  )}
+</ol>
+
+</procedure>

--- a/_partials/_cloud-installation.mdx
+++ b/_partials/_cloud-installation.mdx
@@ -1,0 +1,27 @@
+<procedure>
+
+### Installing Timescale Cloud
+
+1.  Sign up for a [Timescale Cloud account][sign-up] with your
+    name and email address. You do not need to provide payment details to
+    get started. A confirmation email is sent to the email address you provide.
+1.  Verify your email by clicking on the link in the email you received. Don't
+    forget to check your spam folder in case the email ends up there.
+1.  Sign in to the [Timescale Cloud portal][tsc-portal] with the
+    password you set:
+    <img
+      class="main-content__illustration"
+      src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-portal-noservices.png"
+      alt="Timescale Cloud Portal"
+    />
+
+<highlight type="important">
+  Your Timescale Cloud trial is completely free for you to use for the first
+  thirty days. This gives you enough time to complete all our tutorials and run
+  a few test projects of your own.
+</highlight>
+
+</procedure>
+
+[sign-up]: https://www.timescale.com/timescale-signup
+[tsc-portal]: https://console.cloud.timescale.com/

--- a/getting-started/create-database.md
+++ b/getting-started/create-database.md
@@ -1,0 +1,47 @@
+---
+title: Create a TimescaleDB database
+excerpt: Create and connect to a TimescaleDB database
+keywords: [databases, create, connect]
+---
+
+import Install from "versionContent/_partials/_cloud-installation.mdx";
+import CreateService from "versionContent/_partials/_cloud-create-service.mdx";
+import Connect from "versionContent/_partials/_cloud-connect.mdx";
+
+# Create a TimescaleDB database
+
+<!-- vale Google.We = NO -->
+To work with TimescaleDB, you need a TimescaleDB database. The easiest way to
+get started is to use Timescale Cloud, our hosted, cloud-native database
+service.
+<!-- vale Google.We = YES -->
+
+## Install Timescale Cloud
+
+Install Timescale Cloud by signing up for an account. It's free for thirty days.
+It's a cloud service, so you don't need to download anything to your own
+machines.
+
+<Install />
+
+<highlight type="note">
+Need to self-host your own database? See the other installation options in the
+[install section](/install/latest/).
+</highlight>
+
+## Create your first service
+
+<CreateService demoData={false} />
+
+## Connect to your service
+
+<Connect />
+
+## Next steps
+
+Now that you have a database and a way of connecting to it, you're ready to
+start using TimescaleDB features. In the next section, [learn about
+hypertables][gsg-hypertables] and how they improve ingest and query for
+time-based data.
+
+[gsg-hypertables]: /getting-started/:currentVersion:/create-hypertable/

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -5,16 +5,11 @@ excerpt: Get started with your first TimescaleDB instance
 
 # Getting started with TimescaleDB
 
-**Congratulations!** You're here because you have successfully spun
-up your first instance of TimescaleDB, can connect to it, and are ready to
-explore some of the most popular TimescaleDB features. If you have not yet
-created a TimescaleDB instance or learned how to connect to it, make sure to
-check out these two sections:
-
-* [Install TimescaleDB][install]
-* [Connect to TimescaleDB][connecting]
+Get started with TimescaleDB to experience the power of its core features, such
+as hypertables, continuous aggregates, and compression.
 
 ## What is TimescaleDB?
+
 TimescaleDB is an extension on top of PostgreSQL.
 When you use TimescaleDB, you get all the time-series optimizations and special
 features that TimescaleDB provides, along with all the features available
@@ -26,6 +21,7 @@ all the tools and connectors within the PostgreSQL ecosystem. If it works with
 PostgreSQL, it works with TimescaleDB.
 
 ## About this tutorial
+
 This Getting Started section gives you a hands-on introduction to the
 fundamentals of TimescaleDB. You'll learn definitions
 of key terms like hypertables and chunks, and use some of TimescaleDB's key
@@ -38,12 +34,12 @@ and the other containing company information which maps to the symbols.
 
 Let's jump right in!
 
+## Getting help
+
 If you have any questions or concerns as you go through the tutorial,
 check out the Timescale community [Slack][slack] and [Timescale Forum][forum], where
 you can find help from the Timescale community and team.
 
-[connecting]: /timescaledb/:currentVersion:/how-to-guides/connecting/
 [forum]: https://www.timescale.com/forum
-[install]: /install/:currentVersion:/
 [slack]: https://slack.timescale.com/
 [twelve-data]: https://twelvedata.com/

--- a/getting-started/page-index/page-index.js
+++ b/getting-started/page-index/page-index.js
@@ -1,78 +1,87 @@
 module.exports = [
-    {
-        title: "Getting started",
-        href: "getting-started",
-        pageComponents: ['featured-cards'],
-        tags: ["timescaledb", "overview", "learn", "contribute"],
-        keywords: ["instance", "time-series", "hypertable", "query"],
-        excerpt: "Getting started with TimescaleDB",
+  {
+    title: "Getting started",
+    href: "getting-started",
+    pageComponents: ["featured-cards"],
+    tags: ["timescaledb", "overview", "learn", "contribute"],
+    keywords: ["instance", "time-series", "hypertable", "query"],
+    excerpt: "Getting started with TimescaleDB",
+    children: [
+      {
+        title: "1. Create a TimescaleDB database",
+        href: "create-database",
+        tags: ["database", "create", "learn", "timescaledb"],
+        keywords: ["database", "tutorial", "TimescaleDB"],
+        excerpt: "Create and connect to a TimescaleDB database",
+      },
+      {
+        title: "2. Create a hypertable",
+        href: "create-hypertable",
+        tags: ["hypertables", "create", "learn", "timescaledb"],
+        keywords: ["hypertables", "tutorial", "TimescaleDB"],
+        excerpt: "Create a hypertable in TimescaleDB",
+      },
+      {
+        title: "3. Add time-series data",
+        href: "add-data",
+        tags: ["hypertables", "data", "ingest", "learn", "timescaledb"],
+        keywords: ["hypertables", "tutorial", "TimescaleDB"],
+        excerpt: "Add sample data to your TimescaleDB instance",
+      },
+      {
+        title: "4. Query your data",
+        href: "query-data",
+        tags: ["data", "query", "learn", "timescaledb"],
+        keywords: ["tutorial", "TimescaleDB"],
+        excerpt: "Query your data using full SQL in TimescaleDB",
+      },
+      {
+        title: "5. Create a continuous aggregate",
+        href: "create-cagg",
+        tags: ["caggs", "create", "learn", "timescaledb"],
+        keywords: ["continuous aggregates", "tutorial", "TimescaleDB"],
+        excerpt: "Establish continuous aggregates in TimescaleDB",
         children: [
           {
-            title: "1. Create a hypertable",
-            href: "create-hypertable",
-            tags: ['hypertables', 'create', 'learn', 'timescaledb'],
-            keywords: ['hypertables', 'tutorial', 'TimescaleDB'],
-            excerpt: "Create a hypertable in TimescaleDB"
+            title: "Continuous aggregate basics",
+            href: "create-cagg-basics",
+            tags: ["caggs", "create", "learn", "timescaledb"],
+            keywords: ["continuous aggregates", "tutorial", "TimescaleDB"],
+            excerpt: "Create continuous aggregates in TimescaleDB",
           },
           {
-            title: "2. Add time-series data",
-            href: "add-data",
-            tags: ['hypertables', 'data', 'ingest', 'learn', 'timescaledb'],
-            keywords: ['hypertables', 'tutorial', 'TimescaleDB'],
-            excerpt: "Add sample data to your TimescaleDB instance"
+            title: "Continuous aggregate policies and refreshing data",
+            href: "create-cagg-policy",
+            tags: ["caggs", "create", "learn", "timescaledb"],
+            keywords: ["continuous aggregates", "tutorial", "TimescaleDB"],
+            excerpt: "Establish continuous aggregates policy in TimescaleDB",
           },
-          {
-            title: "3. Query your data",
-            href: "query-data",
-            tags: ['data', 'query', 'learn', 'timescaledb'],
-            keywords: ['tutorial', 'TimescaleDB'],
-            excerpt: "Query your data using full SQL in TimescaleDB"
-          },
-          {
-            title: "4. Create a continuous aggregate",
-            href: "create-cagg",
-            tags: ['caggs', 'create', 'learn', 'timescaledb'],
-            keywords: ['continuous aggregates', 'tutorial', 'TimescaleDB'],
-            excerpt: "Establish continuous aggregates in TimescaleDB",
-            children: [
-              {
-                title: "Continuous aggregate basics",
-                href: "create-cagg-basics",
-                tags: ['caggs', 'create', 'learn', 'timescaledb'],
-                keywords: ['continuous aggregates', 'tutorial', 'TimescaleDB'],
-                excerpt: "Create continuous aggregates in TimescaleDB",
-              },
-              {
-                title: "Continuous aggregate policies and refreshing data",
-                href: "create-cagg-policy",
-                tags: ['caggs', 'create', 'learn', 'timescaledb'],
-                keywords: ['continuous aggregates', 'tutorial', 'TimescaleDB'],
-                excerpt: "Establish continuous aggregates policy in TimescaleDB",
-              },
-              ]
-          },
-          {
-            title: "5. Save space with compression",
-            href: "compress-data",
-            tags: ['compression', 'data', 'learn', 'timescaledb'],
-            keywords: ['compression', 'tutorial', 'TimescaleDB'],
-            excerpt: "Use TimescaleDB's native compression to save space"
-          },
-          {
-            title: "6. Learn about data retention",
-            href: "data-retention",
-            tags: ['data', 'manage', 'learn', 'timescaledb'],
-            keywords: ['data', 'tutorial', 'TimescaleDB'],
-            excerpt: "Create a database retention policy for your TimescaleDB instance"
-          },
+        ],
+      },
+      {
+        title: "6. Save space with compression",
+        href: "compress-data",
+        tags: ["compression", "data", "learn", "timescaledb"],
+        keywords: ["compression", "tutorial", "TimescaleDB"],
+        excerpt: "Use TimescaleDB's native compression to save space",
+      },
+      {
+        title: "7. Learn about data retention",
+        href: "data-retention",
+        tags: ["data", "manage", "learn", "timescaledb"],
+        keywords: ["data", "tutorial", "TimescaleDB"],
+        excerpt:
+          "Create a database retention policy for your TimescaleDB instance",
+      },
 
-          {
-            title: "7. Next steps",
-            href: "next-steps",
-            tags: ['migrate', 'visualize', 'manage', 'learn', 'timescaledb'],
-            keywords: ['tutorial', 'TimescaleDB'],
-            excerpt: "Learn how to migrate, visualize and connect your data to TimescaleDB"
-          }
-        ]
-      }
-]
+      {
+        title: "8. Next steps",
+        href: "next-steps",
+        tags: ["migrate", "visualize", "manage", "learn", "timescaledb"],
+        keywords: ["tutorial", "TimescaleDB"],
+        excerpt:
+          "Learn how to migrate, visualize and connect your data to TimescaleDB",
+      },
+    ],
+  },
+];

--- a/install/installation-cloud.md
+++ b/install/installation-cloud.md
@@ -8,7 +8,12 @@ order: 1
 keywords: [install]
 ---
 
+import Install from "versionContent/_partials/_cloud-installation.mdx";
+import CreateService from "versionContent/_partials/_cloud-create-service.mdx";
+import Connect from "versionContent/_partials/_cloud-connect.mdx";
+
 # Install Timescale Cloud
+
 Timescale Cloud is a hosted, cloud-native TimescaleDB service that allows you to
 quickly spin up new TimescaleDB instances. You can
 [try Timescale Cloud for free][sign-up], no credit card required.
@@ -18,97 +23,23 @@ and cost-effective way to store and analyze your time-series data. Get started
 super fast with demo data, or your own dataset, and enjoy the security of
 automated upgrades and backups.
 
-Each Timescale Cloud service can have a single database. The database must be
-named `tsdb`. To create a second database, you need to create a second service.
-
-<procedure>
-
-### Installing Timescale Cloud
-1.  Sign up for a [Timescale Cloud account][sign-up] with your
-    name and email address. You do not need to provide payment details to
-    get started. A confirmation email is sent to the email address you provide.
-1.  Verify your email by clicking on the link in the email you received. Don't
-    forget to check your spam folder in case the email ends up there.
-1.  Sign in to the [Timescale Cloud portal][tsc-portal] with the
-    password you set:
-    <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-portal-noservices.png" alt="Timescale Cloud Portal"/>
-
-<highlight type="important">
-Your Timescale Cloud trial is completely free for you to use for the first
-thirty days. This gives you enough time to complete all our tutorials and run a
-few test projects of your own.
-</highlight>
-
-</procedure>
+<Install />
 
 ## Create your first service
-A service in Timescale Cloud is a cloud instance which you can install your
-database on.
 
-<procedure>
-
-### Creating your first service
-1.  Sign in to the [Timescale Cloud portal][tsc-portal].
-1.  Click `Create service`.
-1.  You can choose to build your service with or without demo data. If this is
-    your first service, we recommend that you choose the `With demo data`,
-    because it is the best way to see how Timescale Cloud works in the real
-    world.
-1.  Click `Start demo` to create your service with demo data, and launch
-    the `Allmilk Factory` interactive demo. You can exit the demo at any time,
-    and revisit it from the same point later on. You can also re-run the demo
-    after you have completed it.
-
-    <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-new-service.png" alt="Create a new service in the Timescale Cloud portal"/>
-
-<highlight type="important">
-Your Timescale Cloud trial is completely free for you to use for the first
-thirty days. This gives you enough time to complete all our tutorials and run a
-few test projects of your own.
-</highlight>
-
-</procedure>
+<CreateService demoData={true} />
 
 ## Connect to your service from the command prompt
-When you have a service up and running, you can connect to it from your local
-system using the `psql` command-line utility. This is the same tool you might
-have used to connect to PostgreSQL before, but if you haven't installed it yet,
-check out our [installing psql][install-psql] section.
 
-<procedure>
-
-### Connecting to your service from the command prompt
-1.  Sign in to the [Timescale Cloud portal][tsc-portal].
-1.  In the `Services` tab, find the service you want to connect to, and check
-    it is marked as `Running`.
-1.  Click the name of the service you want to connect to see the connection
-    information. Take a note of the `Service URL`.
-1.  Navigate to the `Operations` tab, and click `Reset password`. You can choose
-    your own password for the service, or allow Timescale Cloud to generate a
-    secure password for you. Take a note of your new password.
-1.  On your local system, at the command prompt, connect to the service using
-    the service URL. When you are prompted for the password, enter the password
-    you just created:
-    ```bash
-    psql -x "postgres://tsdbadmin@t9aggksc24.gspnhi29bv.tsdb.cloud.timescale.com:33251/tsdb?sslmode=require"
-    Password for user tsdbadmin:
-    ```
-    If your connection is successful, you'll see a message like this, followed
-    by the `psql` prompt:
-    ```
-    psql (13.3, server 12.8 (Ubuntu 12.8-1.pgdg21.04+1))
-    SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
-    Type "help" for help.
-    tsdb=>
-    ```
-
-</procedure>
+<Connect />
 
 ## Check that you have the TimescaleDB extension
+
 TimescaleDB is provided as an extension to your PostgreSQL database, and it is
 enabled by default when you create a new service on Timescale Cloud. You can
 check that the TimescaleDB extension is installed by using the `\dx` command at
 the `psql` prompt. It looks like this:
+
 ```sql
 tsdb=> \dx
 List of installed extensions
@@ -137,6 +68,7 @@ tsdb=>
 ```
 
 ## Where to next
+
 Now that you have your first service up and running, you can check out the
 [Timescale Cloud][tsc-docs] section in our documentation, and
 find out what you can do with it.
@@ -151,12 +83,9 @@ TimescaleDB, visit the
 You can always [contact us][contact] if you need help working something out, or
 if you want to have a chat.
 
-
-[tsc-portal]: https://console.cloud.timescale.com/
+[contact]: https://www.timescale.com/contact
 [sign-up]: https://www.timescale.com/timescale-signup
 [timescale-features]: https://www.timescale.com/products/#Features
 [timescale-pricing]: https://www.timescale.com/products#cloud-pricing
-[contact]: https://www.timescale.com/contact
-[install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
 [tsc-docs]: /cloud/:currentVersion:/
 [tutorials]: /timescaledb/:currentVersion:/tutorials/


### PR DESCRIPTION
The Timescale Cloud signup flow was removed from the Getting Started
Guide to reduce duplicate content, which made getting started less smooth, as it required jumping
back and forth between different how-to guides and tutorials.

This uses partials to add the Timescale Cloud signup flow back into the
guide.

> **Note**: The "create a service" partial admittedly contains an ugly amount of JSX. Gatsby doesn't do control flow in Markdown particularly elegantly compared to other static site generators. I think we can take the degradation in writer experience here because both pages involved (Install Cloud and Getting Started) are high-impact and being able to reuse this content is a great pro.

# Links

Fixes https://github.com/timescale/docs-private/issues/46

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
