### PR TITLE
Partiotioning Column is time

### DIFF
--- a/timescaledb/how-to-guides/hypertables/hypertables-and-unique-indexes.md
+++ b/timescaledb/how-to-guides/hypertables/hypertables-and-unique-indexes.md
@@ -79,7 +79,7 @@ You get the error:
 ERROR: cannot create a unique index without the column "<COLUMN_NAME>" (used in partitioning) 
 ```
 
-Fix the error by adding `device_id` to your unique index.
+Fix the error by adding `time` to your unique index.
 </highlight>
 
 ## Create a hypertable from a table with unique indexes


### PR DESCRIPTION

# Description

We should add `time` into unique index definition. Device_id is already added.


# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
