### PR TITLE
Add TSTUNE_PROFILE var to docker cmd for promscale

### DIFF
--- a/promscale/installation/docker.md
+++ b/promscale/installation/docker.md
@@ -43,6 +43,7 @@ packages and instructions, see the [Docker installation documentation][docker-in
     also port forwards to port `5432` on your local system:
     ```bash
     docker run --name timescaledb -e POSTGRES_PASSWORD=<password> \
+    -e TSTUNE_PROFILE=promscale \
     -d -p 5432:5432 \
     --network promscale \
     timescale/timescaledb-ha:pg14-latest \


### PR DESCRIPTION
# Description

Updated the docker installation instructions for promscale to include an environment variable that will run the timescaledb-tune tool with the "promscale" profile.

# Links


# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
