### PR TITLE
Improve formatting on saturating math documentation

### DIFF
--- a/api/saturating_add_pos.md
+++ b/api/saturating_add_pos.md
@@ -38,6 +38,6 @@ For more information about saturating math functions, see the
 
 |Column|Type|Description|
 |-|-|-|
-|`saturating_add_pos`|`INT`| The result of x+y, saturating at 0 for the minimum bound |
+|`saturating_add_pos`|`INT`| The result of `x+y`, saturating at 0 for the minimum bound |
 
 [saturating-math-docs]: /api/:currentVersion:/hyperfunctions/saturating_math/

--- a/api/saturating_sub_pos.md
+++ b/api/saturating_sub_pos.md
@@ -38,6 +38,6 @@ For more information about saturating math functions, see the
 
 |Column|Type|Description|
 |-|-|-|
-|`saturating_sub_pos` |`INT|` The result of `x-y`, saturating at 0 for the minimum bound |
+|`saturating_sub_pos` |`INT`| The result of `x-y`, saturating at 0 for the minimum bound |
 
 [saturating-math-docs]: /api/:currentVersion:/hyperfunctions/saturating_math/


### PR DESCRIPTION
# Description

Fixes two formatting issues in the documentation for saturating math

# Links

https://docs.timescale.com/api/latest/hyperfunctions/saturating_math/saturating_add_pos/
https://docs.timescale.com/api/latest/hyperfunctions/saturating_math/saturating_sub_pos/

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
