### PR TITLE
Document `first_val`, `last_val`, `first_time` and `last_time` accessors

### DIFF
--- a/api/first-last-time-counter.md
+++ b/api/first-last-time-counter.md
@@ -1,0 +1,78 @@
+---
+api_name: first_time() | last_time()
+excerpt: Get the first and last timestamps seen by `CounterSummary` aggregates
+topics: [hyperfunctions]
+tags: [hyperfunctions, finance]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+# fields below will be deprecated
+api_category: hyperfunction
+api_experimental: true
+toolkit: true
+hyperfunction_family: 'metric aggregation'
+hyperfunction_subfamily: 'counter and gauge aggregation'
+hyperfunction_type: accessor
+---
+
+import Experimental from 'versionContent/_partials/_experimental.mdx';
+
+# first_time, last_time <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+
+This pair of functions returns the timestamps of the first and last points in a `CounterSummary` aggregate.
+
+```sql
+first_time(
+    cs CounterSummary
+) RETURNS TIMESTAMPTZ
+```
+
+```sql
+last_time(
+    cs CounterSummary
+) RETURNS TIMESTAMPTZ
+```
+
+<Experimental />
+
+## Required arguments
+
+|Name| Type |Description|
+|-|-|-|
+|`cs`|CounterSummary|The input CounterSummary from a previous `counter_agg` (point form) call, often from a continuous aggregate|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`first_time`|`TIMESTAMPTZ`|The time of the first point in the `CounterSummary`|
+
+|Column|Type|Description|
+|-|-|-|
+|`last_time`|`TIMESTAMPTZ`|The time of the last point in the `CounterSummary`|
+
+## Sample usage
+
+This example produces a CounterSummary from timestamps and associated values, then applies the `first_time` and `last_time` accessors:
+
+```sql
+WITH t as (
+    SELECT
+        time_bucket('1 day'::interval, ts) as dt,
+        counter_agg(ts, val) AS cs -- get a CounterSummary
+    FROM table
+    GROUP BY time_bucket('1 day'::interval, ts)
+)
+SELECT
+    dt,
+    first_time(cs) -- extract the timestamp of the first point in the CounterSummary
+    last_time(cs) -- extract the timestamp of the last point in the CounterSummary
+FROM t;
+```

