### PR TITLE
Add a missing backtick

### DIFF
--- a/timescaledb/how-to-guides/hyperfunctions/function-pipelines.md
+++ b/timescaledb/how-to-guides/hyperfunctions/function-pipelines.md
@@ -707,7 +707,7 @@ This table lists all function pipeline elements in alphabetical order:
 |`average()`|Aggregate Finalizer|DOUBLE PRECISION|
 |`cbrt()`|Unary Mathematical| `timevector` pipeline|
 |`ceil()`|Unary Mathematical| `timevector` pipeline|
-|counter_agg()`|Aggregate Finalizer| `CounterAgg`|
+|`counter_agg()`|Aggregate Finalizer| `CounterAgg`|
 |`delta()`|Compound|`timevector` pipeline|
 |`div`|Binary Mathematical|`timevector` pipeline|
 |`fill_to`|Compound|`timevector` pipeline|


### PR DESCRIPTION
# Description

Adds a missing backtick that makes a table element not be code formatted:

![One table cell contains "counter_agg()`"; the rest are code formatted and without backticks](https://user-images.githubusercontent.com/10530973/188632076-b875f49c-98c1-4030-90f9-1672e39ffaba.png)


# Links

https://docs.timescale.com/timescaledb/latest/how-to-guides/hyperfunctions/function-pipelines/#all-function-pipeline-elements

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
