### PR TITLE
Fixes a typo in a page title

### DIFF
--- a/.data/redirects.json
+++ b/.data/redirects.json
@@ -89,6 +89,7 @@
   "^/latest/getting-started": "https://docs.timescale.com/getting-started/latest/",
   "^/latest/getting-started/configuring": "https://docs.timescale.com/timescaledb/latest/how-to-guides/configuration/timescaledb-tune/",
   "^/latest/getting-started/creating-hypertables": "https://docs.timescale.com/timescaledb/latest/how-to-guides/hypertables/",
+  "^/latest/getting-started/create-hypertable/#chunks-and-hypertables": "https://docs.timescale.com/getting-started/latest/create-hypertable/#hypertables-and-chunks",
   "^/latest/getting-started/exploring-cloud": "https://docs.timescale.com/cloud/latest/customize-configuration/",
   "^/latest/getting-started/exploring-cloud/cloud-multi-node": "https://docs.timescale.com/cloud/latest/customize-configuration/",
   "^/latest/getting-started/exploring-forge": "https://docs.timescale.com/cloud/latest/create-a-service/",

--- a/timescaledb/how-to-guides/page-index/page-index.js
+++ b/timescaledb/how-to-guides/page-index/page-index.js
@@ -272,7 +272,7 @@ module.exports = [
             excerpt: "Make DISTINCT queries faster with SkipScan",
           },
           {
-            title: "Peform advanced analytic queries",
+            title: "Perform advanced analytic queries",
             href: "advanced-analytic-queries",
             excerpt: "Use advanced analytics queries",
           },


### PR DESCRIPTION
# Description

Fixes a typo in the page title for the "Perform advanced analytic queries" page.

# Links

Fixes https://github.com/timescale/docs/issues/1711

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