--- a/api/first-last-time-timeweight.md
+++ b/api/first-last-time-timeweight.md
@@ -1,0 +1,78 @@
+---
+api_name: first_time() | last_time()
+excerpt: Get the first and last timestamps seen by `TimeWeightSummary` aggregates
+topics: [hyperfunctions]
+tags: [time-weighted, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: time-weighted averages
+  type: accessor
+  aggregates:
+    - time_weight()
+# fields below will be deprecated
+api_category: hyperfunction
+api_experimental: true
+toolkit: true
+hyperfunction_family: 'time-weighted averages'
+hyperfunction_subfamily: 'time-weighted averages'
+hyperfunction_type: accessor
+---
+
+import Experimental from 'versionContent/_partials/_experimental.mdx';
+
+# first_time, last_time <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+
+This pair of functions returns the timestamps of the first and last points in a `TimeWeightSummary` aggregate.
+
+```sql
+first_time(
+    tw TimeWeightSummary
+) RETURNS TIMESTAMPTZ
+```
+
+```sql
+last_time(
+    tw TimeWeightSummary
+) RETURNS TIMESTAMPTZ
+```
+
+<Experimental />
+
+## Required arguments
+
+|Name| Type |Description|
+|-|-|-|
+|`tw`|`TimeWeightSummary`|The input TimeWeightSummary from a previous `time_weight` call, often from a continuous aggregate|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`first_time`|`TIMESTAMPTZ`|The time of the first point in the `TimeWeightSummary`|
+
+|Column|Type|Description|
+|-|-|-|
+|`last_time`|`TIMESTAMPTZ`|The time of the last point in the `TimeWeightSummary`|
+
+## Sample usage
+
+This example produces a linear TimeWeightSummary from timestamps and associated values, then applies the `first_time` and `last_time` accessors:
+
+```sql
+WITH t as (
+    SELECT
+        time_bucket('1 day'::interval, ts) as dt,
+        time_weight('Linear', ts, val) AS tw -- get a TimeWeightSummary
+    FROM table
+    GROUP BY time_bucket('1 day'::interval, ts)
+)
+SELECT
+    dt,
+    first_time(tw) -- extract the timestamp of the first point in the TimeWeightSummary
+    last_time(tw) -- extract the timestamp of the last point in the TimeWeightSummary
+FROM t;
+```

--- a/api/first-last-val-counter.md
+++ b/api/first-last-val-counter.md
@@ -1,0 +1,78 @@
+---
+api_name: first_val() | last_val()
+excerpt: Get the first and last values seen by `CounterSummary` aggregates
+topics: [hyperfunctions]
+tags: [counters, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: metric aggregation
+  type: accessor
+  aggregates:
+    - counter_agg()
+# fields below will be deprecated
+api_category: hyperfunction
+api_experimental: true
+toolkit: true
+hyperfunction_family: 'metric aggregation'
+hyperfunction_subfamily: 'counter and gauge aggregation'
+hyperfunction_type: accessor
+---
+
+import Experimental from 'versionContent/_partials/_experimental.mdx';
+
+# first_val, last_val <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+
+This pair of functions returns the values of the first and last points in a `CounterSummary` aggregate.
+
+```sql
+first_val(
+    cs CounterSummary
+) RETURNS DOUBLE PRECISION
+```
+
+```sql
+last_val(
+    cs CounterSummary
+) RETURNS DOUBLE PRECISION
+```
+
+<Experimental />
+
+## Required arguments
+
+|Name| Type |Description|
+|-|-|-|
+|`cs`|CounterSummary|The input CounterSummary from a previous `counter_agg` (point form) call, often from a continuous aggregate|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`first_val`|`DOUBLE PRECISION`|The value of the first point in the `CounterSummary`|
+
+|Column|Type|Description|
+|-|-|-|
+|`last_val`|`DOUBLE PRECISION`|The value of the last point in the `CounterSummary`|
+
+## Sample usage
+
+This example produces a CounterSummary from timestamps and associated values, then applies the `first_val` and `last_val` accessors:
+
+```sql
+WITH t as (
+    SELECT
+        time_bucket('1 day'::interval, ts) as dt,
+        counter_agg(ts, val) AS cs -- get a CounterSummary
+    FROM table
+    GROUP BY time_bucket('1 day'::interval, ts)
+)
+SELECT
+    dt,
+    first_val(cs) -- extract the value of the first point in the CounterSummary
+    last_val(cs) -- extract the value of the last point in the CounterSummary
+FROM t;
+```

--- a/api/first-last-val-timeweight.md
+++ b/api/first-last-val-timeweight.md
@@ -1,0 +1,78 @@
+---
+api_name: first_val() | last_val()
+excerpt: Get the first and last values seen by `TimeWeightSummary` aggregates
+topics: [hyperfunctions]
+tags: [time-weighted, hyperfunctions, toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+hyperfunction:
+  family: time-weighted averages
+  type: accessor
+  aggregates:
+    - time_weight()
+# fields below will be deprecated
+api_category: hyperfunction
+api_experimental: true
+toolkit: true
+hyperfunction_family: 'time-weighted averages'
+hyperfunction_subfamily: 'time-weighted averages'
+hyperfunction_type: accessor
+---
+
+import Experimental from 'versionContent/_partials/_experimental.mdx';
+
+# first_val, last_val <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+
+This pair of functions returns the timestamps of the first and last points in a `TimeWeightSummary` aggregate.
+
+```sql
+first_val(
+    tw TimeWeightSummary
+) RETURNS DOUBLE PRECISION
+```
+
+```sql
+last_val(
+    tw TimeWeightSummary
+) RETURNS DOUBLE PRECISION
+```
+
+<Experimental />
+
+## Required arguments
+
+|Name| Type |Description|
+|-|-|-|
+|`tw`|`TimeWeightSummary`|The input TimeWeightSummary from a previous `time_weight` call, often from a continuous aggregate|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`first_val`|`DOUBLE PRECISION`|The value of the first point in the `CounterSummary`|
+
+|Column|Type|Description|
+|-|-|-|
+|`last_val`|`DOUBLE PRECISION`|The value of the last point in the `CounterSummary`|
+
+## Sample usage
+
+This example produces a linear TimeWeightSummary from timestamps and associated values, then applies the `first_val` and `last_val` accessors:
+
+```sql
+WITH t as (
+    SELECT
+        time_bucket('1 day'::interval, ts) as dt,
+        time_weight('Linear', ts, val) AS tw -- get a TimeWeightSummary
+    FROM table
+    GROUP BY time_bucket('1 day'::interval, ts)
+)
+SELECT
+    dt,
+    first_val(tw) -- extract the value of the first point in the TimeWeightSummary
+    last_val(tw) -- extract the value of the last point in the TimeWeightSummary
+FROM t;
+```

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -577,6 +577,14 @@ module.exports = [
                 href: "extrapolated_rate",
               },
               {
+                title: "first_time, last_time",
+                href: "first-last-time-counter",
+              },
+              {
+                title: "first_val, last_val",
+                href: "first-last-val-counter",
+              },
+              {
                 title: "interpolated_delta",
                 href: "interpolated_delta",
               },
@@ -643,6 +651,13 @@ module.exports = [
                 title: "average",
                 href: "average-time-weight",
               },
+                title: "first_time, last_time",
+                href: "first-last-time-timeweight",
+              },
+              {
+                title: "first_val, last_val",
+                href: "first-last-val-timeweight",
+              },
               {
                 title: "integral",
                 href: "integral-time-weight",
@@ -654,7 +669,7 @@ module.exports = [
               {
                 title: "interpolated_integral",
                 href: "interpolated_integral",
-              }
+              },
             ],
           },
           {


### PR DESCRIPTION
# Description

These experimental accessors have been added to work on both time_weight and counter_agg aggregates in Toolkit 1.11.0

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [x] Have you checked the built version of this content?
