### PR TITLE
Add note about backups on compressed chunks

### DIFF
--- a/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
+++ b/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
@@ -9,7 +9,8 @@ tags: [recovery, logical backup, pg_dump, pg_restore]
 
 You can backup and restore an entire database or individual hypertables using
 the native PostgreSQL [`pg_dump`][pg_dump] and [`pg_restore`][pg_restore]
-commands.
+commands. This works even for compressed hypertables, without having to
+decompress the chunks before you begin.
 
 Upgrades between different versions of TimescaleDB can be done in place; you
 don't need to backup and restore your data. See
@@ -29,6 +30,7 @@ example, to backup a database named `tsdb`:
 ```bash
 pg_dump -Fc -f tsdb.bak tsdb
 ```
+
 To backup a database named `tsdb` hosted on a remote server:
 
 ```bash
@@ -163,6 +165,5 @@ partitions, or the chunk interval sizes.
 [pg_dump]: https://www.postgresql.org/docs/current/static/app-pgdump.html
 [pg_restore]: https://www.postgresql.org/docs/current/static/app-pgrestore.html
 [timescaledb_post_restore]: /api/:currentVersion:/administration/timescaledb_post_restore/
-[timescaledb_pre_restore]: /api/:currentVersion:/administration/timescaledb_pre_restore/
 [timescaledb-upgrade]: /timescaledb/:currentVersion:/how-to-guides/upgrades/
 [troubleshooting]: /timescaledb/:currentVersion:/how-to-guides/backup-and-restore/troubleshooting/


### PR DESCRIPTION
# Description

Added note about being able to use `pg_dump` and `pg_restore` on compressed chunks.

# Links

Fixes https://github.com/timescale/docs/issues/1484

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
