### PR TITLE
Fix 404s from over the weekend

### DIFF
--- a/mst/about-mst.md
+++ b/mst/about-mst.md
@@ -216,4 +216,4 @@ SET statement_timeout = <milliseconds>
 [aiven-sla]: https://aiven.io/sla
 [pg-keepalive]: http://www.postgresql.org/docs/9.5/static/libpq-connect.html#LIBPQ-KEEPALIVES
 [connection-pooling]: /mst/:currentVersion:/connection-pools/
-[mst-billing]: mst/:currentVersion:/billing
+[mst-billing]: /mst/:currentVersion:/billing/

--- a/mst/logging.md
+++ b/mst/logging.md
@@ -84,4 +84,4 @@ Service for TimescaleDB.
 
 [loggly-site]: https://www.loggly.com/
 [mst-portal]: https://portal.managed.timescale.com
-[aiven-cli]: /mst/:currentVersion:/FIXME
+[aiven-cli]: /mst/:currentVersion:/aiven-client/

--- a/mst/security.md
+++ b/mst/security.md
@@ -152,15 +152,23 @@ There is no ability for any customer or member of the public to access any
 virtual machines used in Managed Service for TimescaleDB.
 
 TimescaleDB services are periodically assessed and penetration tested for any
-security issues by an independent professional cybersecurity vendor. The most
+security issues by an independent professional cybersecurity vendor.
+
+<!---
+The most
 recent evaluation report
 [is available for download][cloud-security-eval].
+This link is currently timing out.
+-->
 
 Aiven is fully GDPR-compliant, and has executed data processing agreements
 (DPAs) with relevant cloud infrastructure providers. If you require a DPA, or if
 you want more information about information security policies, contact
 [Timescale Support][timescale-support].
 
+<!---
 [cloud-security-eval]: https://www.elfgroup.fi/ecc/1708-S6-71acd0046.pdf
+-->
+
 [mst-portal]: https://portal.managed.timescale.com
 [timescale-support]: https://www.timescale.com/support


### PR DESCRIPTION
# Description

* This adds in a link for a PR that isn't merged yet, so the link checker will continue to fail until PR #1502 is merged.
* This also comments out a link to the Aiven cybersecurity report, which is currently timing out. We will need to either update the URL, or go back and check it once the outage is done (I guess? 🤷‍♀️ )

# Links

- Fixes https://github.com/timescale/docs/issues/1512
- Fixes https://github.com/timescale/docs/issues/1513
- Fixes https://github.com/timescale/docs/issues/1514
- Fixes https://github.com/timescale/docs/issues/1516
- Fixes https://github.com/timescale/docs/issues/1501
- Fixes https://github.com/timescale/docs/issues/1506

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
