### PR TITLE
Fixed broken link in the _plan_upgrade.mdx

### DIFF
--- a/_partials/_plan_upgrade.mdx
+++ b/_partials/_plan_upgrade.mdx
@@ -15,5 +15,5 @@ Before you upgrade:
   case of disaster.
 
 [relnotes]: /timescaledb/:currentVersion:/overview/release-notes/
-[upgrade-pg]: /timescaledb/:currentVersion:/how-to-guides/upgrades/upgrade-postgresql/
+[upgrade-pg]: /timescaledb/:currentVersion:/how-to-guides/upgrades/upgrade-pg/
 [backup]: timescaledb/:currentVersion:/how-to-guides/backup-and-restore/


### PR DESCRIPTION
# Description

The link to the upgrade postgresql docs page was broken and ended up in a 404.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
