### PR TITLE
refactor(frontmatter): deprecate fields

### DIFF
--- a/api/approx_count.md
+++ b/api/approx_count.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - count_min_sketch()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: CountMinSketch
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/approx_count_distinct.md
+++ b/api/approx_count_distinct.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: approximate count distinct
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'approximate count distinct'
-hyperfunction_subfamily: hyperloglog
-hyperfunction_type: aggregate
 ---
 
 # approx_count_distinct()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>

--- a/api/approx_percentile.md
+++ b/api/approx_percentile.md
@@ -18,12 +18,6 @@ hyperfunction:
     - percentile_agg()
     - tdigest()
     - uddsketch()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'percentile approximation'
-hyperfunction_type: accessor
 ---
 
 ## approx_percentile()  <tag type="toolkit">Toolkit</tag>

--- a/api/approx_percentile_rank.md
+++ b/api/approx_percentile_rank.md
@@ -18,12 +18,6 @@ hyperfunction:
     - percentile_agg()
     - tdigest()
     - uddsketch()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'percentile approximation'
-hyperfunction_type: accessor
 ---
 
 # approx_percentile_rank()  <tag type="toolkit">Toolkit</tag>

--- a/api/asap.md
+++ b/api/asap.md
@@ -15,13 +15,6 @@ api:
 hyperfunction:
   family: downsample
   type: one-step aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: false
-toolkit: true
-hyperfunction_family: 'downsample'
-hyperfunction_subfamily: 'downsample'
-hyperfunction_type: other
 ---
 
 # asap_smooth()  <tag type="toolkit">Toolkit</tag>

--- a/api/average-time-weight.md
+++ b/api/average-time-weight.md
@@ -15,12 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - time_weight()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'time-weighted averages'
-hyperfunction_subfamily: 'time-weighted averages'
-hyperfunction_type: accessor
 ---
 
 # average() <tag type="toolkit">Toolkit</tag>

--- a/api/corr-counter.md
+++ b/api/corr-counter.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # corr() <tag type="toolkit" content="Toolkit" />

--- a/api/count_min_sketch.md
+++ b/api/count_min_sketch.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: frequency analysis
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: CountMinSketch
-hyperfunction_type: aggregate
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/counter_agg_point.md
+++ b/api/counter_agg_point.md
@@ -13,12 +13,6 @@ api:
 hyperfunction:
   family: metric aggregation
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: aggregate
 ---
 
 # counter_agg() <tag type="toolkit" content="Toolkit" />

--- a/api/counter_zero_time.md
+++ b/api/counter_zero_time.md
@@ -16,12 +16,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - counter_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # counter_zero_time() <tag type="toolkit" content="Toolkit" />

--- a/api/delta.md
+++ b/api/delta.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # delta() <tag type="toolkit" content="Toolkit" />

--- a/api/distinct_count.md
+++ b/api/distinct_count.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - approx_count_distinct()
     - hyperloglog()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'approximate count distinct'
-hyperfunction_subfamily: hyperloglog
-hyperfunction_type: accessor
 ---
 
 # distinct_count()  <tag type="toolkit">Toolkit</tag>

--- a/api/duration_in.md
+++ b/api/duration_in.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - state_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: StateAgg
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/error.md
+++ b/api/error.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - percentile_agg()
     - uddsketch()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'percentile approximation'
-hyperfunction_type: accessor
 ---
 
 # error()  <tag type="toolkit">Toolkit</tag>

--- a/api/extrapolated_delta.md
+++ b/api/extrapolated_delta.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # extrapolated_delta() <tag type="toolkit" content="Toolkit" />

--- a/api/extrapolated_rate.md
+++ b/api/extrapolated_rate.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # extrapolated_rate() <tag type="toolkit" content="Toolkit" />

--- a/api/first-last-time-counter.md
+++ b/api/first-last-time-counter.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - counter_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/first-last-time-timeweight.md
+++ b/api/first-last-time-timeweight.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - time_weight()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'time-weighted averages'
-hyperfunction_subfamily: 'time-weighted averages'
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/first-last-val-counter.md
+++ b/api/first-last-val-counter.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - counter_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/first-last-val-timeweight.md
+++ b/api/first-last-val-timeweight.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - time_weight()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'time-weighted averages'
-hyperfunction_subfamily: 'time-weighted averages'
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/freq_agg.md
+++ b/api/freq_agg.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: frequency analysis
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: SpaceSavingAggregate
-hyperfunction_type: aggregate
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/gauge_agg.md
+++ b/api/gauge_agg.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: metric aggregation
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: aggregate
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/gp_lttb.md
+++ b/api/gp_lttb.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: downsample
   type: one-step aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'downsample'
