### PR TITLE
ci(build): comment on pr if build fails

### DIFF
--- a/.github/workflows/failed-builds.yml
+++ b/.github/workflows/failed-builds.yml
@@ -1,0 +1,24 @@
+name: Failed builds
+
+on:
+  repository_dispatch:
+    types: [failed-build]
+
+permissions: {}
+
+jobs:
+  comment:
+    name: Write comment on PR
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@7dff1a87643417cf3b95bb10b29f4c4bc60d8ebd
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: github.event.client_payload.pr_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Site build failed. For Timescale internal contributors, check the logs in the web-documentation repo to see the failure reason. For help, contact the docs team.'
+            })


### PR DESCRIPTION
# Description

The web-documentation repo now dispatches an event if a build from docs content fails. When this event is received, write a comment in the corresponding PR.