### PR TITLE
Fixed broken link in the hypertable-architecture.md

### DIFF
--- a/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertable-architecture.md
+++ b/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertable-architecture.md
@@ -28,7 +28,7 @@ This section uses the example of 1-day chunks to explain how hypertables work.
 The default chunk time interval is actually 7 days, and you can change it to
 suit your data ingest patterns. To learn about best practices for chunk time
 intervals, see the documentation on
-[chunk sizing](timescaledb/latest/how-to-guides/hypertables/best-practices/#time-intervals).
+[chunk sizing](/timescaledb/latest/how-to-guides/hypertables/best-practices/#time-intervals).
 </highlight>
 
 ## Time-and-space partitioning


### PR DESCRIPTION
# Description

The link to the chunk sizing docs page was broken and ended up in a 404.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
