### PR TITLE
Add hypertable distributed argument and defaults

### DIFF
--- a/api/create_distributed_hypertable.md
+++ b/api/create_distributed_hypertable.md
@@ -36,7 +36,7 @@ when creating distributed hypertables.
 | `partitioning_func` | REGCLASS | The function to use for calculating a value's partition.|
 | `migrate_data` | BOOLEAN | Set to TRUE to migrate any existing data from the `relation` table to chunks in the new hypertable. A non-empty table generates an error without this option. Large tables may take significant time to migrate. Default is FALSE. |
 | `time_partitioning_func` | REGCLASS | Function to convert incompatible primary time column values to compatible ones. The function must be `IMMUTABLE`. |
-| `replication_factor` | INTEGER | The number of data nodes to which the same data is written to. This is done by creating chunk copies on this amount of data nodes. Must be >= 1; default is 1.  Read [the best practices][best-practices] before changing the default. |
+| `replication_factor` | INTEGER | The number of data nodes to which the same data is written to. This is done by creating chunk copies on this amount of data nodes. Must be >= 1; If not set, the default value will be determined by the `timescaledb.hypertable_replication_factor_default` GUC. Read [the best practices][best-practices] before changing the default. |
 | `data_nodes` | ARRAY | The set of data nodes used for the distributed hypertable. If not present, defaults to all data nodes known by the access node (the node on which the distributed hypertable is created). |
 
 ### Returns

--- a/api/create_distributed_hypertable.md
+++ b/api/create_distributed_hypertable.md
@@ -36,7 +36,7 @@ when creating distributed hypertables.
 | `partitioning_func` | REGCLASS | The function to use for calculating a value's partition.|
 | `migrate_data` | BOOLEAN | Set to TRUE to migrate any existing data from the `relation` table to chunks in the new hypertable. A non-empty table generates an error without this option. Large tables may take significant time to migrate. Default is FALSE. |
 | `time_partitioning_func` | REGCLASS | Function to convert incompatible primary time column values to compatible ones. The function must be `IMMUTABLE`. |
-| `replication_factor` | INTEGER | The number of data nodes to which the same data is written to. This is done by creating chunk copies on this amount of data nodes. Must be >= 1; If not set, the default value will be determined by the `timescaledb.hypertable_replication_factor_default` GUC. Read [the best practices][best-practices] before changing the default. |
+| `replication_factor` | INTEGER | The number of data nodes to which the same data is written to. This is done by creating chunk copies on this amount of data nodes. Must be >= 1; If not set, the default value is determined by the `timescaledb.hypertable_replication_factor_default` GUC. Read [the best practices][best-practices] before changing the default. |
 | `data_nodes` | ARRAY | The set of data nodes used for the distributed hypertable. If not present, defaults to all data nodes known by the access node (the node on which the distributed hypertable is created). |
 
 ### Returns

--- a/api/create_hypertable.md
+++ b/api/create_hypertable.md
@@ -43,9 +43,9 @@ still work on the resulting hypertable.
 |`associated_table_prefix`|TEXT|Prefix for internal hypertable chunk names. Default is `_hyper`.|
 |`migrate_data`|BOOLEAN|Set to TRUE to migrate any existing data from the `relation` table to chunks in the new hypertable. A non-empty table generates an error without this option. Large tables may take significant time to migrate. Defaults to FALSE.|
 |`time_partitioning_func`|REGCLASS| Function to convert incompatible primary time column values to compatible ones. The function must be `IMMUTABLE`.|
-|`replication_factor`|INTEGER|Replication factor to use with distributed hypertable. If not provided, value will be determined by the `timescaledb.hypertable_replication_factor_default` GUC. |
+|`replication_factor`|INTEGER|Replication factor to use with distributed hypertable. If not provided, value is determined by the `timescaledb.hypertable_replication_factor_default` GUC. |
 |`data_nodes`|ARRAY|This is the set of data nodes that are used for this table if it is distributed. This has no impact on non-distributed hypertables. If no data nodes are specified, a distributed hypertable uses all data nodes known by this instance.|
