### PR TITLE
Updates wording around cloud backup retention

### DIFF
--- a/cloud/backup-restore-cloud.md
+++ b/cloud/backup-restore-cloud.md
@@ -7,41 +7,45 @@ tags: [recovery, failures]
 ---
 
 # Backup and restore
+
 Timescale Cloud has a range of automated backup and restore mechanisms. All
 automated backups in Timescale Cloud are created using the `pgBackRest` tool.
 There is no need for you to manually perform backups for your Timescale Cloud
 service.
 
-Timescale Cloud allows a point-in-time recovery to any point since the service 
-was created, regardless of when a failure occurs. To achieve this, Timescale 
-Cloud automatically creates one full backup every week. We also take 
-incremental backups every day, which store any changes since the last full 
-backup. Finally, all generated WAL ([Write-Ahead Log][wal]) files are streamed 
-to S3. The two most recent full backups are also stored securely on an Amazon 
-S3 service with the most recent incremental backups. This means that you always 
-have a full "base" backup for the current and the previous week, and we can 
-restore your backup to any point up to the point of failure. 
+Timescale Cloud allows a point-in-time recovery to any point since the service
+was created, regardless of when a failure occurs. To achieve this, Timescale
+Cloud automatically creates one full backup every week. We also take
+incremental backups every day, which store any changes since the last full
+backup. Finally, all generated WAL ([Write-Ahead Log][wal]) files are streamed
+to S3. The two most recent full backups are also stored securely on an Amazon
+S3 service with the most recent incremental backups. This means that you always
+have a full "base" backup for the current and the previous week, and we can
+restore your backup to any point up to the point of failure.
 
-To perform a point-in-time recovery, your database is first restored using the full backup, 
-then any available incremental backups, and finally by replaying any WAL to 
-cover any gap in time between the incremental backup and the target recovery 
-point. For more information about how backup and restore works, see 
-the [blog post on high availability][ha-post].
+To perform a point-in-time recovery, your database is first restored using the
+full backup, then any available incremental backups, and finally by replaying
+any WAL to cover any gap in time between the incremental backup and the target
+recovery point. For more information about how backup and restore works, see the
+[blog post on high availability][ha-post].
 
-When you delete an instance, we retain a backup of the instance for seven days.
-If you need to restore your database from a backup, [contact support][support].
+When you delete an instance, a backup of your instance is retained for at least
+seven days. If you need to restore your database from a backup,
+[contact support][support].
 
 If you want to verify that your service is being backed up, you can run this
 query from the `psql` prompt:
+
 ```sql
 SELECT pg_is_in_backup()::text
 ```
 
 <highlight type="cloud" header="Sign up for Timescale Cloud" button="Try for free">
-
+You can try Timescale Cloud for free, no credit card required.
 </highlight>
 
 ## Weekly backups
+
 A full database backup is performed weekly. The two most recent full backups are
 automatically saved to a secure Amazon S3 service. For every successful weekly
 backup, the logs show `DB BACKED UP`.
@@ -56,6 +60,7 @@ of data, but not enough CPU processing capability. Increasing the size of the
 CPU can help alleviate this bottleneck.
 
 ## Daily backups
+
 Incremental database backups are performed daily. This backs up the database
 first against the weekly full backup, and then against the previous day's
 incremental backup. This means that each day has a full record that can be used
@@ -70,6 +75,7 @@ this case, the backup contains the difference between the last complete backup
 and the current day.
 
 ## Restore from backup
+
 If your database fails, the restore process begins automatically. This occurs in
 two stages:
 
@@ -88,10 +94,10 @@ two stages:
 
 If you want to check if your service is in the recovery phase, you can run this
 query from the `psql` prompt:
+
 ```sql
 SELECT pg_is_in_recovery()::text
 ```
-
 
 [support]: https://www.timescale.com/support
 [wal]: https://www.postgresql.org/docs/current/wal-intro.html


### PR DESCRIPTION
# Description

Updates wording to be "*at least* seven days" for the backup retention period. Also adds some text to the Cloud highlight, since it looks a bit funny without it.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
