### PR TITLE
feat(api reference): Add documentation for new 'check config' function

### DIFF
--- a/api/add_job.md
+++ b/api/add_job.md
@@ -27,6 +27,7 @@ Register an action for scheduling by the automation framework. For more informat
 |`config`|JSONB|Job-specific configuration, passed to the function when it runs|
 |`initial_start`|TIMESTAMPTZ|Time the job is first run|
 |`scheduled`|BOOLEAN|Set to `FALSE` to exclude this job from scheduling. Defaults to `TRUE`. |
+|`check_config`|`REGPROC`|A function that takes a single argument, the `JSONB` `config` structure. The function is expected to raise an error if the configuration is valid, and return nothing otherwise. Can be used to validate the configuration when adding a job. Only functions, not procedures, are allowed as values for `check_config`.|
 
 ### Returns
 

--- a/api/add_job.md
+++ b/api/add_job.md
@@ -27,7 +27,7 @@ Register an action for scheduling by the automation framework. For more informat
 |`config`|JSONB|Job-specific configuration, passed to the function when it runs|
 |`initial_start`|TIMESTAMPTZ|Time the job is first run|
 |`scheduled`|BOOLEAN|Set to `FALSE` to exclude this job from scheduling. Defaults to `TRUE`. |
-|`check_config`|`REGPROC`|A function that takes a single argument, the `JSONB` `config` structure. The function is expected to raise an error if the configuration is valid, and return nothing otherwise. Can be used to validate the configuration when adding a job. Only functions, not procedures, are allowed as values for `check_config`.|
+|`check_config`|`REGPROC`|A function that takes a single argument, the `JSONB` `config` structure. The function is expected to raise an error if the configuration is not valid, and return nothing otherwise. Can be used to validate the configuration when adding a job. Only functions, not procedures, are allowed as values for `check_config`.|
 
 ### Returns
 

--- a/api/alter_job.md
+++ b/api/alter_job.md
@@ -24,20 +24,21 @@ other useful statistics for deciding what the new schedule should be.
 
 |Name|Type|Description|
 |-|-|-|
-|`job_id`|INTEGER|The ID of the policy job being modified|
+|`job_id`|`INTEGER`|The ID of the policy job being modified|
 
 ### Optional arguments
 
 |Name|Type|Description|
 |-|-|-|
-|`schedule_interval`|INTERVAL|The interval at which the job runs. Defaults to 24 hours|
-|`max_runtime`|INTERVAL|The maximum amount of time the job is allowed to run by the background worker scheduler before it is stopped|
-|`max_retries`|INTEGER|The number of times the job is retried if it fails|
-|`retry_period`|INTERVAL|The amount of time the scheduler waits between retries of the job on failure|
-|`scheduled`|BOOLEAN|Set to `FALSE` to exclude this job from being run as background job|
-|`config`|JSONB|Job-specific configuration, passed to the function when it runs|
-|`next_start`|TIMESTAMPTZ|The next time at which to run the job. The job can be paused by setting this value to `infinity`, and restarted with a value of `now()`|
-|`if_exists`|BOOLEAN|Set to `true`to issue a notice instead of an error if the job does not exist. Defaults to false.|
+|`schedule_interval`|`INTERVAL`|The interval at which the job runs. Defaults to 24 hours|
+|`max_runtime`|`INTERVAL`|The maximum amount of time the job is allowed to run by the background worker scheduler before it is stopped|
+|`max_retries`|`INTEGER`|The number of times the job is retried if it fails|
+|`retry_period`|`INTERVAL`|The amount of time the scheduler waits between retries of the job on failure|
+|`scheduled`|`BOOLEAN`|Set to `FALSE` to exclude this job from being run as background job|
+|`config`|`JSONB`|Job-specific configuration, passed to the function when it runs|
+|`next_start`|`TIMESTAMPTZ`|The next time at which to run the job. The job can be paused by setting this value to `infinity`, and restarted with a value of `now()`|
+|`if_exists`|`BOOLEAN`|Set to `true`to issue a notice instead of an error if the job does not exist. Defaults to false.|
+|`check_config`|`REGPROC`|A function that takes a single argument, the `JSONB` `config` structure. The function is expected to raise an error if the configuration is valid, and return nothing otherwise. Can be used to validate the configuration when updating a job. Only functions, not procedures, are allowed as values for `check_config`.|
 
 When a job begins, the `next_start` parameter is set to `infinity`. This
 prevents the job from attempting to be started again while it is running. When
@@ -48,14 +49,15 @@ automatically updated to the next computed start time.
 
 |Column|Type|Description|
 |-|-|-|
