### PR TITLE
[update] fixed a typo in the command

### DIFF
--- a/install/installation-kubernetes.md
+++ b/install/installation-kubernetes.md
@@ -108,7 +108,7 @@ the name that you provided during the installation.
    ```
 2. Run `psql` inside the Pod containing the primary:
    ```bash
-   kubectl exec -i --tty --namespace default {MASTERPOD} -- psql -U postgres
+   kubectl exec -i --tty --namespace default ${MASTERPOD} -- psql -U postgres
    ```
 
 </procedure>


### PR DESCRIPTION
# Description

Fixed a typo.
Validated here:
```
rajie@RajakavithasMBP ~ % MASTERPOD="$(kubectl get pod -o name --namespace default -l release=test,role=master)"
rajie@RajakavithasMBP ~ %  kubectl exec -i --tty --namespace default ${MASTERPOD} -- psql -U postgres
Defaulted container "timescaledb" out of: timescaledb, tstune (init)
psql (13.4 (Ubuntu 13.4-1.pgdg21.04+1))
Type "help" for help.

postgres=# CREATE database tsdb;
CREATE DATABASE
postgres=# \c tsdb
You are now connected to database "tsdb" as user "postgres".
tsdb=# \dx
                                      List of installed extensions
    Name     | Version |   Schema   |                            Description                            
-------------+---------+------------+-------------------------------------------------------------------
 plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
 timescaledb | 2.4.2   | public     | Enables scalable inserts and complex queries for time-series data
(2 rows)

tsdb=# 
```
# Links

Fixes https://github.com/timescale/docs/issues/1549
# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
