### PR TITLE
[update]Install self-hosted TimescaleDB from a pre-built container

### DIFF
--- a/install/installation-docker.md
+++ b/install/installation-docker.md
@@ -114,7 +114,7 @@ data volume using the `-v` flag. For example:
 
 ```bash
 docker run -d --name timescaledb -p 5432:5432 \
--v /your/data/dir:/var/lib/postgresql/data \
+-v /your/data/dir:/home/postgres/pgdata/data \
 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14-latest
 ```
 


### PR DESCRIPTION
# Description

The location of pgdata in pg 14 is now different:
``` rajakavithakodhandapani@RajakavthasMBP2 ~ % docker run -d --name timescaledb -p 127.0.0.1:5432:5432 \
-e POSTGRES_PASSWORD=Sc0rpi0n timescale/timescaledb-ha:pg14-latest
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
2ead1633a6364c4224e4086282df2fa6ba225d7d1f39d6369b1b8e787a3a76e4
rajakavithakodhandapani@RajakavthasMBP2 ~ % psql -U postgres -h localhost
Password for user postgres: 
psql (14.4, server 14.5 (Ubuntu 14.5-1.pgdg22.04+1))
Type "help" for help.

postgres=# SHOW data_directory;
       data_directory       
----------------------------
 /home/postgres/pgdata/data
(1 row)

postgres=# 
```
# Links

Fixes https://github.com/timescale/docs/issues/1509

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
