### PR TITLE
Update docs for integrals in Toolkit 1.11

### DIFF
--- a/api/average-time-weight.md
+++ b/api/average-time-weight.md
@@ -28,14 +28,12 @@ average(
 ) RETURNS DOUBLE PRECISION
 ```
 
-A function to compute a time-weighted average from a `TimeWeightSummary`.
+Compute a time-weighted average from a `TimeWeightSummary`.
 
 This function is similar to [`integral`][hyperfunctions-integral] but divides by the length of time being averaged.
 
 *   For more information about time-weighted average functions, see the
     [hyperfunctions documentation][hyperfunctions-time-weight-average].
-*   For more information about statistical aggregate functions, see the
-    [hyperfunctions documentation][hyperfunctions-stats-agg].
 
 ### Required arguments
 

--- a/api/integral-time-weight.md
+++ b/api/integral-time-weight.md
@@ -31,20 +31,23 @@ integral(
 ) RETURNS DOUBLE PRECISION
 ```
 
-A function to compute a time-weighted integral from a `TimeWeightSummary`.
+Compute a time-weighted integral from a `TimeWeightSummary`.
 
 This function is similar to [`average`][hyperfunctions-average] but doesn't divide by the length of time being integrated.
 
 *   For more information about time-weighted average functions, see the
     [hyperfunctions documentation][hyperfunctions-time-weight-average].
-*   For more information about statistical aggregate functions, see the
-    [hyperfunctions documentation][hyperfunctions-stats-agg].
 
 ### Required arguments
 
 |Name|Type|Description|
 |-|-|-|
 |`tws`|`TimeWeightSummary`|The input TimeWeightSummary from a [`time_weight`][time_weight] call|
+
+### Optional arguments
+|Name|Type|Description|
+|-|-|-|
+|`unit`|`TEXT`|The unit of time to express the integral in. Can be `microsecond`/`millisecond`/`second`/`minute`/`hour` or any alias for those units supported by PostgreSQL. If `NULL`, defaults to `second`.|
 
 ### Returns
 
@@ -55,16 +58,21 @@ This function is similar to [`average`][hyperfunctions-average] but doesn't divi
 ### Sample usage
 
 ```SQL
+-- Create a table to track irregularly sampled storage usage
+CREATE TABLE user_storage_usage(ts TIMESTAMP, storage_bytes BIGINT);
+INSERT INTO user_storage_usage(ts, storage_bytes) VALUES
+    ('01-01-2022 00:00', 0),
+    ('01-01-2022 00:30', 100),
+    ('01-01-2022 03:00', 300),
+    ('01-01-2022 03:10', 1000),
+    ('01-01-2022 03:25', 817);
+
+-- Get the total byte-hours used
 SELECT
-    id,
-    integral(tws)
-FROM (
-    SELECT
-        id,
-        time_weight('LOCF', ts, val) AS tws
-    FROM foo
-    GROUP BY id
-) t
+    time_weight('LOCF', ts, storage_bytes) ->
+    toolkit_experimental.integral('hours')
+FROM
+    user_storage_usage;
 ```
 
 [hyperfunctions-time-weight-average]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/time-weighted-averages/

--- a/api/integral-time-weight.md
+++ b/api/integral-time-weight.md
@@ -1,11 +1,12 @@
 ---
-api_name: average()
-excerpt: Calculate the time-weighted average of values in a `TimeWeightSummary`
+api_name: integral()
+excerpt: Calculate the time-weighted integral of values in a `TimeWeightSummary`
 topics: [hyperfunctions]
 keywords: [average, time-weighted, hyperfunctions, toolkit]
 api:
   license: community
   type: function
+  experimental: true
   toolkit: true
 hyperfunction:
   family: time-weighted averages
@@ -14,23 +15,25 @@ hyperfunction:
     - time_weight()
 # fields below will be deprecated
 api_category: hyperfunction
+api_experimental: true
 toolkit: true
 hyperfunction_family: 'time-weighted averages'
 hyperfunction_subfamily: 'time-weighted averages'
 hyperfunction_type: accessor
 ---
 