-|`job_id`|INTEGER|The ID of the job being modified|
-|`schedule_interval`|INTERVAL|The interval at which the job runs. Defaults to 24 hours|
-|`max_runtime`|INTERVAL|The maximum amount of time the job is allowed to run by the background worker scheduler before it is stopped|
+|`job_id`|`INTEGER`|The ID of the job being modified|
+|`schedule_interval`|`INTERVAL`|The interval at which the job runs. Defaults to 24 hours|
+|`max_runtime`|`INTERVAL`|The maximum amount of time the job is allowed to run by the background worker scheduler before it is stopped|
 |`max_retries`|INTEGER|The number of times the job is retried if it fails|
-|`retry_period`|INTERVAL|The amount of time the scheduler waits between retries of the job on failure|
-|`scheduled`|BOOLEAN|Returns `true` if the job is executed by the TimescaleDB scheduler|
-|`config`|JSONB|Job-specific configuration, passed to the function when it runs|
-|`next_start`|TIMESTAMPTZ|The next time to run the job|
+|`retry_period`|`INTERVAL`|The amount of time the scheduler waits between retries of the job on failure|
+|`scheduled`|`BOOLEAN`|Returns `true` if the job is executed by the TimescaleDB scheduler|
+|`config`|`JSONB`|Job-specific configuration, passed to the function when it runs|
+|`next_start`|`TIMESTAMPTZ`|The next time to run the job|
+|`check_config`|`TEXT`|The function used to validate updated job configurations|
 
 ### Sample usage
 

--- a/api/alter_job.md
+++ b/api/alter_job.md
@@ -38,7 +38,7 @@ other useful statistics for deciding what the new schedule should be.
 |`config`|`JSONB`|Job-specific configuration, passed to the function when it runs|
 |`next_start`|`TIMESTAMPTZ`|The next time at which to run the job. The job can be paused by setting this value to `infinity`, and restarted with a value of `now()`|
 |`if_exists`|`BOOLEAN`|Set to `true`to issue a notice instead of an error if the job does not exist. Defaults to false.|
-|`check_config`|`REGPROC`|A function that takes a single argument, the `JSONB` `config` structure. The function is expected to raise an error if the configuration is valid, and return nothing otherwise. Can be used to validate the configuration when updating a job. Only functions, not procedures, are allowed as values for `check_config`.|
+|`check_config`|`REGPROC`|A function that takes a single argument, the `JSONB` `config` structure. The function is expected to raise an error if the configuration is not valid, and return nothing otherwise. Can be used to validate the configuration when updating a job. Only functions, not procedures, are allowed as values for `check_config`.|
 
 When a job begins, the `next_start` parameter is set to `infinity`. This
 prevents the job from attempting to be started again while it is running. When

--- a/api/jobs.md
+++ b/api/jobs.md
@@ -17,20 +17,22 @@ Shows information about all jobs registered with the automation framework.
 
 |Name|Type|Description|
 |-|-|-|
-|`job_id`|INTEGER|The ID of the background job|
-|`application_name`|TEXT|Name of the policy or user defined action|
-|`schedule_interval`|INTERVAL|The interval at which the job runs. Defaults to 24 hours|
-|`max_runtime`|INTERVAL|The maximum amount of time the job is allowed to run by the background worker scheduler before it is stopped|
-|`max_retries`|INTEGER|The number of times the job is retried if it fails|
-|`retry_period`|INTERVAL|The amount of time the scheduler waits between retries of the job on failure|
-|`proc_schema`|TEXT|Schema name of the function or procedure executed by the job|
-|`proc_name`|TEXT|Name of the function or procedure executed by the job|
-|`owner`|TEXT|Owner of the job|
-|`scheduled`|BOOLEAN|Set to `true` to run the job automatically|
-|`config`|JSONB|Configuration passed to the function specified by `proc_name` at execution time|
-|`next_start`|TIMESTAMP WITH TIME ZONE|Next start time for the job, if it is scheduled to run automatically|
-|`hypertable_schema`|TEXT|Schema name of the hypertable. Set to `NULL` for user-defined action|
-|`hypertable_name`|TEXT|Table name of the hypertable. Set to `NULL` for user-defined action|
+|`job_id`|`INTEGER`|The ID of the background job|
+|`application_name`|`TEXT`|Name of the policy or user defined action|
+|`schedule_interval`|`INTERVAL`|The interval at which the job runs. Defaults to 24 hours|
+|`max_runtime`|`INTERVAL`|The maximum amount of time the job is allowed to run by the background worker scheduler before it is stopped|
+|`max_retries`|`INTEGER`|The number of times the job is retried if it fails|
+|`retry_period`|`INTERVAL`|The amount of time the scheduler waits between retries of the job on failure|
+|`proc_schema`|`TEXT`|Schema name of the function or procedure executed by the job|
+|`proc_name`|`TEXT`|Name of the function or procedure executed by the job|
+|`owner`|`TEXT`|Owner of the job|
+|`scheduled`|`BOOLEAN`|Set to `true` to run the job automatically|
+|`config`|`JSONB`|Configuration passed to the function specified by `proc_name` at execution time|
+|`next_start`|`TIMESTAMP WITH TIME ZONE`|Next start time for the job, if it is scheduled to run automatically|
+|`hypertable_schema`|`TEXT`|Schema name of the hypertable. Set to `NULL` for user-defined action|
+|`hypertable_name`|`TEXT`|Table name of the hypertable. Set to `NULL` for user-defined action|
+|`check_schema`|`TEXT`|Schema name of the optional configuration validation function, set when the job is created or updated|
+|`check_table`|`TEXT`|Table name of the optional configuration validation function, set when the job is created or updated|
 
 ### Sample use
 
