### PR TITLE
Document cagg improvements

### DIFF
--- a/_partials/_caggs-function-support.mdx
+++ b/_partials/_caggs-function-support.mdx
@@ -4,14 +4,8 @@ This table summarizes aggregate function support in continuous aggregates:
 |-|-|-|
 |Parallelizable aggregate functions|✅|✅|
 |Non-parallelizable aggregate functions|❌|✅|
+|`ORDER BY`|❌|✅|
 |Ordered-set aggregates|❌|✅|
 |Hypothetical-set aggregates|❌|✅|
 |`DISTINCT` in aggregate functions|❌|✅|
 |`FILTER` in aggregate functions|❌|✅|
-|`ORDER BY` in aggregate functions|❌|✅|
-
-<highlight type="note">
-Note that `ORDER BY` is supported within the PostgreSQL
-[ordered-set aggregates](https://www.postgresql.org/docs/current/functions-aggregate.html).
-It is not yet supported in general.
-</highlight>

--- a/timescaledb/how-to-guides/continuous-aggregates/create-index.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/create-index.md
@@ -5,11 +5,13 @@ keywords: [continuous aggregates, indexes]
 ---
 
 # Create an index on a continuous aggregate
+
 By default, some indexes are automatically created when you create a continuous
 aggregate. You can change this behavior. You can also manually create and drop
 indexes.
 
 ## Automatically created indexes
+
 When you create a continuous aggregate, an index is automatically created for
 each `GROUP BY` column. The index is a composite index, combining the `GROUP BY`
 column with the `time_bucket` column.
@@ -19,10 +21,12 @@ location, bucket`, two composite indexes are created: one on `{device, bucket}`
 and one on `{location, bucket}`.
 
 ### Turn off automatic index creation
+
 To turn off automatic index creation, set `timescaledb.create_group_indexes` to
 `false` when you create the continuous aggregate.
 
 For example:
+
 ```sql
 CREATE MATERIALIZED VIEW conditions_daily
   WITH (timescaledb.continuous, timescaledb.create_group_indexes=false)
@@ -31,27 +35,21 @@ CREATE MATERIALIZED VIEW conditions_daily
 ```
 
 ## Manually create and drop indexes
-You can manually create and drop indexes. To do so, you need to know the name of
-your materialized hypertable. To find the name, see the instructions in the
-[managing materialized hypertables][materialized-hypertable-name] section.
 
-<highlight type="note">
-The name you give when you run `CREATE MATERIALIZED VIEW` is the view name. The
-continuous aggregate's data is stored in a materialized hypertable, which is
-automatically created and named.
-</highlight>
+You can use a regular PostgreSQL statement to create or drop an index on a
+continuous aggregate. For example, to create an index on `avg_temp` for a
+materialized hypertable named `weather_daily`:
 
-You can then use a regular PostgreSQL statement to create or drop an index on
-the hypertable. For example, to create an index on `avg_temp` for a materialized
-hypertable named `_timescaledb_internal._materialized_hypertable_2`:
 ```sql
-CREATE INDEX avg_temp_idx ON _timescaledb_internal._materialized_hypertable_2 (avg_temp);
+CREATE INDEX avg_temp_idx ON weather_daily (avg_temp);
 ```
 
 ### Limitations on created indexes
+
 In TimescaleDB 2.7 and above, you can create an index on any column in the
 materialized view. This includes aggregated columns, such as those storing sums
 and averages. In earlier versions of TimescaleDB, you can't create an index on
 an aggregated column.
 
-[materialized-hypertable-name]: /timescaledb/:currentVersion:/how-to-guides/continuous-aggregates/materialized-hypertables/#discover-the-name-of-a-materialized-hypertable
+In all versions of TimescaleDB, you can't create a unique index on a continuous
+aggregate.

--- a/timescaledb/how-to-guides/continuous-aggregates/create-index.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/create-index.md
@@ -37,11 +37,21 @@ CREATE MATERIALIZED VIEW conditions_daily
 ## Manually create and drop indexes
 
 You can use a regular PostgreSQL statement to create or drop an index on a
-continuous aggregate. For example, to create an index on `avg_temp` for a
-materialized hypertable named `weather_daily`:
+continuous aggregate.
+
+For example, to create an index on `avg_temp` for a materialized hypertable
+named `weather_daily`:
 
 ```sql
 CREATE INDEX avg_temp_idx ON weather_daily (avg_temp);
+```
+
+Indexes are created under the `_timescaledb_internal` schema, where the
+continuous aggregate data is stored. To drop the index, specify the schema. For
+example, to drop the index `avg_temp_idx`, run:
+
+```sql
+DROP INDEX _timescaledb_internal.avg_temp_idx
 ```
 
 ### Limitations on created indexes
@@ -51,5 +61,5 @@ materialized view. This includes aggregated columns, such as those storing sums
 and averages. In earlier versions of TimescaleDB, you can't create an index on
 an aggregated column.
 
-In all versions of TimescaleDB, you can't create a unique index on a continuous
-aggregate.
+You can't create unique indexes on a continuous aggregate, in any version
+of TimescaleDB.


### PR DESCRIPTION
Indexes can now be created directly on caggs by using the view name.
`ORDER BY` is supported in general, not just in the ordered-set
aggregates.

# Links

Fixes #1494 

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
