### PR TITLE
Remove note re: `ON CONFLICT ON CONSTRAINT`

### DIFF
--- a/timescaledb/how-to-guides/write-data/upsert.md
+++ b/timescaledb/how-to-guides/write-data/upsert.md
@@ -5,7 +5,9 @@ keywords: [upsert, hypertables]
 ---
 
 # Upsert data
+
 Upserting is shorthand for:
+
 *   Inserting a new row if a matching row doesn't already exist
 *   Either updating the existing row, or doing nothing, if a matching row
     already exists
@@ -20,9 +22,11 @@ If you have a primary key, you automatically have a unique index.
 </highlight>
 
 ## Create a table with a unique constraint
+
 The examples in this section use a `conditions` table with a unique constraint
 on the columns `(time, location)`. To create a unique constraint, use `UNIQUE
 (<COLUMNS>)` while defining your table:
+
 ```sql
 CREATE TABLE conditions (
   time        TIMESTAMPTZ       NOT NULL,
@@ -36,6 +40,7 @@ CREATE TABLE conditions (
 You can also create a unique constraint after the table is created. Use the
 syntax `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE`. In this example, the
 constraint is named `conditions_time_location`:
+
 ```sql
 ALTER TABLE conditions
   ADD CONSTRAINT conditions_time_location
@@ -56,12 +61,14 @@ well. For more information, see the section on
 </highlight>
 
 ## Insert or update data to a table with a unique constraint
+
 You can tell the database to insert new data if it doesn't violate the
 constraint, and to update the existing row if it does. Use the syntax `INSERT
 INTO ... VALUES ... ON CONFLICT ... DO UPDATE`.
 
 For example, to update the `temperature` and `humidity` values if a row with the
-specified `time` and `location` already exists, run: 
+specified `time` and `location` already exists, run:
+
 ```sql
 INSERT INTO conditions
   VALUES ('2017-07-28 11:42:42.846621+00', 'office', 70.2, 50.1)
@@ -71,6 +78,7 @@ INSERT INTO conditions
 ```
 
 ## Insert or do nothing to a table with a unique constraint
+
 You can also tell the database to do nothing if the constraint is violated. The
 new data is not inserted, and the old row is not updated. This is useful when
 writing many rows as one batch, to prevent the entire transaction from failing.
@@ -78,30 +86,11 @@ The database engine skips the row and moves on.
 
 To insert or do nothing, use the syntax `INSERT INTO ... VALUES ... ON CONFLICT
 DO NOTHING`:
+
 ```sql
 INSERT INTO conditions
   VALUES ('2017-07-28 11:42:42.846621+00', 'office', 70.1, 50.0)
   ON CONFLICT DO NOTHING;
 ```
-
-<highlight type="note">
-You cannot specify a constraint by name when using `INSERT ... ON CONFLICT` on
-hypertables. Work around this by explicitly specifying the constrained columns.
-For example, instead of this:
-
-```sql
--- This does not work
-INSERT INTO conditions
-  VALUES ('2017-07-28 11:42:42.846621+00', 'office', 70.1, 50.0)
-  ON CONFLICT ON CONSTRAINT conditions_time_location DO NOTHING;
-```
-
-Do this:
-```sql
-INSERT INTO conditions
-  VALUES ('2017-07-28 11:42:42.846621+00', 'office', 70.1, 50.0)
-  ON CONFLICT (time, location) DO NOTHING;
-```
-</highlight>
 
 [postgres-upsert]: https://www.postgresql.org/docs/current/static/sql-insert.html#SQL-ON-CONFLICT


### PR DESCRIPTION
TimescaleDB 2.8 removes the limitation on `ON CONFLICT ON CONSTRAINT` on
hypertables. Delete the note that mentions this on the upserting page.

# Links

Fixes #1521 

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
