### PR TITLE
[update] Install self-hosted TimescaleDB on Red Hat-based systems

### DIFF
--- a/_partials/_psql-installation-centos.md
+++ b/_partials/_psql-installation-centos.md
@@ -1,0 +1,17 @@
+## Install psql on CentOS
+You can use the `yum` package manager on CentOS systems to install
+the `psql` tool.
+
+<procedure>
+
+### Installing psql using the apt package manager
+1.  Make sure your `apt` repository is up to date:
+    ```bash
+    sudo yum update
+    ```
+1.  Install the `postgresql-client` package:
+    ```bash
+    sudo dnf install postgresql14
+    ```
+
+</procedure>

--- a/_partials/_psql-installation-centos.md
+++ b/_partials/_psql-installation-centos.md
@@ -7,11 +7,11 @@ the `psql` tool.
 ### Installing psql using the apt package manager
 1.  Make sure your `apt` repository is up to date:
     ```bash
-    sudo yum update
+    yum update
     ```
 1.  Install the `postgresql-client` package:
     ```bash
-    sudo dnf install postgresql14
+    dnf install postgresql14
     ```
 
 </procedure>

--- a/install/installation-redhat.md
+++ b/install/installation-redhat.md
@@ -201,7 +201,8 @@ the `psql` command-line utility.
     postgres=#\password postgres 
     ```
 
-1.  Exit from PostgreSQL using the command `\q` and use `psql` to connect:
+1.  Exit from PostgreSQL using the command `\q`.
+1.  Use `psql` client to connect to PostgreSQL:
 
     ```bash
     psql -U postgres -h localhost

--- a/install/installation-redhat.md
+++ b/install/installation-redhat.md
@@ -193,7 +193,6 @@ the `psql` command-line utility.
     Type "help" for help.
 
     postgres=#
-
     ```
 
 1.  Set the password for the `postgres` user using:

--- a/install/installation-redhat.md
+++ b/install/installation-redhat.md
@@ -44,7 +44,7 @@ instead.
     <tab label='Red Hat'>
 
     ```bash
-    sudo yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+    yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
     ```
 
     </tab>
@@ -52,7 +52,7 @@ instead.
     <tab label="Fedora">
 
     ```bash
-    sudo yum install https://download.postgresql.org/pub/repos/yum/reporpms/F-$(rpm -E %{fedora})-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+    yum install https://download.postgresql.org/pub/repos/yum/reporpms/F-$(rpm -E %{fedora})-x86_64/pgdg-fedora-repo-latest.noarch.rpm
     ```
 
     </tab>
@@ -60,7 +60,7 @@ instead.
     <tab label="CentOS">
 
     ```bash
-    sudo yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{centos})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+    yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{centos})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
     ```
 
     </tab>
@@ -72,7 +72,7 @@ instead.
     <tab label='Red Hat'>
 
     ```bash
-    sudo tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
+    tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
     [timescale_timescaledb]
     name=timescale_timescaledb
     baseurl=https://packagecloud.io/timescale/timescaledb/el/$(rpm -E %{rhel})/\$basearch
@@ -91,7 +91,7 @@ instead.
     <tab label="Fedora">
 
     ```bash
-    sudo tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
+    tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
     [timescale_timescaledb]
     name=timescale_timescaledb
     baseurl=https://packagecloud.io/timescale/timescaledb/el/8/$basearch
@@ -110,7 +110,7 @@ instead.
     <tab label="CentOS">
 
     ```bash
-    sudo tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
+    tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
     [timescale_timescaledb]
     name=timescale_timescaledb
     baseurl=https://packagecloud.io/timescale/timescaledb/el/$(rpm -E %{rhel})/\$basearch
@@ -130,13 +130,13 @@ instead.
 1.  Update your local repository list:
 
     ```bash
-    sudo yum update
+    yum update
     ```
 
 1.  Install TimescaleDB:
 
     ```bash
-    sudo yum install timescaledb-2-postgresql-14
+    yum install timescaledb-2-postgresql-14
     ```
 
      <highlight type="note">
@@ -149,7 +149,8 @@ instead.
 1.  Initialize the database:
 
     ```bash
-    sudo /usr/pgsql-14/bin/postgresql-14-setup initdb
+    /usr/pgsql-14/bin/postgresql-14-setup initdb
+    ```
 
 </procedure>
 