@@ -53,6 +55,8 @@ days", "mat_hypertable_id": 2}
 next_start        | 2020-10-02 12:38:07.014042-04
 hypertable_schema | _timescaledb_internal
 hypertable_name   | _materialized_hypertable_2
+check_schema      | _timescaledb_internal
+check_table       | policy_refresh_continuous_aggregate_check
 ```
 
 Find all jobs related to compression policies:
@@ -74,6 +78,8 @@ config            | {"hypertable_id": 3, "compress_after": "60 days"}
 next_start        | 2020-10-18 01:31:40.493764-04
 hypertable_schema | public
 hypertable_name   | conditions
+check_schema      | _timescaledb_internal
+check_table       | policy_compression_check
 ```
 
 Find jobs that are run by user defined actions:
@@ -95,6 +101,8 @@ config            | {"type": "function"}
 next_start        | 2020-10-02 14:45:33.339885-04
 hypertable_schema |
 hypertable_name   |
+check_schema      | NULL
+check_table       | NULL
 -[ RECORD 2 ]-----+------------------------------
 job_id            | 1004
 application_name  | User-Defined Action [1004]
@@ -110,4 +118,6 @@ config            | {"type": "function"}
 next_start        | 2020-10-02 14:45:33.353733-04
 hypertable_schema |
 hypertable_name   |
+check_schema      | NULL
+check_table       | NULL
 ```

--- a/api/jobs.md
+++ b/api/jobs.md
@@ -102,7 +102,7 @@ next_start        | 2020-10-02 14:45:33.339885-04
 hypertable_schema |
 hypertable_name   |
 check_schema      | NULL
-check_table       | NULL
+check_name        | NULL
 -[ RECORD 2 ]-----+------------------------------
 job_id            | 1004
 application_name  | User-Defined Action [1004]
@@ -119,5 +119,5 @@ next_start        | 2020-10-02 14:45:33.353733-04
 hypertable_schema |
 hypertable_name   |
 check_schema      | NULL
-check_table       | NULL
+check_name        | NULL
 ```

--- a/api/jobs.md
+++ b/api/jobs.md
@@ -32,7 +32,7 @@ Shows information about all jobs registered with the automation framework.
 |`hypertable_schema`|`TEXT`|Schema name of the hypertable. Set to `NULL` for user-defined action|
 |`hypertable_name`|`TEXT`|Table name of the hypertable. Set to `NULL` for user-defined action|
 |`check_schema`|`TEXT`|Schema name of the optional configuration validation function, set when the job is created or updated|
-|`check_table`|`TEXT`|Table name of the optional configuration validation function, set when the job is created or updated|
+|`check_name`|`TEXT`|Name of the optional configuration validation function, set when the job is created or updated|
 
 ### Sample use
 
@@ -56,7 +56,7 @@ next_start        | 2020-10-02 12:38:07.014042-04
 hypertable_schema | _timescaledb_internal
 hypertable_name   | _materialized_hypertable_2
 check_schema      | _timescaledb_internal
-check_table       | policy_refresh_continuous_aggregate_check
+check_name       | policy_refresh_continuous_aggregate_check
 ```
 
 Find all jobs related to compression policies:
@@ -79,7 +79,7 @@ next_start        | 2020-10-18 01:31:40.493764-04
 hypertable_schema | public
 hypertable_name   | conditions
 check_schema      | _timescaledb_internal
-check_table       | policy_compression_check
+check_name        | policy_compression_check
 ```
 
 Find jobs that are run by user defined actions:


### PR DESCRIPTION
# Description

Add documentation for new 'check config' function that validates JSONB job configurations. Adds a new optional parameter for `alter_job` and `add_job`, plus a new return column for `alter_job` and `timescaledb_information.jobs`.

As a drive-by change, also standardizes how parameter data types are displayed in the affected tables so they are all displayed as inline code.

# Links

Fixes #1610 

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
