### PR TITLE
Improve HyperLogLog documentation

### DIFF
--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -39,8 +39,7 @@ Using a value for `buckets` less than 1024 results in very poor accuracy and is 
 </highlight>
 
 Increasing the `buckets` argument usually provides more accuracy at the expense
-of more memory usage. Because hyperloglog is a probabilistic algorithm, it works
-best on datasets that have many distinct values: at least tens of thousands.
+of more memory usage.
 
 See [stderror][stderror] for how estimated error rate is related to `buckets`.
 

--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -31,8 +31,12 @@ For more information about approximate count distinct functions, see the
 
 |Name|Type|Description|
 |-|-|-|
-|buckets|integer|Number of buckets in the digest. Rounded up to the next power of 2. Must be between 16 and 2^18, values less than 1024 are not recommended. If unsure, start experimenting with 32768 (2^15).|
+|buckets|integer|Number of buckets in the digest. Rounded up to the next power of 2. Must be between 16 and 2^18. If unsure, start experimenting with 32768 (2^15).|
 |value|AnyElement| Column to count distinct elements. The type must have an extended, 64-bit, hash function.|
+
+<highlight type="warning">
+Using a value for `buckets` less than 1024 results in very poor accuracy and is not recommended.
+</highlight>
 
 Increasing the `buckets` argument usually provides more accuracy at the expense
 of more memory usage. Because hyperloglog is a probabilistic algorithm, it works


### PR DESCRIPTION
# Description

Updates the HyperLogLog documentation:

- Emphasizes the warning about low bucket count: using a value for buckets that's less than 1024 results in very poor
accuracy, and is almost never wanted.
- Remove outdated claim about poor performance with low cardinality: this used to be true, but no longer is, since Toolkit now uses HyperLogLog++ which has better accuracy for low cardinality data.

# Links

https://docs.timescale.com/api/latest/hyperfunctions/approx_count_distincts/hyperloglog/

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
