### PR TITLE
[TimescaleDB 2.8] Update `time_bucket`

### DIFF
--- a/_partials/_time-bucket-function-comparison.mdx
+++ b/_partials/_time-bucket-function-comparison.mdx
@@ -1,6 +1,0 @@
-|Feature|`time_bucket`|`time_bucket_ng`|
-|-|-|-|
-|Bucket by microseconds, milliseconds, seconds, hours, minutes, days, weeks, months, years, and centuries|✅|✅|
-|Bucket `TIMESTAMPTZ` values according to local time using the `timezone` parameter|❌|✅|
-|Origin|January 3, 2000 for buckets shorter than a month, and January 1, 2000 for buckets longer than a month|January 1, 2000|
-|Bucket dates before the origin|✅|❌ Work around this by changing the origin.|

--- a/_partials/_time-bucket-function-comparison.mdx
+++ b/_partials/_time-bucket-function-comparison.mdx
@@ -1,0 +1,6 @@
+|Feature|`time_bucket`|`time_bucket_ng`|
+|-|-|-|
+|Bucket by microseconds, milliseconds, seconds, hours, minutes, days, weeks, months, years, and centuries|✅|✅|
+|Bucket `TIMESTAMPTZ` values according to local time using the `timezone` parameter|❌|✅|
+|Origin|January 3, 2000 for buckets shorter than a month, and January 1, 2000 for buckets longer than a month|January 1, 2000|
+|Bucket dates before the origin|✅|❌ Work around this by changing the origin.|

--- a/api/time_bucket.md
+++ b/api/time_bucket.md
@@ -31,10 +31,9 @@ aggregated into a bucket after such a cast can be irregular. For example, if the
 daylight savings time boundaries can be either three hours or one hour.
 
 <highlight type="important">
-Month, year, and timezones are not supported by the `time_bucket`
-function. If you need to use month, year, or timezone arguments, try the
-experimental [`time_bucket_ng`](/api/latest/hyperfunctions/time_bucket_ng/)
-function instead.
+Timezones are not supported by the `time_bucket` function. If you need to use
+timezone arguments, try the experimental
+[`time_bucket_ng`](/api/latest/hyperfunctions/time_bucket_ng/) function instead.
 </highlight>
 
 ## Required arguments for interval time inputs
@@ -43,6 +42,10 @@ function instead.
 |-|-|-|
 |`bucket_width`|INTERVAL|A PostgreSQL time interval for how long each bucket is|
 |`ts`|TIMESTAMP|The timestamp to bucket|
+
+If you use months as an interval for `bucket_width`, you cannot combine it with
+a non-month component. For example, `1 month` and `3 months` are both valid
+bucket widths, but `1 month 1 day` and `3 months 2 weeks` are not.
 
 ## Optional arguments for interval time inputs
 
