### PR TITLE
fix malformed link in admon

### DIFF
--- a/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertables-and-chunks-benefits.md
+++ b/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertables-and-chunks-benefits.md
@@ -24,7 +24,7 @@ disk.
 <highlight type="note">
 For more information about chunk sizing for improved performance, see the
 section on
-[chunk sizing](timescaledb/latest/how-to-guides/hypertables/about-hypertables/#best-practices-for-time-partitioning).
+[chunk sizing](/timescaledb/latest/how-to-guides/hypertables/about-hypertables/#best-practices-for-time-partitioning).
 </highlight>
 
 Though fitting chunks in memory gives the best performance, TimescaleDB doesn't


### PR DESCRIPTION
# Description

Link in admonition was missing a leading slash, so it was producing a malformed URL

![image](https://user-images.githubusercontent.com/3914967/202347368-3921b2ce-6f22-41ee-9019-1c27e988a298.png)


# Links

https://timescaledb.slack.com/archives/C4GT3N90X/p1668200568630899

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