-hyperfunction_subfamily: 'downsample'
-hyperfunction_type: other
 ---
 
 # gp_lttb()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>

--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -14,12 +14,6 @@ api:
 hyperfunction:
   family: approximate count distinct
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'approximate count distinct'
-hyperfunction_subfamily: hyperloglog
-hyperfunction_type: aggregate
 ---
 
 # hyperloglog()  <tag type="toolkit">Toolkit</tag>

--- a/api/idelta.md
+++ b/api/idelta.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # idelta_left() and idelta_right() <tag type="toolkit" content="Toolkit" />

--- a/api/integral-time-weight.md
+++ b/api/integral-time-weight.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - time_weight()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'time-weighted averages'
-hyperfunction_subfamily: 'time-weighted averages'
-hyperfunction_type: accessor
 ---
 
 # integral() <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>

--- a/api/intercept-counter.md
+++ b/api/intercept-counter.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # intercept() <tag type="toolkit" content="Toolkit" />

--- a/api/interpolate.md
+++ b/api/interpolate.md
@@ -12,11 +12,6 @@ api:
 hyperfunction:
   family: gapfilling and interpolation
   type: interpolator
-# fields below will be deprecated
-api_category: hyperfunction
-hyperfunction_family: 'gapfilling and interpolation'
-hyperfunction_subfamily: interpolation
-hyperfunction_type: other
 ---
 
 # interpolate() <tag type="community">Community</tag>

--- a/api/interpolated_average.md
+++ b/api/interpolated_average.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - time_weight()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'time-weighted averages'
-hyperfunction_subfamily: 'time-weighted averages'
-hyperfunction_type: accessor
 ---
 
 # interpolated_average() <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>

--- a/api/interpolated_delta.md
+++ b/api/interpolated_delta.md
@@ -16,13 +16,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # interpolated_delta() <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit">Experimental</tag>

--- a/api/interpolated_duration_in.md
+++ b/api/interpolated_duration_in.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - state_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: StateAgg
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/interpolated_integral.md
+++ b/api/interpolated_integral.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - time_weight()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'time-weighted averages'
-hyperfunction_subfamily: 'time-weighted averages'
-hyperfunction_type: accessor
 ---
 
 # interpolated_integral() <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>

--- a/api/interpolated_rate.md
+++ b/api/interpolated_rate.md
@@ -16,13 +16,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # interpolated_rate() <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit">Experimental</tag>

--- a/api/into_values-freq_agg.md
+++ b/api/into_values-freq_agg.md
@@ -16,13 +16,6 @@ hyperfunction:
   aggregates:
     - freq_agg()
     - topn_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: SpaceSavingAggregate
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/into_values-state_agg.md
+++ b/api/into_values-state_agg.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - state_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: StateAgg
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/irate.md
+++ b/api/irate.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # irate_left() and irate_right() <tag type="toolkit" content="Toolkit" />

--- a/api/locf.md
+++ b/api/locf.md
@@ -12,11 +12,6 @@ api:
 hyperfunction:
   family: gapfilling and interpolation
   type: interpolator
-# fields below will be deprecated
-api_category: hyperfunction
-hyperfunction_family: 'gapfilling and interpolation'
-hyperfunction_subfamily: interpolation
-hyperfunction_type: other
 ---
 
 # locf() <tag type="community">Community</tag>

--- a/api/lttb.md
+++ b/api/lttb.md
@@ -13,12 +13,6 @@ api:
 hyperfunction:
   family: downsample
   type: one-step aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'downsample'
-hyperfunction_subfamily: 'downsample'
-hyperfunction_type: other
 ---
 
 # lttb()  <tag type="toolkit">Toolkit</tag>

--- a/api/max_val.md
+++ b/api/max_val.md
@@ -16,12 +16,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - tdigest()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'percentile approximation'
-hyperfunction_type: accessor
 ---
 
 # max_val()  <tag type="toolkit">Toolkit</tag>

--- a/api/mean.md
+++ b/api/mean.md
@@ -18,12 +18,6 @@ hyperfunction:
     - percentile_agg()
     - tdigest()
     - uddsketch()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'percentile approximation'
-hyperfunction_type: accessor
 ---
 
 # mean()  <tag type="toolkit">Toolkit</tag>

--- a/api/min_frequency-max_frequency.md
+++ b/api/min_frequency-max_frequency.md
@@ -17,13 +17,6 @@ hyperfunction:
   aggregates:
     - freq_agg()
     - topn_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: SpaceSavingAggregate