@@ -174,14 +175,14 @@ the `psql` command-line utility.
 1.  Enable and start the service:
 
     ```bash
-    sudo systemctl enable postgresql-14
-    sudo systemctl start postgresql-14
+    systemctl enable postgresql-14
+    systemctl start postgresql-14
     ```
 
 1.  Connect to the PostgreSQL instance as the `postgres` superuser:
 
     ```bash
-    sudo -u postgres psql
+    -u postgres psql
     ```
 
     If your connection is successful, you see a message similar to this, followed

--- a/install/installation-redhat.md
+++ b/install/installation-redhat.md
@@ -140,9 +140,9 @@ instead.
     ```
 
      <highlight type="note">
-     When installing on CentOS 8 you need to disable the built-in PostgreSQL
-     module in the system using the `sudo dnf -qy module disable postgresql`
-     command.
+     When installing on CentOS 8 or Red Hat Enterprise Linux 8 you need
+     to disable the built-in PostgreSQL module in the system using the
+     `sudo dnf -qy module disable postgresql`command.
 
 </highlight>
 

--- a/install/installation-redhat.md
+++ b/install/installation-redhat.md
@@ -7,10 +7,14 @@ subsection: self-hosted
 keywords: [install, self-hosted, Red Hat]
 ---
 
+import Debian from "versionContent/_partials/_psql-installation-centos.mdx";
+
 # Install self-hosted TimescaleDB on Red Hat-based systems
+
 You can host TimescaleDB yourself on your Red Hat, CentOS, or Fedora system.
 These instructions use the `yum` package manager on these
 distributions:
+
 *   Red Hat Enterprise Linux 7
 *   Red Hat Enterprise Linux 8
 *   CentOS 7
@@ -32,6 +36,7 @@ instead.
 <procedure>
 
 ### Installing self-hosted TimescaleDB on Red Hat-based systems
+
 1.  At the command prompt, as root, add the PostgreSQL third party repository
     to get the latest PostgreSQL packages:
     <terminal>
@@ -39,7 +44,7 @@ instead.
     <tab label='Red Hat'>
 
     ```bash
-    yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+    sudo yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
     ```
 
     </tab>
@@ -47,7 +52,7 @@ instead.
     <tab label="Fedora">
 
     ```bash
-    yum install https://download.postgresql.org/pub/repos/yum/reporpms/F-$(rpm -E %{fedora})-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+    sudo yum install https://download.postgresql.org/pub/repos/yum/reporpms/F-$(rpm -E %{fedora})-x86_64/pgdg-fedora-repo-latest.noarch.rpm
     ```
 
     </tab>
@@ -55,7 +60,7 @@ instead.
     <tab label="CentOS">
 
     ```bash
-    yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{centos})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+    sudo yum install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{centos})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
     ```
 
     </tab>
@@ -67,7 +72,7 @@ instead.
     <tab label='Red Hat'>
 
     ```bash
-    tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
+    sudo tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
     [timescale_timescaledb]
     name=timescale_timescaledb
     baseurl=https://packagecloud.io/timescale/timescaledb/el/$(rpm -E %{rhel})/\$basearch
@@ -86,7 +91,7 @@ instead.
     <tab label="Fedora">
 
     ```bash
-    tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
+    sudo tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
     [timescale_timescaledb]
     name=timescale_timescaledb
     baseurl=https://packagecloud.io/timescale/timescaledb/el/8/$basearch
@@ -105,7 +110,7 @@ instead.
     <tab label="CentOS">
 
     ```bash
-    tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
+    sudo tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
     [timescale_timescaledb]
     name=timescale_timescaledb
     baseurl=https://packagecloud.io/timescale/timescaledb/el/$(rpm -E %{rhel})/\$basearch
@@ -123,93 +128,129 @@ instead.
 
     </terminal>
 1.  Update your local repository list:
+
     ```bash
-    yum update
+    sudo yum update
     ```
+
 1.  Install TimescaleDB:
+
     ```bash
-    yum install timescaledb-2-postgresql-14
+    sudo yum install timescaledb-2-postgresql-14
     ```
