### PR TITLE
Update service-overview.md

### DIFF
--- a/cloud/service-overview.md
+++ b/cloud/service-overview.md
@@ -18,16 +18,13 @@ an overview of the configuration and resource usage for the service.
 By default, when you create a new service, a new `tsdbadmin` user is created.
 This is the user that you use to connect to your new service.
 
-The `tsdbadmin` user is the owner of the database, but is not a superuser. To
-access features requiring a superuser, log in as the `postgres` user instead.
+The `tsdbadmin` user is the owner of the database, but is not a superuser. We 
+do not currently allow access to the `postgres` user, nor creation of multiple 
+databases. We recommend using schemas or creating additional services for data
+isolation.
 
-On Timescale Cloud services, the `tsdbadmin` user can:
-
-* Create a database
-* Create a role
-
-This allows you to use the `tsdbadmin` user to create another user with any
-other roles. For a complete list of roles available, see the
+On Timescale Cloud services, the `tsdbadmin` user can create another user 
+with any other roles. For a complete list of roles available, see the
 [PostgreSQL role attributes documentation][pg-roles-doc].
 
 [cloud-login]: https://console.cloud.timescale.com/


### PR DESCRIPTION
update service overview to be more accurate

# Description

The docs currently state that the user can log in as the `postgres` user, which is not the case. I also added a note about creating additional databases. Technically the `tsdbadmin` role has permissions to do this, but we don't allow it.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [x] Is the content technically accurate?
- [x] Is the content complete?
- [X] Is the content presented in a logical order?
- [x] Does the content use appropriate names for features and products?
- [x] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
