### PR TITLE
promscale: Add doc about usage of jaeger grpc storage

### DIFF
--- a/promscale/send-data/jaeger.md
+++ b/promscale/send-data/jaeger.md
@@ -9,10 +9,12 @@ tags: [configure, traces]
 # Send Jaeger traces to Promscale
 Promscale natively supports both Jaeger gRPC based remote storage(Promscale >= 0.14.0) and
 OpenTelemetry Protocol (OTLP) for traces.
-To ingest Jaeger traces to Promscale, you can use either of the following,
- - Use the Jaeger Collector, it ingests Jaeger spans directly to configured remote storage and 
-this avoid using any non Jaeger components like OpenTelemetry collector.
- - Use the OpenTelemetry Collector, it converts Jaeger traces to OpenTelemetry traces.
+To ingest Jaeger traces to Promscale, you can either:
+
+* Use the Jaeger Collector to ingest Jaeger spans directly to configured 
+   remote storage. This avoids using any non-Jaeger components, including 
+   the OpenTelemetry collector.
+* Use the OpenTelemetry Collector to convert Jaeger traces to OpenTelemetry traces.
 
 # Send data using the Jaeger Collector
 You can configure the Jaeger Collector to store the traces using Promscale's native 

--- a/promscale/send-data/jaeger.md
+++ b/promscale/send-data/jaeger.md
@@ -21,7 +21,7 @@ You can configure the Jaeger Collector to store the traces using Promscale's nat
 implementation of [Jaeger gRPC storage specification][jaeger-grpc-storage].
 
 Here's an example configuration to enable the Jaeger collector to forward traces
-to Promscale.
+to Promscale:
 
 ```sh
 docker run \

--- a/promscale/send-data/jaeger.md
+++ b/promscale/send-data/jaeger.md
@@ -38,8 +38,10 @@ If you are running the Jaeger Collector and the Promscale Connector on a
 Kubernetes cluster, the endpoint parameter is similar to `endpoint:
 "promscale-connector.default.svc.cluster.local:<PORT>"`
 
-Note: We recommend to use this option unless otherwise you need additional capabilities
-offered by [OpenTelemetry collector][otelcol-config].
+<highlight type="note">
+This is the preferred option, unless you need the additional capabilities
+of the [OpenTelemetry collector][otelcol-config].
+</highlight>
 
 # Send data using the OpenTelemetry Collector
 You can configure the OpenTelemetry Collector to forward Jaeger traces to Promscale

--- a/promscale/send-data/jaeger.md
+++ b/promscale/send-data/jaeger.md
@@ -7,8 +7,9 @@ tags: [configure, traces]
 ---
 
 # Send Jaeger traces to Promscale
-Promscale natively supports both Jaeger gRPC based remote storage(Promscale >= 0.14.0) and
-OpenTelemetry Protocol (OTLP) for traces.
+On Promscale&nbsp;0.14.0 and above, you can natively use Jaeger gRPC 
+based remote storage. On Promscale&nbsp;0.11.0 and above, you can natively 
+use OpenTelemetry Protocol (OTLP) for traces.
 To ingest Jaeger traces to Promscale, you can either:
 
 * Use the Jaeger Collector to ingest Jaeger spans directly to configured 

--- a/promscale/send-data/jaeger.md
+++ b/promscale/send-data/jaeger.md
@@ -7,9 +7,37 @@ tags: [configure, traces]
 ---
 
 # Send Jaeger traces to Promscale
-Promscale natively supports the OpenTelemetry Protocol (OTLP) for traces.
-To ingest Jaeger traces to Promscale, use the OpenTelemetry Collector.
-The OpenTelemetry Collector converts Jaeger traces to OpenTelemetry traces.
+Promscale natively supports both Jaeger gRPC based remote storage(Promscale >= 0.14.0) and
+OpenTelemetry Protocol (OTLP) for traces.
+To ingest Jaeger traces to Promscale, you can use either of the following,
+ - Use the Jaeger Collector, it ingests Jaeger spans directly to configured remote storage and 
+this avoid using any non Jaeger components like OpenTelemetry collector.
+ - Use the OpenTelemetry Collector, it converts Jaeger traces to OpenTelemetry traces.
+
+# Send data using the Jaeger Collector
+You can configure the Jaeger Collector to store the traces using Promscale's native 
+implementation of [Jaeger gRPC storage specification][jaeger-grpc-storage].
+
+Here's an example configuration to enable the Jaeger collector to forward traces
+to Promscale.
+
+```sh
+docker run \
+  -e SPAN_STORAGE_TYPE=grpc-plugin \
+  -e GRPC_STORAGE_SERVER="<PROMSCALE_HOST>:<gRPC_PORT>" \
+  jaegertracing/jaeger-collector:1.37.0
+```
+
+Where: 
+* `<PROMSCALE_HOST>`: hostname of Promscale.
+* `<gRPC_PORT>`: gRPC port of Promscale. The default port is 9202.
+
+If you are running the Jaeger Collector and the Promscale Connector on a
+Kubernetes cluster, the endpoint parameter is similar to `endpoint:
+"promscale-connector.default.svc.cluster.local:<PORT>"`
+
+Note: We recommend to use this option unless otherwise you need additional capabilities
+offered by [OpenTelemetry collector][otelcol-config].
 
 # Send data using the OpenTelemetry Collector
 You can configure the OpenTelemetry Collector to forward Jaeger traces to Promscale
@@ -67,3 +95,5 @@ For more information about the OpenTelemetry Collector, see the
 
 [jaeger-receiver]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver#jaeger-receiver
 [otelcol-docs]: https://opentelemetry.io/docs/collector/
+[jaeger-grpc-storage]: https://www.jaegertracing.io/docs/next-release/deployment/#remote-storage-model
+[otelcol-config]: https://opentelemetry.io/docs/collector/configuration/


### PR DESCRIPTION
# Description

Adds documentation about how to use promscale's jaeger grpc remote storage implementation.

# Links

Fixes https://github.com/timescale/promscale/issues/1544

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