-# average() <tag type="toolkit">Toolkit</tag>
+# integral() <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
 
 ```SQL
-average(
-    tws TimeWeightSummary
+integral(
+    tws TimeWeightSummary,
+    unit TEXT
 ) RETURNS DOUBLE PRECISION
 ```
 
-A function to compute a time-weighted average from a `TimeWeightSummary`.
+A function to compute a time-weighted integral from a `TimeWeightSummary`.
 
-This function is similar to [`integral`][hyperfunctions-integral] but divides by the length of time being averaged.
+This function is similar to [`average`][hyperfunctions-average] but doesn't divide by the length of time being integrated.
 
 *   For more information about time-weighted average functions, see the
     [hyperfunctions documentation][hyperfunctions-time-weight-average].
@@ -47,14 +50,14 @@ This function is similar to [`integral`][hyperfunctions-integral] but divides by
 
 |Column|Type|Description|
 |-|-|-|
-|`average`|`DOUBLE PRECISION`|The time-weighted average computed from the `TimeWeightSummary`|
+|`integral`|`DOUBLE PRECISION`|The time-weighted integral computed from the `TimeWeightSummary`|
 
 ### Sample usage
 
 ```SQL
 SELECT
     id,
-    average(tws)
+    integral(tws)
 FROM (
     SELECT
         id,
@@ -67,4 +70,4 @@ FROM (
 [hyperfunctions-time-weight-average]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/time-weighted-averages/
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
 [time_weight]: /api/:currentVersion:/hyperfunctions/time-weighted-averages/time_weight/
-[hyperfunctions-integral]: /api/:currentVersion:/hyperfunctions/time-weighted-averages/integral-time-weight/
+[hyperfunctions-average]: /api/:currentVersion:/hyperfunctions/time-weighted-averages/average-time-weight/

--- a/api/interpolated_average.md
+++ b/api/interpolated_average.md
@@ -51,8 +51,6 @@ This function is similar to [`interpolated_integral`][hyperfunctions-interpolate
 
 *   For more information about time-weighted average functions, see the
     [hyperfunctions documentation][hyperfunctions-time-weight-average].
-*   For more information about statistical aggregate functions, see the
-    [hyperfunctions documentation][hyperfunctions-stats-agg].
 
 ### Required arguments
 

--- a/api/interpolated_integral.md
+++ b/api/interpolated_integral.md
@@ -1,8 +1,8 @@
 ---
-api_name: interpolated_average()
-excerpt: Calculate the time-weighted average of values within an interval, interpolating the interval bounds
+api_name: interpolated_integral()
+excerpt: Calculate the time-weighted integral of values within an interval, interpolating the interval bounds
 topics: [hyperfunctions]
-tags: [hyperfunctions, average, time-weighted, TimeWeightSummary, interpolated]
+tags: [hyperfunctions, integral, time-weighted, TimeWeightSummary, interpolated]
 api:
   license: community
   type: function
@@ -22,32 +22,34 @@ hyperfunction_subfamily: 'time-weighted averages'
 hyperfunction_type: accessor
 ---
 
-# interpolated_average() <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+# interpolated_integral() <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
 
 ```SQL