-|`distributed`|BOOLEAN|Set to TRUE to create distributed hypertable. If not provided, value will be determined by the `timescaledb.hypertable_distributed_default` GUC. When creating a distributed hypertable, consider using [`create_distributed_hypertable`][create_distributed_hypertable] in place of `create_hypertable`. Default is NULL. |
+|`distributed`|BOOLEAN|Set to TRUE to create distributed hypertable. If not provided, value is determined by the `timescaledb.hypertable_distributed_default` GUC. When creating a distributed hypertable, consider using [`create_distributed_hypertable`][create_distributed_hypertable] in place of `create_hypertable`. Default is NULL. |
 
 ### Returns
 

--- a/api/create_hypertable.md
+++ b/api/create_hypertable.md
@@ -43,8 +43,9 @@ still work on the resulting hypertable.
 |`associated_table_prefix`|TEXT|Prefix for internal hypertable chunk names. Default is `_hyper`.|
 |`migrate_data`|BOOLEAN|Set to TRUE to migrate any existing data from the `relation` table to chunks in the new hypertable. A non-empty table generates an error without this option. Large tables may take significant time to migrate. Defaults to FALSE.|
 |`time_partitioning_func`|REGCLASS| Function to convert incompatible primary time column values to compatible ones. The function must be `IMMUTABLE`.|
-|`replication_factor`|INTEGER| If set to 1 or greater, creates a distributed hypertable. Default is NULL. When creating a distributed hypertable, consider using [`create_distributed_hypertable`][create_distributed_hypertable] in place of `create_hypertable`.|
+|`replication_factor`|INTEGER|Replication factor to use with distributed hypertable. If not provided, value will be determined by the `timescaledb.hypertable_replication_factor_default` GUC. |
 |`data_nodes`|ARRAY|This is the set of data nodes that are used for this table if it is distributed. This has no impact on non-distributed hypertables. If no data nodes are specified, a distributed hypertable uses all data nodes known by this instance.|
+|`distributed`|BOOLEAN|Set to TRUE to create distributed hypertable. If not provided, value will be determined by the `timescaledb.hypertable_distributed_default` GUC. When creating a distributed hypertable, consider using [`create_distributed_hypertable`][create_distributed_hypertable] in place of `create_hypertable`. Default is NULL. |
 
 ### Returns
 

--- a/timescaledb/how-to-guides/configuration/configuration.md
+++ b/timescaledb/how-to-guides/configuration/configuration.md
@@ -195,6 +195,17 @@ workers. Default value is 8.
 
 ### Distributed hypertables
 
+#### `timescaledb.hypertable_distributed_default (enum)`
+
+Set default policy to create local or distributed hypertables for
+`create_hypertable()` command, when the `distributed` argument is not provided.
+Supported values are `auto`, `local` or `distributed`.
+
+#### `timescaledb.hypertable_replication_factor_default (int)`
+
+Global default value for replication factor to use with hypertables
+when the `replication_factor` argument is not provided in. Default is 1.
+
 #### `timescaledb.enable_2pc (bool)`
 
 Enables two-phase commit for distributed hypertables. If disabled, it

--- a/timescaledb/how-to-guides/configuration/configuration.md
+++ b/timescaledb/how-to-guides/configuration/configuration.md
@@ -204,7 +204,7 @@ Supported values are `auto`, `local` or `distributed`.
 #### `timescaledb.hypertable_replication_factor_default (int)`
 
 Global default value for replication factor to use with hypertables
-when the `replication_factor` argument is not provided in. Default is 1.
+when the `replication_factor` argument is not provided. Defaults to 1.
 
 #### `timescaledb.enable_2pc (bool)`
 


### PR DESCRIPTION
# Description

This change introduces a new `distributed` argument to the
`create_hypertable()` function as well as two new GUC's to
control its default behaviour: `timescaledb.hypertable_distributed_default`
and `timescaledb.hypertable_replication_factor_default`.

The main idea of this change is to allow automatic creation
of the distributed hypertables by default.

# Links

https://github.com/timescale/timescaledb/pull/4545

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