-hyperfunction_type: accessor
 ---
 
 # min_frequency() and max_frequency() <tag type="toolkit" content="Toolkit" /><tag type="experimental" content="Experimental" />

--- a/api/min_val.md
+++ b/api/min_val.md
@@ -16,12 +16,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - tdigest()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'percentile approximation'
-hyperfunction_type: accessor
 ---
 
 # min_val()  <tag type="toolkit">Toolkit</tag>

--- a/api/num_changes.md
+++ b/api/num_changes.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # num_changes() <tag type="toolkit" content="Toolkit" />

--- a/api/num_elements.md
+++ b/api/num_elements.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # num_elements() <tag type="toolkit" content="Toolkit" />

--- a/api/num_resets.md
+++ b/api/num_resets.md
@@ -16,12 +16,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - counter_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # num_resets() <tag type="toolkit" content="Toolkit" />

--- a/api/num_vals-percentile.md
+++ b/api/num_vals-percentile.md
@@ -18,12 +18,6 @@ hyperfunction:
     - percentile_agg()
     - tdigest()
     - uddsketch()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'percentile approximation'
-hyperfunction_type: accessor
 ---
 
 # num_vals()  <tag type="toolkit">Toolkit</tag>

--- a/api/ohlc.md
+++ b/api/ohlc.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: financial analysis
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'financial analysis'
-hyperfunction_subfamily: OpenHighLowClose
-hyperfunction_type: aggregate
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/open-high-low-close-time.md
+++ b/api/open-high-low-close-time.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - ohlc()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'financial analysis'
-hyperfunction_subfamily: OpenHighLowClose
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/open-high-low-close.md
+++ b/api/open-high-low-close.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - ohlc()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'financial analysis'
-hyperfunction_subfamily: OpenHighLowClose
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/percentile_agg.md
+++ b/api/percentile_agg.md
@@ -13,12 +13,6 @@ api:
 hyperfunction:
   family: percentile approximation
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'percentile approximation'
-hyperfunction_type: aggregate
 ---
 
 # percentile_agg()  <tag type="toolkit">Toolkit</tag>

--- a/api/rate.md
+++ b/api/rate.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # rate() <tag type="toolkit" content="Toolkit" />

--- a/api/rollup-counter.md
+++ b/api/rollup-counter.md
@@ -16,12 +16,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: rollup
 ---
 
 # rollup(CounterSummary) <tag type="toolkit">Toolkit</tag>

--- a/api/rollup-hyperloglog.md
+++ b/api/rollup-hyperloglog.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - approx_count_distinct()
     - hyperloglog()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'approximate count distinct'
-hyperfunction_subfamily: hyperloglog
-hyperfunction_type: rollup
 ---
 
 # rollup()  <tag type="toolkit">Toolkit</tag>

--- a/api/rollup-percentile.md
+++ b/api/rollup-percentile.md
@@ -18,12 +18,6 @@ hyperfunction:
     - percentile_agg()
     - tdigest()
     - uddsketch()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'percentile approximation'
-hyperfunction_type: rollup
 ---
 
 # rollup()  <tag type="toolkit">Toolkit</tag>

--- a/api/rollup-timeweight.md
+++ b/api/rollup-timeweight.md
@@ -15,12 +15,6 @@ hyperfunction:
   type: rollup
   aggregates:
     - time_weight()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'time-weighted averages'
-hyperfunction_subfamily: 'time-weighted averages'
-hyperfunction_type: rollup
 ---
 
 # rollup(TimeWeightSummary) <tag type="toolkit">Toolkit</tag>

--- a/api/rollup.md
+++ b/api/rollup.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: rollup
   aggregates:
     - ohlc()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'financial analysis'
-hyperfunction_subfamily: OpenHighLowClose
-hyperfunction_type: rollup
 ---
 
 # rollup <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />

--- a/api/saturating_add.md
+++ b/api/saturating_add.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: saturating math
   type: one-step operation
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'saturating math'
-hyperfunction_subfamily: saturating math
-hyperfunction_type: one-step
 ---
 
 # saturating_add()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit" content="Experimental" />

--- a/api/saturating_add_pos.md
+++ b/api/saturating_add_pos.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: saturating math
   type: one-step operation
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'saturating math'
-hyperfunction_subfamily: saturating math
-hyperfunction_type: one-step
 ---
 
 # saturating_add_pos()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit" content="Experimental" />

