### PR TITLE
Remove duplicate word

### DIFF
--- a/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
+++ b/timescaledb/how-to-guides/continuous-aggregates/compression-on-continuous-aggregates.md
@@ -20,7 +20,7 @@ If you receive historical data and need to refresh a compressed chunk, see
 
 <highlight type="warning">
 You can't refresh the compressed regions of a continuous aggregate. To avoid
-conflicts between compression and refresh, make sure you set `compress_after` to
+conflicts between compression and refresh, make sure you set `compress_after`
 to a larger interval than the `start_offset` of your
 [refresh policy](/api/latest/continuous-aggregates/add_continuous_aggregate_policy).
 </highlight>


### PR DESCRIPTION
# Description

The word `to` appears two times in a row in the `How-to guides` page on compressing continuous integration. 

# Links

N/A

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