-interpolated_average(
+interpolated_integral(
     tws TimeWeightSummary,
     start TIMESTAMPTZ,
     interval INTERVAL,
     prev TimeWeightSummary,
-    next TimeWeightSummary
+    next TimeWeightSummary,
+    unit TEXT
 ) RETURNS DOUBLE PRECISION
 ```
 
-A function to compute a time-weighted average over the interval, defined as `start`
+A function to compute a time-weighted integral over the interval, defined as `start`
 plus `interval`, given a `prev` and `next` time-weight summary from which to
 compute the boundary points. This is intended to allow a precise time-weighted
-average over intervals even when the points representing the intervals are grouped
+integral over intervals even when the points representing the intervals are grouped
 into discrete time-weight summaries. PostgreSQL window functions such as
 `LEAD` and `LAG` can be used to determine the `prev` and `next` arguments,
 as used in the examples in this section.
 
 Note that if either `prev` or `next` are `NULL`, the first or last point in the
 summary is treated as the edge of the interval. The interpolated point is
-determined using LOCF or linear interpolation, depending on which interpolation
-style the time-weight summary was created with.
+determined using LOCF (Last Observation Carries Forward) or linear
+interpolation, depending on which interpolation style the time-weight summary
+was created with.
 
-This function is similar to [`interpolated_integral`][hyperfunctions-interpolated-integral] but divides by the length of time being averaged.
+This function is similar to [`interpolated_average`][hyperfunctions-interpolated-average] but doesn't divide by the length of time being integrated.
 
 *   For more information about time-weighted average functions, see the
     [hyperfunctions documentation][hyperfunctions-time-weight-average].
@@ -59,8 +61,8 @@ This function is similar to [`interpolated_integral`][hyperfunctions-interpolate
 |Name|Type|Description|
 |-|-|-|
 |`tws`|`TimeWeightSummary`|The input TimeWeightSummary from a [`time_weight`][hyperfunctions-time-weight] call|
-|`start`|`TIMESTAMPTZ`|The start of the interval which the time-weighted average should cover (if there is a preceeding point)|
-|`interval`|`INTERVAL`|The length of the interval which the time-weighted average should cover|
+|`start`|`TIMESTAMPTZ`|The start of the interval which the time-weighted integral should cover (if there is a preceeding point)|
+|`interval`|`INTERVAL`|The length of the interval which the time-weighted integral should cover|
 
 ### Optional arguments
 
@@ -68,12 +70,13 @@ This function is similar to [`interpolated_integral`][hyperfunctions-interpolate
 |-|-|-|
 |`prev`|`TimeWeightSummary`|The TimeWeightSummary from the prior interval, used to interpolate the value at `start`. If `NULL`, the first timestamp in `tws` is used as the start of the interval.|
 |`next`|`TimeWeightSummary`|The TimeWeightSummary from the following interval, used to interpolate the value at `start` + `interval`. If `NULL`, the last timestamp in `tws` is used as the end of the interval.|
+|`unit`|`TEXT`|The unit of time to express the integral in. Can be `microsecond`/`millisecond`/`second`/`minute`/`hour` or any alias for those units supported by PostgreSQL. If `NULL`, `second` is defaulted to.|
 
 ### Returns
 
 |Column|Type|Description|
 |-|-|-|
-|`interpolated_average`|`DOUBLE PRECISION`|The time-weighted average for the interval (`start`, `start` + `interval`) computed from the `TimeWeightSummary` plus end points interpolated from `prev` and `next`|
+|`interpolated_integral`|`DOUBLE PRECISION`|The time-weighted integral for the interval (`start`, `start` + `interval`) computed from the `TimeWeightSummary` plus end points interpolated from `prev` and `next`|
 
 ### Sample usage
 
@@ -81,7 +84,7 @@ This function is similar to [`interpolated_integral`][hyperfunctions-interpolate
 SELECT
     id,
     time,
-    interpolated_average(
+    interpolated_integral(
         tws,
         time,
         '1 day',
@@ -100,5 +103,5 @@ FROM (
 
 [hyperfunctions-time-weight-average]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/time-weighted-averages/
 [hyperfunctions-time-weight]: /api/:currentVersion:/hyperfunctions/time-weighted-averages/time_weight/
+[hyperfunctions-interpolated-average]: /api/:currentVersion:/hyperfunctions/time-weighted-averages/interpolated_average/
 [hyperfunctions-stats-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/stats-aggs/
-[hyperfunctions-interpolated-integral]: /api/:currentVersion:/hyperfunctions/time-weighted-averages/interpolated_integral/

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -644,9 +644,17 @@ module.exports = [
                 href: "average-time-weight",
               },
               {
+                title: "integral",
+                href: "integral-time-weight",
+              },
+              {
                 title: "interpolated_average",
                 href: "interpolated_average",
               },
+              {
+                title: "interpolated_integral",
+                href: "interpolated_integral",
+              }
             ],
           },
           {

--- a/api/time-weighted-averages.md
+++ b/api/time-weighted-averages.md
@@ -6,10 +6,10 @@ tags: [mean]
 ---
 
 # Time-weighted average functions <tag type="toolkit">Toolkit</tag>
-This section contains functions related to time-weighted averages. Time weighted
-averages are commonly used in cases where a time series is not evenly sampled,
-so a traditional average gives misleading results. For more information
-about time-weighted average functions, see the
+This section contains functions related to time-weighted averages and integrals.
+Time weighted averages and integrals are commonly used in cases where a time
+series is not evenly sampled, so a traditional average gives misleading results.
+For more information about these functions, see the
 [hyperfunctions documentation][hyperfunctions-time-weight-average].
 
 Some hyperfunctions are included in the default TimescaleDB product. For

--- a/api/time_weight.md
+++ b/api/time_weight.md
@@ -37,14 +37,14 @@ For more information about time-weighted average functions, see the
 
 |Name|Type|Description|
 |---|---|---|
-|`method`|`TEXT`| The weighting method we should use, options are `linear` or `LOCF`, not case sensitive|
+|`method`|`TEXT`| The weighting method to use, options are `linear` (or its alias `trapezoidal`) or `LOCF`, not case sensitive|
 |`ts`|`TIMESTAMPTZ`|The time at each point|
 |`value`|`DOUBLE PRECISION`|The value at each point to use for the time-weighted average|
 
 Note that `ts` and `value` can be `null`, however the aggregate is not evaluated
 on `null` values and returns `null`, but does not error on `null` inputs.
 
-Only two values for `method` are currently supported: `linear` and `LOCF`, and
+Only two values for `method` are currently supported: `linear` (or its alias `trapezoidal`) and `LOCF`, and
 any capitalization is accepted. See [interpolation methods](#interpolation-methods-details)
 for more information.
 

--- a/timescaledb/how-to-guides/hyperfunctions/function-pipelines.md
+++ b/timescaledb/how-to-guides/hyperfunctions/function-pipelines.md
@@ -549,6 +549,7 @@ need to use them in another pipeline later on. The two types of output are:
 These elements take a `timevector` and run the corresponding aggregate over it
 to produce a result.. The possible elements are:
 *   `average()`
+*   `integral()`
 *   `counter_agg()`
 *   `hyperloglog()`
 *   `stats_agg()`

--- a/timescaledb/how-to-guides/hyperfunctions/time-weighted-averages.md
+++ b/timescaledb/how-to-guides/hyperfunctions/time-weighted-averages.md
@@ -1,15 +1,15 @@
 ---
-title: Time-weighted averages
-excerpt: Calculate time-weighted averages for unevenly sampled data
+title: Time-weighted averages and integrals
+excerpt: Calculate time-weighted averages and integrals for unevenly sampled data
 keywords: [hyperfunctions, Toolkit, time-weighted]
 ---
 
-# Time-weighted averages
-Time weighted averages are used in cases where a time series is not evenly
-sampled. Time series data points are often evenly spaced, for example every 30
-seconds, or every hour. But sometimes data points are recorded irregularly, for
-example if a value has a large change, or changes quickly. Computing an average
-using data that is not evenly sampled is not always useful.
+# Time-weighted averages and integrals
+Time weighted averages and integrals are used in cases where a time series is
+not evenly sampled. Time series data points are often evenly spaced, for
+example every 30 seconds, or every hour. But sometimes data points are recorded
+irregularly, for example if a value has a large change, or changes quickly.
+Computing an average using data that is not evenly sampled is not always useful.
 
 For example, if you have a lot of ice cream in freezers, you need to make sure
 the ice cream stays within a 0-10℉ (-20 to -12℃) temperature range. The
@@ -22,6 +22,12 @@ quick moving transients, an average of all the data points weights the transient
 values too highly. A time weighted average weights each value by the duration
 over which it occurred based on the points around it, producing much more
 accurate results.
+
+Time weighted integrals are useful when you need a time-weighted sum of
+irregularly sampled data. For example, if you bill your users based on
+irregularly sampled CPU usage, you need to find the total area under the graph
+of their CPU usage. You can use a time-weighted integral to find the total
+CPU-hours used by a user over a given time period.
 
 *   For more information about how time-weighted averages work, read our
     [time-weighted averages blog][blog-timeweight].


### PR DESCRIPTION
# Description

Updates documentation for the addition of `integral`/`interpolated_integral` in Toolkit 1.11. I based the content for these based on `average`/`interpolated_average`, since the functions are very similar.

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