--- a/api/saturating_mul.md
+++ b/api/saturating_mul.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: saturating math
   type: one-step operation
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'saturating math'
-hyperfunction_subfamily: saturating math
-hyperfunction_type: one-step
 ---
 
 # saturating_mul()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit" content="Experimental" />

--- a/api/saturating_sub.md
+++ b/api/saturating_sub.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: saturating math
   type: one-step operation
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'saturating math'
-hyperfunction_subfamily: saturating math
-hyperfunction_type: one-step
 ---
 
 # saturating_sub()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit" content="Experimental" />

--- a/api/saturating_sub_pos.md
+++ b/api/saturating_sub_pos.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: saturating math
   type: one-step operation
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'saturating math'
-hyperfunction_subfamily: saturating math
-hyperfunction_type: one-step
 ---
 
 # saturating_sub_pos()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit" content="Experimental" />

--- a/api/slope-counter.md
+++ b/api/slope-counter.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # slope() <tag type="toolkit" content="Toolkit" />

--- a/api/state_agg.md
+++ b/api/state_agg.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: frequency analysis
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: StateAgg
-hyperfunction_type: aggregate
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/stderror.md
+++ b/api/stderror.md
@@ -17,12 +17,6 @@ hyperfunction:
   aggregates:
     - approx_count_distinct()
     - hyperloglog()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'approximate count distinct'
-hyperfunction_subfamily: hyperloglog
-hyperfunction_type: accessor
 ---
 
 # stderror()  <tag type="toolkit">Toolkit</tag>

--- a/api/tdigest.md
+++ b/api/tdigest.md
@@ -14,12 +14,6 @@ api:
 hyperfunction:
   family: percentile approximation
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'advanced aggregation'
-hyperfunction_type: aggregate
 ---
 
 # tdigest() <tag type="toolkit">Toolkit</tag>

--- a/api/time_bucket_gapfill.md
+++ b/api/time_bucket_gapfill.md
@@ -12,11 +12,6 @@ api:
 hyperfunction:
   family: gapfilling and interpolation
   type: bucket
-# fields below will be deprecated
-api_category: hyperfunction
-hyperfunction_family: 'gapfilling and interpolation'
-hyperfunction_subfamily: gapfill
-hyperfunction_type: other
 ---
 
 # time_bucket_gapfill() <tag type="community">Community</tag>

--- a/api/time_delta.md
+++ b/api/time_delta.md
@@ -16,12 +16,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: accessor
 ---
 
 # time_delta() <tag type="toolkit" content="Toolkit" />

--- a/api/time_weight.md
+++ b/api/time_weight.md
@@ -13,12 +13,6 @@ api:
 hyperfunction:
   family: time-weighted averages
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'time-weighted averages'
-hyperfunction_subfamily: 'time-weighted averages'
-hyperfunction_type: aggregate
 ---
 
 ## time_weight() <tag type="toolkit">Toolkit</tag>

--- a/api/topn.md
+++ b/api/topn.md
@@ -15,13 +15,6 @@ hyperfunction:
   type: accessor
   aggregates:
     - topn_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: SpaceSavingAggregate
-hyperfunction_type: accessor
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/topn_agg.md
+++ b/api/topn_agg.md
@@ -13,13 +13,6 @@ api:
 hyperfunction:
   family: frequency analysis
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-api_experimental: true
-toolkit: true
-hyperfunction_family: 'frequency analysis'
-hyperfunction_subfamily: SpaceSavingAggregate
-hyperfunction_type: aggregate
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';

--- a/api/uddsketch.md
+++ b/api/uddsketch.md
@@ -14,12 +14,6 @@ api:
 hyperfunction:
   family: percentile approximation
   type: aggregate
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'percentile approximation'
-hyperfunction_subfamily: 'advanced aggregation'
-hyperfunction_type: aggregate
 ---
 
 # uddsketch() <tag type="toolkit">Toolkit</tag>

--- a/api/with_bounds.md
+++ b/api/with_bounds.md
@@ -16,12 +16,6 @@ hyperfunction:
   aggregates:
     - counter_agg()
     - gauge_agg()
-# fields below will be deprecated
-api_category: hyperfunction
-toolkit: true
-hyperfunction_family: 'metric aggregation'
-hyperfunction_subfamily: 'counter and gauge aggregation'
-hyperfunction_type: mutator
 ---
 
 # with_bounds() <tag type="toolkit" content="Toolkit" />


### PR DESCRIPTION
# Description

Fields for hyperfunctions frontmatter were reorganized and renamed. The legacy fields have been excised from the codebase and can be removed now.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
