### PR TITLE
Fix link in create_hypertable docs

### DIFF
--- a/api/create_hypertable.md
+++ b/api/create_hypertable.md
@@ -255,4 +255,4 @@ hypertables are described in the [add_dimension][add_dimension] section.
 [create_distributed_hypertable]: /api/:currentVersion:/distributed-hypertables/create_distributed_hypertable
 [hash-partitions]: /timescaledb/:currentVersion:/how-to-guides/hypertables/about-hypertables/#hypertable-partitioning
 [migrate-data]: /timescaledb/:currentVersion:/how-to-guides/migrate-data/
-[set_chunk_time_interval]:
+[set_chunk_time_interval]: /api/:currentVersion:/hypertable/set_chunk_time_interval/


### PR DESCRIPTION
# Description

Fixes a link that wasn't linked right in the `create_hypertable` documentation.

# Links

https://docs.timescale.com/api/latest/hypertable/create_hypertable/

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