@@ -127,12 +130,3 @@ FROM metrics
 GROUP BY five_min
 ORDER BY five_min DESC LIMIT 10;
 ```
-
-<highlight type="important">
-If you are upgrading from a version earlier than 1.0.0, the default origin is
-moved from 2000-01-01 (Saturday) to 2000-01-03 (Monday) between versions 0.12.1
-and 1.0.0. This change was made to make `time_bucket` compliant with the ISO
-standard for Monday as the start of a week. This should only affect multi-day
-calls to `time_bucket`. The old behavior can be reproduced by passing
-`2000-01-01` as the origin parameter to `time_bucket`.
-</highlight>

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -12,26 +12,18 @@ hyperfunction:
   type: bucket
 ---
 
+import Experimental from "versionContent/_partials/_experimental.mdx";
+import TimeBucketComparison from 'versionContent/_partials/_time-bucket-function-comparison.mdx';
+
 ## timescaledb_experimental.time_bucket_ng() <tag type="experimental">Experimental</tag>
 
 The `time_bucket_ng()` (next generation) experimental function is an updated
-version of  the original [`time_bucket()`][time_bucket] function. While
-`time_bucket` works only with small units of time,  `time_bucket_ng()`
-supports years and months in addition to small units of time.
+version of  the original [`time_bucket()`][time_bucket] function. It supports
+a new timezone argument.
 
-<highlight type="warning">
-Experimental features could have bugs! They might not be backwards compatible,
-and could be removed in future releases. When this function is no longer experimental,
-you will need to delete and rebuild any continuous aggregate that uses it.
-Use experimental features at your own risk and we do not recommend to use
-any experimental feature in a production environment.
-</highlight>
+<Experimental />
 
-|Functionality|time_bucket()|time_bucket_ng()|
-|-|-|-|
-|Buckets by seconds, minutes, hours, days and weeks|YES|YES|
-|Buckets by months and years|NO|YES|
-|Timezones support|NO|YES|
+<TimeBucketComparison />
 
 <highlight type="warning">
 The `time_bucket()` and `time_bucket_ng()` functions are similar, but not
@@ -41,10 +33,8 @@ Firstly, `time_bucket_ng()` doesn't work with timestamps prior to `origin`,
 while `time_bucket()` does.
 
 Secondly, the default `origin` values differ. `time_bucket()` uses an origin
-date of January 3, 2000, because that date is a Monday. This works better with
-weekly buckets. `time_bucket_ng()` uses an origin date of January 1, 2000, because
-it is the first day of the month and the year. This works better with monthly
-or annual aggregates.
+date of January 3, 2000, for buckets shorter than a month. `time_bucket_ng()`
+uses an origin date of January 1, 2000, for all bucket sizes.
 </highlight>
 
 ### Required arguments

--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -8,22 +8,21 @@ api:
   license: apache
   type: function
   experimental: true
+  deprecated: true
 hyperfunction:
   type: bucket
 ---
 
-import Experimental from "versionContent/_partials/_experimental.mdx";
-import TimeBucketComparison from 'versionContent/_partials/_time-bucket-function-comparison.mdx';
+import DeprecationNotice from "versionContent/_partials/_deprecated.mdx";
 
 ## timescaledb_experimental.time_bucket_ng() <tag type="experimental">Experimental</tag>
 
-The `time_bucket_ng()` (next generation) experimental function is an updated
-version of  the original [`time_bucket()`][time_bucket] function. It supports
-a new timezone argument.
+The `time_bucket_ng()` function is an experimental version of the
+[`time_bucket()`][time_bucket] function. It introduced some new capabilities,
+such as monthly buckets and timezone support. Those features are now part of the
+regular `time_bucket()` function.
 
-<Experimental />
-
-<TimeBucketComparison />
+<DeprecationNotice />
 
 <highlight type="warning">
 The `time_bucket()` and `time_bucket_ng()` functions are similar, but not

--- a/timescaledb/how-to-guides/time-buckets/about-time-buckets.md
+++ b/timescaledb/how-to-guides/time-buckets/about-time-buckets.md
@@ -4,10 +4,8 @@ excerpt: Learn how time buckets help you aggregate data by time interval
 keywords: [time buckets]
 ---
 
-import Experimental from 'versionContent/_partials/_experimental.mdx';
-import TimeBucketComparison from 'versionContent/_partials/_time-bucket-function-comparison.mdx';
-
 # About time buckets
+
 The [`time_bucket`][time_bucket] function allows you to aggregate data into
 buckets of time, for example: 5 minutes, 1 hour, or 3 days. It's similar to
 PostgreSQL's [`date_trunc`][date_trunc] function, but it gives you more
@@ -19,13 +17,14 @@ roll up data for analysis or downsampling. For example, you can calculate
 rollups as needed, or pre-calculate them in [continuous aggregates][caggs].
 
 This section explains how time bucketing works. For examples of the
-`time_bucket` function, see the section on 
+`time_bucket` function, see the section on
 [using time buckets][use-time-buckets].
 
 ## How time bucketing works
+
 Time bucketing groups data into time intervals. With `time_bucket`, the interval
 length can be any number of microseconds, milliseconds, seconds, minutes, hours,
-days, or weeks.
+days, weeks, months, years, or centuries.
 
 `time_bucket` is usually used in combination with `GROUP BY` to aggregate data.
 For example, you can calculate the average, maximum, minimum, or sum of values
@@ -36,13 +35,8 @@ within a bucket.
     alt="Diagram showing time-bucket aggregating data into daily buckets, and calculating the daily sum of a value"
 />
 
-<highlight type="note"> 
-`time_bucket` doesn't support timezones. The experimental function
-`time_bucket_ng` adds timezone support. To learn more, see the section on
-[`time_bucket_ng`](#experimental-function-time-bucket-ng).
-</highlight>
-
 ### Origin
+
 The origin determines when time buckets start and end. By default, a time bucket
 doesn't start at the earliest timestamp in your data. There is often a more
 logical time. For example, you might collect your first data point at `00:37`,
@@ -63,32 +57,31 @@ for the beginning of the bucket.
   alt="Diagram showing how time buckets are calculated from the origin"
 />
 
-The default origin for `time_bucket`, for intervals shorter than a month, is
-January 3, 2000. For month, year, or century intervals, the default origin is
-January 1, 2000. For integer time values, the default origin is 0.
-
 For example, say that your data's earliest timestamp is April 24, 2020. If you
 bucket by an interval of two weeks, the first bucket doesn't start on April 24,
 which is a Friday. It doesn't start on April 20, which is the immediately
 preceding Monday. It starts on April 13, because you can get to April 13, 2020,
-by counting in two-week increments from January 3, 2000.
+by counting in two-week increments from January 3, 2000, which is the default
+origin in this case.
 
-#### Choice of origin
-The default origin for `time_bucket`, for intervals shorter than a month, is
-January 3, 2000. That date is a Monday, which allows week-based buckets to begin
-on Monday by default. This behavior is compliant with the ISO standard for
-Monday as the start of a week.
+#### Default origins
 
-For intervals greater than a month, and for all buckets using `time_bucket_ng`,
-the default origin is January 1, 2000. `time_bucket_ng` also uses January 1,
-2000. This allows your monthly and yearly buckets to start on the first date of
-the calendar year or month.
+For intervals that don't include months or years, the default origin is January
+3, 2000. For month, year, or century intervals, the default origin is January 1,
+2000. For integer time values, the default origin is 0.
+
+These choices make the time ranges of time buckets more intuitive. Because
+January 3, 2000, is a Monday, weekly time buckets start on Monday. This is
+compliant with the ISO standard for calculating calendar weeks. By contrast,
+monthly and yearly time buckets use January 1, 2000, as an origin. This allows
+them to start on the first day of the calendar month or year.
 
 If you prefer another origin, you can set it yourself using the [`origin`
 parameter][origin]. For example, to start weeks on Sunday, set the origin to
 Sunday, January 2, 2000.
 
 ### Timezones
+
 The origin time depends on the data type of your time values.
 
 If you use `TIMESTAMP`, by default, bucket start times are aligned with
@@ -97,74 +90,11 @@ at a time that you can get to by counting in bucket increments from `00:00:00`
 on the origin date.
 
 If you use `TIMESTAMPTZ`, by default, bucket start times are aligned with
-`00:00:00 UTC`. To get buckets aligned to local time, cast the `TIMESTAMPTZ` to
-`TIMESTAMP` before passing it to `time_bucket`.
-
-<highlight type="note">
-Casting `TIMESTAMPTZ` to `TIMESTAMP` works outside of continuous aggregates. For
-example, you can use it in a stand-alone `SELECT` statement to perform a
-one-time calculation. It does not work within continuous aggregates. To learn 
-more, see the section on [time in continuous aggregates](/timescaledb/latest/how-to-guides/continuous-aggregates/time/).
-</highlight>
-
-### Time_bucket in continuous aggregates
-Time buckets are commonly used to create [continuous aggregates][caggs].
-Continuous aggregates add some limitations to what you can do with
-`time_bucket`.
-
-Continuous aggregates don't allow functions that depend on a local timezone
-setting. That is, you cannot cast `TIMESTAMPTZ` to `TIMESTAMP` within a
-continuous aggregate definition. To learn more and find a workaround, see the
-section on [time in continuous aggregates][time-cagg].
-
-Continuous aggregates also don't allow named parameters.
-
-## Experimental function: time_bucket_ng
-The experimental function [`time_bucket_ng`][time_bucket_ng] adds new features,
-including support for timezones.
-
-<Experimental />
-
-### Origin
-By default, `time_bucket_ng` uses Saturday, January 1, 2000 for its origin,
-regardless of bucket size. This differs from `time_bucket`.
-
-Unlike `time_bucket`, `time_bucket_ng` doesn't support dates before the origin.
-In other words, by default, you cannot use `time_bucket_ng` with data from
-before the year 2000. If you need to go farther back in time, you can change the
-origin by setting the [`origin` parameter][origin-ng].
-
-### Timezones
-`time_bucket_ng` adds support for timezones. By setting the `timezone`
-parameter, you can align bucket start times to local time, even if the time
-values are in `TIMESTAMPTZ` form. That means you can start daily buckets at
-midnight local time rather than UTC time.
-
-### Time_bucket_ng in continuous aggregates
-Time buckets are commonly used to create [continuous aggregates][caggs].
-Continuous aggregates add some limitations to what you can do with
-`time_bucket_ng`. For example, continuous aggregates don't allow named
-parameters.
-
-Here are the `time_bucket_ng` features supported by continuous aggregates:
-
-|Feature|Available in continuous aggregate|TimescaleDB version|
-|-|-|-|
-|Buckets by seconds, minutes, hours, days, and weeks|✅|2.4.0 and later|
-|Buckets by months and years|✅|2.6.0 and later|
-|Timezones|✅|2.6.0 and later|
-|Custom origin|✅|2.7.0 and later|
-
-## Time_bucket compared to time_bucket_ng
-There are several differences between `time_bucket` and `time_bucket_ng`:
-
-<TimeBucketComparison />
+`00:00:00 UTC`. To align time buckets to another timezone, set the `timezone`
+parameter.
 
 [caggs]: /timescaledb/:currentVersion:/how-to-guides/continuous-aggregates/
 [date_trunc]: https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
-[origin-ng]: /api/:currentVersion:/hyperfunctions/time_bucket_ng/#optional-arguments
 [origin]: /api/:currentVersion:/hyperfunctions/time_bucket/#optional-arguments-for-interval-time-inputs
-[time-cagg]: /timescaledb/:currentVersion:/how-to-guides/continuous-aggregates/time/
 [time_bucket]: /api/:currentVersion:/hyperfunctions/time_bucket/
-[time_bucket_ng]: /api/:currentVersion:/hyperfunctions/time_bucket_ng/
 [use-time-buckets]: /timescaledb/:currentVersion:/how-to-guides/time-buckets/use-time-buckets/

--- a/timescaledb/how-to-guides/time-buckets/about-time-buckets.md
+++ b/timescaledb/how-to-guides/time-buckets/about-time-buckets.md
@@ -5,6 +5,7 @@ keywords: [time buckets]
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';
+import TimeBucketComparison from 'versionContent/_partials/_time-bucket-function-comparison.mdx';
 
 # About time buckets
 The [`time_bucket`][time_bucket] function allows you to aggregate data into
@@ -36,9 +37,8 @@ within a bucket.
 />
 
 <highlight type="note"> 
-`time_bucket` doesn't support months, years, or timezones. The experimental
-function `time_bucket_ng` adds support for these intervals and parameters. To
-learn more, see the section on
+`time_bucket` doesn't support timezones. The experimental function
+`time_bucket_ng` adds timezone support. To learn more, see the section on
 [`time_bucket_ng`](#experimental-function-time-bucket-ng).
 </highlight>
 
@@ -63,8 +63,9 @@ for the beginning of the bucket.
   alt="Diagram showing how time buckets are calculated from the origin"
 />
 
-The default origin for `time_bucket` is January 3, 2000. For integer time
-values, the default origin is 0.
+The default origin for `time_bucket`, for intervals shorter than a month, is
+January 3, 2000. For month, year, or century intervals, the default origin is
+January 1, 2000. For integer time values, the default origin is 0.
 
 For example, say that your data's earliest timestamp is April 24, 2020. If you
 bucket by an interval of two weeks, the first bucket doesn't start on April 24,
@@ -73,13 +74,15 @@ preceding Monday. It starts on April 13, because you can get to April 13, 2020,
 by counting in two-week increments from January 3, 2000.
 
 #### Choice of origin
-In TimescaleDB 1.0 and above, the default origin for `time_bucket` is January 3,
-2000. That date is a Monday, which allows week-based buckets to begin on Monday
-by default. This behavior is compliant with the ISO standard for Monday as the
-start of a week.
+The default origin for `time_bucket`, for intervals shorter than a month, is
+January 3, 2000. That date is a Monday, which allows week-based buckets to begin
+on Monday by default. This behavior is compliant with the ISO standard for
+Monday as the start of a week.
 
-In prior versions, the default origin was January 1, 2000. `time_bucket_ng` also
-uses January 1, 2000. That date is more natural for counting months and years.
+For intervals greater than a month, and for all buckets using `time_bucket_ng`,
+the default origin is January 1, 2000. `time_bucket_ng` also uses January 1,
+2000. This allows your monthly and yearly buckets to start on the first date of
+the calendar year or month.
 
 If you prefer another origin, you can set it yourself using the [`origin`
 parameter][origin]. For example, to start weeks on Sunday, set the origin to
@@ -91,7 +94,7 @@ The origin time depends on the data type of your time values.
 If you use `TIMESTAMP`, by default, bucket start times are aligned with
 `00:00:00`. Daily and weekly buckets start at `00:00:00`. Shorter buckets start
 at a time that you can get to by counting in bucket increments from `00:00:00`
-on January 3, 2000.
+on the origin date.
 
 If you use `TIMESTAMPTZ`, by default, bucket start times are aligned with
 `00:00:00 UTC`. To get buckets aligned to local time, cast the `TIMESTAMPTZ` to
@@ -118,19 +121,13 @@ Continuous aggregates also don't allow named parameters.
 
 ## Experimental function: time_bucket_ng
 The experimental function [`time_bucket_ng`][time_bucket_ng] adds new features,
-including support for months, years, and timezones.
+including support for timezones.
 
 <Experimental />
 
-### Months and years
-In addition to the time units supported by `time_bucket`, `time_bucket_ng` also
-supports months and years. For example, you can bucket data into 3-month or
-5-year intervals.
-
 ### Origin
-By default, `time_bucket_ng` uses Saturday, January 1, 2000 for its origin. This
-differs from `time_bucket`. Because `time_bucket_ng` supports months and years,
-January 1 provides a more natural starting date for counting intervals.
+By default, `time_bucket_ng` uses Saturday, January 1, 2000 for its origin,
+regardless of bucket size. This differs from `time_bucket`.
 
 Unlike `time_bucket`, `time_bucket_ng` doesn't support dates before the origin.
 In other words, by default, you cannot use `time_bucket_ng` with data from
@@ -161,13 +158,7 @@ Here are the `time_bucket_ng` features supported by continuous aggregates:
 ## Time_bucket compared to time_bucket_ng
 There are several differences between `time_bucket` and `time_bucket_ng`:
 
-|Feature|`time_bucket`|`time_bucket_ng`|
-|-|-|-|
-|Bucket by microseconds, milliseconds, seconds, hours, minutes, days, and weeks|✅|✅|
-|Bucket by months and years|❌|✅|
-|Bucket `TIMESTAMPTZ` values according to local time using the `timezone` parameter|❌|✅|
-|Origin|January 3, 2000|January 1, 2000|
-|Bucket dates before the origin|✅|❌ Work around this by changing the origin.|
+<TimeBucketComparison />
 
 [caggs]: /timescaledb/:currentVersion:/how-to-guides/continuous-aggregates/
 [date_trunc]: https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC


### PR DESCRIPTION
# Description

`time_bucket` is updated with the features of `time_bucket_ng`, and `time_bucket_ng` will be deprecated.

# Links

Fixes #1523 

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