+
+     <highlight type="note">
+     When installing on CentOS 8 you need to disable the built-in PostgreSQL
+     module in the system using the `sudo dnf -qy module disable postgresql`
+     command.
+
+</highlight>
+
+1.  Initialize the database:
+
+    ```bash
+    sudo /usr/pgsql-14/bin/postgresql-14-setup initdb
 
 </procedure>
 
 When you have completed the installation, you need to configure your database so
 that you can use it. The easiest way to do this is to run the `timescaledb-tune`
-script, which is included with the `timescaledb-tools` package. For more
+script, which is included with the `timescaledb-tools` package. Run the
+`timescaledb-tune` script using the
+`sudo timescaledb-tune --pg-config=/usr/pgsql-14/bin/pg_config` command. For more
 information, see the [configuration][config] section.
 
 ## Set up the TimescaleDB extension
-When you have PostgreSQL and TimescaleDB installed, you can connect to it from
-your local system using the `psql` command-line utility. This is the same tool
-you might have used to connect to PostgreSQL before, but if you haven't
-installed it yet, check out our [installing psql][install-psql] section.
+
+When you have PostgreSQL and TimescaleDB installed, you can connect to it using
+the `psql` command-line utility.
+
+<CentOS />
 
 <procedure>
 
 ### Setting up the TimescaleDB extension
-1.  Initialize the database:
+
+1.  Enable and start the service:
+
     ```bash
-    /usr/pgsql-14/bin/postgresql-14-setup initdb
-    ```
-1. Enable and start the service:
-    ```
-    systemctl enable postgresql-14
-    systemctl start postgresql-14
+    sudo systemctl enable postgresql-14
+    sudo systemctl start postgresql-14
     ```
 
 1.  Connect to the PostgreSQL instance as the `postgres` superuser:
+
     ```bash
-    su postgres -c psql
+    sudo -u postgres psql
     ```
-    If your connection is successful, you see a message like this, followed
+
+    If your connection is successful, you see a message similar to this, followed
     by the `psql` prompt:
-    ```
-    psql (13.3, server 12.8 (Ubuntu 12.8-1.pgdg21.04+1))
-    SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
+
+    ```bash
+    could not change directory to "/root": Permission denied
+    psql (14.5)
     Type "help" for help.
-    tsdb=>
+
+    postgres=#
+
     ```
+
+1.  Set the password for the `postgres` user using:
+
+    ```sql
+    postgres=#\password postgres 
+    ```
+
+1.  Exit from PostgreSQL using the command `\q` and use `psql` to connect:
+
+    ```bash
+    psql -U postgres -h localhost
+    ```
+
 1.  At the `psql` prompt, create an empty database. Our database is
-    called `example`:
+    called `tsdb`:
+
     ```sql
-    CREATE database example;
+    CREATE database tsdb;
     ```
+
 1.  Connect to the database you created:
+
     ```sql
-    \c example
+    \c tsdb
     ```
+
 1.  Add the TimescaleDB extension:
+
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     ```
-1.  You can now connect to your database using this command:
-    ```bash
-    su postgres -c 'psql -d example'
+
+1.  Check that the TimescaleDB extension is installed by using the `\dx`
+    command at the `psql` prompt. Output is similar to:
+
+    ```sql
+    tsdb-# \dx
+                                          List of installed extensions
+        Name     | Version |   Schema   |                            Description                            
+    -------------+---------+------------+-------------------------------------------------------------------
+     plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
+     timescaledb | 2.7.0   | public     | Enables scalable inserts and complex queries for time-series data
+    (2 rows)
     ```
 
 </procedure>
 
-You can check that the TimescaleDB extension is installed by using the `\dx`
-command at the `psql` prompt. It looks like this:
-```sql
-tsdb=> \dx
-List of installed extensions
--[ RECORD 1 ]------------------------------------------------------------------
-Name        | plpgsql
-Version     | 1.0
-Schema      | pg_catalog
-Description | PL/pgSQL procedural language
--[ RECORD 2 ]------------------------------------------------------------------
-Name        | timescaledb
-Version     | 2.6.1
-Schema      | public
-Description | Enables scalable inserts and complex queries for time-series data
+After you have created the extension and the database, you can connect to your
+database directly using this command:
 
-
-tsdb=>
+```bash
+psql -U postgres -h localhost -d tsdb
 ```
 
 ## Where to next
+
 Now that you have your first TimescaleDB database up and running, you can check
 out the [TimescaleDB][tsdb-docs] section in our documentation, and find out what
 you can do with it.
@@ -219,7 +260,6 @@ TimescaleDB and time-series data, check out our [tutorials][tutorials] section.
 
 You can always [contact us][contact] if you need help working something out, or
 if you want to have a chat.
-
 
 [contact]: https://www.timescale.com/contact
 [install-psql]: /timescaledb/latest/how-to-guides/connecting/psql/


### PR DESCRIPTION
# Description

- Installed and validated psql on centos and added the partials
- Added the instructions to run timescaledb-tune
- Validated that the database has to be initialized before running the timescaledb-tune
- Validated that the built-in module has to be disabled in centos8

# Links

Fixes https://github.com/timescale/docs/issues/1569

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
