### PR TITLE
Fix link source

### DIFF
--- a/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertable-architecture.md
+++ b/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertable-architecture.md
@@ -28,7 +28,7 @@ This section uses the example of 1-day chunks to explain how hypertables work.
 The default chunk time interval is actually 7 days, and you can change it to
 suit your data ingest patterns. To learn about best practices for chunk time
 intervals, see the documentation on
-[chunk sizing](timescaledb/latest/how-to-guides/hypertables/best-practices/#time-intervals).
+[chunk sizing](timescaledb/latest/how-to-guides/hypertables/about-hypertables/#best-practices-for-time-partitioning).
 </highlight>
 
 ## Time-and-space partitioning

--- a/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertables-and-chunks-benefits.md
+++ b/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertables-and-chunks-benefits.md
@@ -17,7 +17,7 @@ disk.
 <highlight type="note">
 For more information about chunk sizing for improved performance, see the
 section on
-[chunk sizing](timescaledb/latest/how-to-guides/hypertables/about-hypertables/#best-practices-for-time-partitioning)
+[chunk sizing](timescaledb/latest/how-to-guides/hypertables/about-hypertables/#best-practices-for-time-partitioning).
 </highlight>
 
 Though fitting chunks in memory gives the best performance, TimescaleDB doesn't

--- a/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertables-and-chunks-benefits.md
+++ b/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertables-and-chunks-benefits.md
@@ -17,7 +17,7 @@ disk.
 <highlight type="note">
 For more information about chunk sizing for improved performance, see the
 section on
-[chunk sizing](timescaledb/latest/how-to-guides/hypertables/best-practices/#time-intervals).
+[chunk sizing](timescaledb/latest/how-to-guides/hypertables/about-hypertables/#best-practices-for-time-partitioning)
 </highlight>
 
 Though fitting chunks in memory gives the best performance, TimescaleDB doesn't


### PR DESCRIPTION
# Description

Fix link source. Probably the source was renamed at some point.

# Links

Fixes issue [reported](https://timescaledb.slack.com/archives/C4GT3N90X/p1668200568630899) in the  community slack.

## Subject matter expert (SME) review checklist

- [x] Is the content technically accurate?
- [x] Is the content complete?
- [x] Is the content presented in a logical order?
- [x] Does the content use appropriate names for features and products?
- [x] Does the content provide relevant links to further information?

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
