### PR TITLE
fix(keywords)

### DIFF
--- a/_troubleshooting/promscale/promql-dashboard-no-promscale-data.md
+++ b/_troubleshooting/promscale/promql-dashboard-no-promscale-data.md
@@ -3,8 +3,7 @@ title: PromQL dashboard doesn't show Promscale data
 section: troubleshooting
 products: [promscale]
 topics: [visualization]
-tags: [PromQL]
-keywords: [promscale, PromQL, dashboard, disk, memory, CPU]
+keywords: [PromQL, disk, memory, CPU, backfilling]
 ---
 
 <!---

--- a/_troubleshooting/timescaledb/background-worker-failed-start.md
+++ b/_troubleshooting/timescaledb/background-worker-failed-start.md
@@ -14,7 +14,7 @@ apis:
   - [hypertables, add_retention_policy()]
   - [hypertables, add_compression_policy()]
   - [hypertables, add_continuous_aggregate_policy()]
-keywords: [jobs, policies, user-defined actions]
+keywords: [jobs, policies, actions]
 tags: [jobs, scheduled jobs, background jobs, background workers, automation framework, policies, user-defined actions]
 ---
 

--- a/_troubleshooting/timescaledb/explain.md
+++ b/_troubleshooting/timescaledb/explain.md
@@ -2,7 +2,7 @@
 title: A particular query executes more slowly than expected
 section: troubleshooting
 topics: [queries]
-keywords: [query, explain]
+keywords: [EXPLAIN]
 tags: [queries, query, explain, performance]
 ---
 

--- a/_troubleshooting/timescaledb/install-timescaledb-could-not-access-file.md
+++ b/_troubleshooting/timescaledb/install-timescaledb-could-not-access-file.md
@@ -6,7 +6,7 @@ errors:
   - language: text
     message: |-
       Log error: could not access file "timescaledb"
-keywords: [install, configuration]
+keywords: [configuration]
 tags: [install, configuration]
 ---
 

--- a/_troubleshooting/timescaledb/pg_dump-errors.md
+++ b/_troubleshooting/timescaledb/pg_dump-errors.md
@@ -1,5 +1,5 @@
 ---
-title: Errors occur when running pg_dump
+title: Errors occur when running `pg_dump`
 section: troubleshooting
 topics: [backups]
 errors:
@@ -8,7 +8,7 @@ errors:
       pg_dump: NOTICE:  hypertable data are in the chunks, no data will be copied
       DETAIL:  Data for hypertables are stored in the chunks of a hypertable so COPY TO of a hypertable will not copy any data.
       HINT:  Use "COPY (SELECT * FROM <hypertable>) TO ..." to copy all data in hypertable, or copy each chunk individually.
-keywords: [backups, restores]
+keywords: [backups, restore]
 ---
 
 <!---

--- a/_troubleshooting/timescaledb/pg_dump-version-mismatch.md
+++ b/_troubleshooting/timescaledb/pg_dump-version-mismatch.md
@@ -2,7 +2,7 @@
 title: Versions are mismatched when dumping and restoring a database
 section: troubleshooting
 topics: [backups]
-keywords: [backups, restores]
+keywords: [backups, restore]
 ---
 
 <!---

--- a/_troubleshooting/timescaledb/scheduled-jobs-stop-running.md
+++ b/_troubleshooting/timescaledb/scheduled-jobs-stop-running.md
@@ -12,8 +12,8 @@ apis:
   - [information, timescaledb_information.jobs]
   - [information, timescaledb_information.job_stats]
   - [jobs, add_job()]
-keywords: [jobs, policies, user-defined actions]
-tags: [jobs, scheduled jobs, background jobs, background workers, automation framework, policies, user-defined actions]
+keywords: [jobs, policies, actions]
+tags: [jobs, scheduled jobs, background jobs, background workers, automation framework, policies, actions]
 ---
 
 import CloudMSTRestartWorkers from 'versionContent/_partials/_cloud-mst-restart-workers.mdx';

--- a/_troubleshooting/timescaledb/toolkit-cannot-create-upgrade-extension.md
+++ b/_troubleshooting/timescaledb/toolkit-cannot-create-upgrade-extension.md
@@ -6,8 +6,7 @@ errors:
   - language: sql
     message: |-
       ERROR: extension "timescaledb_toolkit" has no update path from version "1.2" to version "1.3"
-keywords: [hyperfunctions, toolkit, install, upgrades, updates]
-tags: [hyperfunctions, toolkit, install, updates, upgrades]
+keywords: [hyperfunctions, Toolkit, installation, upgrades, updates]
 ---
 
 <!---

--- a/_troubleshooting/timescaledb/update-error-third-party-tool.md
+++ b/_troubleshooting/timescaledb/update-error-third-party-tool.md
@@ -1,8 +1,7 @@
 ---
 title: Error updating TimescaleDB when using a third-party PostgreSQL admin tool
 topics: [upgrades]
-keywords: [update, third-party tools]
-tags: [update, third-party tools]
+keywords: [updates, third-party tools]
 ---
 
 <!---

--- a/_troubleshooting/timescaledb/update-timescaledb-could-not-access-file.md
+++ b/_troubleshooting/timescaledb/update-timescaledb-could-not-access-file.md
@@ -6,8 +6,7 @@ errors:
   - language: text
     message: |-
       ERROR: could not access file "timescaledb-<VERSION>": No such file or directory
-keywords: [update]
-tags: [update]
+keywords: [updates]
 ---
 
 <!---

--- a/_troubleshooting/timescaledb/upgrade-fails-already-loaded.md
+++ b/_troubleshooting/timescaledb/upgrade-fails-already-loaded.md
@@ -6,7 +6,7 @@ errors:
   - language: sql
     message: |-
       ERROR: extension "timescaledb" cannot be updated after the old version has already been loaded
-keywords: [upgrade]
+keywords: [upgrades]
 tags: [upgrade]
 ---
 

--- a/_troubleshooting/timescaledb/upgrade-no-update-path.md
+++ b/_troubleshooting/timescaledb/upgrade-no-update-path.md
@@ -6,7 +6,7 @@ errors:
   - language: sql
     message: |-
       ERROR: extension "timescaledb_toolkit" has no update path from version "1.2" to version "1.3"
-keywords: [upgrade]
+keywords: [upgrades]
 tags: [upgrade]
 ---
 

--- a/api/_hyperfunctions/stats_agg-one-variable/average.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/average.md
@@ -2,7 +2,7 @@
 api_name: average()
 excerpt: Calculate the average from a one-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [average, statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [average, statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-one-variable/kurtosis.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/kurtosis.md
@@ -2,7 +2,7 @@
 api_name: kurtosis()
 excerpt: Calculate the kurtosis from a one-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [skew]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-one-variable/num_vals.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/num_vals.md
@@ -2,7 +2,7 @@
 api_name: num_vals()
 excerpt: Calculate the number of values in a one-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [count, number]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-one-variable/rolling.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/rolling.md
@@ -2,7 +2,7 @@
 api_name: rolling()
 excerpt: Combine multiple one-dimensional statistical aggregates to calculate rolling window aggregates
 topics: [hyperfunctions]
-keywords: [rollup, statistics, statistical aggregates, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-one-variable/rollup.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/rollup.md
@@ -2,7 +2,7 @@
 api_name: rollup()
 excerpt: Combine multiple one-dimensional statistical aggregates
 topics: [hyperfunctions]
-keywords: [rollup, statistics, statistical aggregates, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-one-variable/skewness.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/skewness.md
@@ -2,7 +2,7 @@
 api_name: skewness()
 excerpt: Calculate the skewness from a one-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-one-variable/stats_agg.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/stats_agg.md
@@ -2,7 +2,7 @@
 api_name: stats_agg() (one variable)
 excerpt: Aggregate data into an intermediate statistical aggregate form for further calculation
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-one-variable/stddev.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/stddev.md
@@ -2,7 +2,7 @@
 api_name: stddev()
 excerpt: Calculate the standard deviation from a one-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [standard deviation]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-one-variable/sum.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/sum.md
@@ -2,7 +2,7 @@
 api_name: sum()
 excerpt: Calculate the sum from a one-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [sum]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-one-variable/variance.md
+++ b/api/_hyperfunctions/stats_agg-one-variable/variance.md
@@ -2,7 +2,7 @@
 api_name: variance()
 excerpt: Calculate the variance from a one-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-two-variables/average_y_x.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/average_y_x.md
@@ -2,7 +2,7 @@
 api_name: average_y() | average_x()
 excerpt: Calculate the average from a two-dimensional statistical aggregate for the dimension specified
 topics: [hyperfunctions]
-keywords: [average, statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [average, statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-two-variables/intercept.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/intercept.md
@@ -2,7 +2,7 @@
 api_name: intercept()
 excerpt: Calculate the intercept from a two-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [intercept, least squares, linear regression]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-two-variables/kurtosis_y_x.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/kurtosis_y_x.md
@@ -2,7 +2,7 @@
 api_name: kurtosis_y() | kurtosis_x()
 excerpt: Calculate the kurtosis from a two-dimensional statistical aggregate for the dimension specified
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [skew]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-two-variables/num_vals.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/num_vals.md
@@ -2,7 +2,7 @@
 api_name: num_vals()
 excerpt: Calculate the number of values in a two-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [count, number]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-two-variables/rolling.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/rolling.md
@@ -2,7 +2,7 @@
 api_name: rolling()
 excerpt: Combine multiple two-dimensional statistical aggregates to calculate rolling window aggregates
 topics: [hyperfunctions]
-keywords: [rollup, statistics, statistical aggregates, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-two-variables/rollup.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/rollup.md
@@ -2,7 +2,7 @@
 api_name: rollup()
 excerpt: Combine multiple two-dimensional statistical aggregates
 topics: [hyperfunctions]
-keywords: [rollup, statistics, statistical aggregates, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-two-variables/skewness_y_x.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/skewness_y_x.md
@@ -2,7 +2,7 @@
 api_name: skewness_y() | skewness_x()
 excerpt: Calculate the skewness from a two-dimensional statistical aggregate for the dimension specified
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-two-variables/slope.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/slope.md
@@ -2,7 +2,7 @@
 api_name: slope()
 excerpt: Calculate the slope from a two-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [least squares, linear regression]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-two-variables/stats_agg.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/stats_agg.md
@@ -2,7 +2,7 @@
 api_name: stats_agg() (two variables)
 excerpt: Aggregate data into an intermediate statistical aggregate form for further calculation
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-two-variables/stddev_y_x.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/stddev_y_x.md
@@ -2,7 +2,7 @@
 api_name: stddev_y() | stddev_x()
 excerpt: Calculate the standard deviation from a two-dimensional statistical aggregate for the dimension specified
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [standard deviation]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-two-variables/sum_y_x.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/sum_y_x.md
@@ -2,7 +2,7 @@
 api_name: sum_y() | sum_x()
 excerpt: Calculate the sum from a two-dimensional statistical aggregate for the dimension specified
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [sum]
 api:
   license: community

--- a/api/_hyperfunctions/stats_agg-two-variables/variance_y_x.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/variance_y_x.md
@@ -2,7 +2,7 @@
 api_name: variance_y() | variance_x()
 excerpt: Calculate the variance from a two-dimensional statistical aggregate for the dimension specified
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/_hyperfunctions/stats_agg-two-variables/x_intercept.md
+++ b/api/_hyperfunctions/stats_agg-two-variables/x_intercept.md
@@ -2,7 +2,7 @@
 api_name: x_intercept()
 excerpt: Calculate the x-intercept from a two-dimensional statistical aggregate
 topics: [hyperfunctions]
-keywords: [statistics, statistical aggregate, hyperfunctions, toolkit]
+keywords: [statistics, hyperfunctions, Toolkit]
 tags: [least squares, linear regression]
 api:
   license: community

--- a/api/average-time-weight.md
+++ b/api/average-time-weight.md
@@ -2,7 +2,7 @@
 api_name: average()
 excerpt: Calculate the time-weighted average of values in a `TimeWeightSummary`
 topics: [hyperfunctions]
-keywords: [average, time-weighted, hyperfunctions, toolkit]
+keywords: [average, time-weighted, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/corr-counter.md
+++ b/api/corr-counter.md
@@ -2,7 +2,7 @@
 api_name: corr()
 excerpt: Calculate the correlation coefficient from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [correlation coefficient, counters, hyperfunctions, toolkit]
+keywords: [correlation coefficient, counters, hyperfunctions, Toolkit]
 tags: [least squares, linear regression]
 api:
   license: community

--- a/api/counter_agg_point.md
+++ b/api/counter_agg_point.md
@@ -2,7 +2,7 @@
 api_name: counter_agg()
 excerpt: Aggregate counter data into a `CounterSummary` for further analysis
 topics: [hyperfunctions]
-keywords: [counters, aggregates, hyperfunctions, toolkit]
+keywords: [counters, aggregates, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/counter_aggs.md
+++ b/api/counter_aggs.md
@@ -1,12 +1,13 @@
 ---
 title: Counter and gauge aggregation
 excerpt: Perform statistical analysis of counters and gauges
-keywords: [counters, gauges, hyperfunctions, toolkit]
+keywords: [counters, gauges, hyperfunctions, Toolkit]
 ---
 
 # Counter and gauge aggregation
+
 This section contains functions related to counter and gauge aggregation.
-Counter aggregation functions are used to accumulate monotonically increasing data 
+Counter aggregation functions are used to accumulate monotonically increasing data
 by treating any decrements as resets. Gauge aggregates are similar, but are used to
 track data which can decrease as well as increase. For more information about counter
 aggregation functions, see the
@@ -26,7 +27,6 @@ additional hyperfunctions, you need to install the
 All accessors can be used with `CounterSummary`, and all but `num_resets`
 with `GaugeSummary`.
 </highlight>
-
 
 [hyperfunctions-counter-agg]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/counter-aggregation/
 [install-toolkit]: /timescaledb/:currentVersion:/how-to-guides/hyperfunctions/install-toolkit

--- a/api/counter_zero_time.md
+++ b/api/counter_zero_time.md
@@ -2,7 +2,7 @@
 api_name: counter_zero_time()
 excerpt: Predict the time when a counter was at zero
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [least squares, linear regression, extrapolate]
 api:
   license: community

--- a/api/create_distributed_restore_point.md
+++ b/api/create_distributed_restore_point.md
@@ -2,7 +2,7 @@
 api_name: create_distributed_restore_point()
 excerpt: Create a consistent restore point for all nodes in a multi-node cluster
 topics: [distributed hypertables, multi-node]
-keywords: [distributed hypertables, restore, backup, multi-node]
+keywords: [distributed hypertables, restore, backups, multi-node]
 tags: [clusters, write-ahead logs, recovery]
 api:
   license: community

--- a/api/days_in_month.md
+++ b/api/days_in_month.md
@@ -2,7 +2,7 @@
 api_name: days_in_month()
 excerpt: Calculates days in month given a timestamptz
 topics: [hyperfunctions]
-keywords: [hyperfunctions, toolkit, normalization]
+keywords: [hyperfunctions, Toolkit, normalization]
 api:
   license: community
   type: function

--- a/api/decompress_chunk.md
+++ b/api/decompress_chunk.md
@@ -2,7 +2,7 @@
 api_name: decompress_chunk()
 excerpt: Decompress a compressed chunk
 topics: [compression]
-keywords: [compression, decompression, chunks]
+keywords: [compression, decompression, chunks, backfilling]
 api:
   license: community
   type: function

--- a/api/delta.md
+++ b/api/delta.md
@@ -2,7 +2,7 @@
 api_name: delta()
 excerpt: Calculate the change in a counter from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [delta]
 api:
   license: community

--- a/api/distinct_count.md
+++ b/api/distinct_count.md
@@ -2,7 +2,7 @@
 api_name: distinct_count()
 excerpt: Estimate the number of distinct values from values in a hyperloglog
 topics: [hyperfunctions]
-keywords: [count, hyperfunctions, toolkit]
+keywords: [count, hyperfunctions, Toolkit]
 tags: [approximate, distinct, hyperloglog]
 api:
   license: community

--- a/api/downsample.md
+++ b/api/downsample.md
@@ -1,10 +1,11 @@
 ---
 title: Downsample
 excerpt: Downsample data to a smaller, representative subset
-keywords: [downsample, hyperfunctions, toolkit]
+keywords: [downsample, hyperfunctions, Toolkit]
 ---
 
 # Downsample
+
 This section includes functions used to downsample data. Downsampling
 is used to replace a set of values with a much smaller set that is highly
 representative of the original data. This is particularly useful for

--- a/api/duration_in.md
+++ b/api/duration_in.md
@@ -2,7 +2,7 @@
 api_name: duration_in()
 excerpt: Calculate the total time spent in a given state from values in a state aggregate
 topics: [hyperfunctions]
-keywords: [hyperfunctions, duration, states, hyperfunctions, toolkit]
+keywords: [hyperfunctions, duration, states, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/error.md
+++ b/api/error.md
@@ -2,7 +2,7 @@
 api_name: error()
 excerpt: Get the maximum relative error for a percentile estimate
 topics: [hyperfunctions]
-keywords: [percentiles, hyperfunctions, toolkit]
+keywords: [percentiles, hyperfunctions, Toolkit]
 tags: [relative error]
 api:
   license: community

--- a/api/extrapolated_delta.md
+++ b/api/extrapolated_delta.md
@@ -2,7 +2,7 @@
 api_name: extrapolated_delta()
 excerpt: Calculate the extrapolated change in a counter from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [change, extrapolate]
 api:
   license: community

--- a/api/extrapolated_rate.md
+++ b/api/extrapolated_rate.md
@@ -2,7 +2,7 @@
 api_name: extrapolated_rate()
 excerpt: Calculate the extrapolated rate of change from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [rate, counters, hyperfunctions, toolkit]
+keywords: [rate, counters, hyperfunctions, Toolkit]
 tags: [extrapolate]
 api:
   license: community

--- a/api/freq_agg.md
+++ b/api/freq_agg.md
@@ -2,7 +2,7 @@
 api_name: freq_agg()
 excerpt: Aggregate frequency data into a frequency aggregate for further analysis
 topics: [hyperfunctions]
-keywords: [frequency, aggregate, hyperfunctions, toolkit]
+keywords: [frequency, aggregate, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/frequency-analysis.md
+++ b/api/frequency-analysis.md
@@ -1,10 +1,11 @@
 ---
 title: Frequency analysis
 excerpt: Measure how often values occur in a dataset
-keywords: [frequency, hyperfunctions, toolkit]
+keywords: [frequency, hyperfunctions, Toolkit]
 ---
 
 # Frequency analysis
+
 This section includes functions used to measure how often particular values
 occur. These are broken further into state aggregate APIs, which measure the
 time spent in a relatively small number of states, and frequency aggregate APIs,

--- a/api/gapfilling-interpolation.md
+++ b/api/gapfilling-interpolation.md
@@ -1,10 +1,11 @@
 ---
 title: Gapfilling and interpolation
 excerpt: Fill in gaps for unevenly collected data
-keywords: [gapfill, interpolate, hyperfunctions, toolkit]
+keywords: [gapfilling, interpolate, hyperfunctions, Toolkit]
 ---
 
 # Gapfilling and interpolation
+
 This section contains functions related to gapfilling and interpolation. You can
 use a gapfilling function to create additional rows of data in any gaps,
 ensuring that the returned rows are in chronological order, and contiguous. For

--- a/api/gauge_agg.md
+++ b/api/gauge_agg.md
@@ -2,7 +2,7 @@
 api_name: gauge_agg()
 excerpt: Aggregate gauge data into a `GaugeSummary` for further analysis
 topics: [hyperfunctions]
-keywords: [gauges, aggregate, hyperfunctions, toolkit]
+keywords: [gauges, aggregate, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/gp_lttb.md
+++ b/api/gp_lttb.md
@@ -2,7 +2,7 @@
 api_name: gp_lttb()
 excerpt: An implementation of our lttb algorithm that will preserve gaps in the original data
 topics: [hyperfunctions]
-keywords: [downsample, smooth, hyperfunctions, toolkit]
+keywords: [downsample, smooth, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/hyperfunctions.md
+++ b/api/hyperfunctions.md
@@ -1,7 +1,7 @@
 ---
 title: Hyperfunctions
 excerpt: Use hyperfunctions to simplify data analysis
-keywords: [hyperfunctions, toolkit]
+keywords: [hyperfunctions, Toolkit]
 ---
 
 # Hyperfunctions

--- a/api/hyperloglog.md
+++ b/api/hyperloglog.md
@@ -2,7 +2,7 @@
 api_name: hyperloglog()
 excerpt: Aggregate data into a hyperloglog for approximate counting
 topics: [hyperfunctions]
-keywords: [count, hyperloglog, hyperfunctions, toolkit]
+keywords: [count, hyperloglog, hyperfunctions, Toolkit]
 tags: [approximate, distinct]
 api:
   license: community

--- a/api/idelta.md
+++ b/api/idelta.md
@@ -2,7 +2,7 @@
 api_name: idelta_left() | idelta_right()
 excerpt: Calculate the instantaneous change from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [delta, change]
 api:
   license: community

--- a/api/integral-time-weight.md
+++ b/api/integral-time-weight.md
@@ -2,7 +2,7 @@
 api_name: integral()
 excerpt: Calculate the time-weighted integral of values in a `TimeWeightSummary`
 topics: [hyperfunctions]
-keywords: [average, time-weighted, hyperfunctions, toolkit]
+keywords: [average, time-weighted, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/intercept-counter.md
+++ b/api/intercept-counter.md
@@ -2,7 +2,7 @@
 api_name: intercept()
 excerpt: Calculate the intercept from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [intercept, least squares, linear regression]
 api:
   license: community

--- a/api/interpolate.md
+++ b/api/interpolate.md
@@ -2,7 +2,7 @@
 api_name: interpolate()
 excerpt: Linearly interpolate missing values when gapfilling
 topics: [hyperfunctions]
-keywords: [gapfill, interpolate, hyperfunctions, toolkit]
+keywords: [gapfilling, interpolate, hyperfunctions, Toolkit]
 tags: [missing values]
 api:
   license: community

--- a/api/into_values-freq_agg.md
+++ b/api/into_values-freq_agg.md
@@ -2,7 +2,7 @@
 api_name: into_values()
 excerpt: Calculate all frequency estimates from a frequency aggregate or top N aggregate
 topics: [hyperfunctions]
-keywords: [frequency, top N, hyperfunctions, toolkit]
+keywords: [frequency, top N, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/into_values-state_agg.md
+++ b/api/into_values-state_agg.md
@@ -2,7 +2,7 @@
 api_name: into_values()
 excerpt: Calculate all state durations from a state aggregate
 topics: [hyperfunctions]
-keywords: [duration, states, hyperfunctions, toolkit]
+keywords: [duration, states, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/irate.md
+++ b/api/irate.md
@@ -2,7 +2,7 @@
 api_name: irate_left() | irate_right()
 excerpt: Calculate the instantaneous rate of change from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [rate]
 api:
   license: community

--- a/api/locf.md
+++ b/api/locf.md
@@ -2,7 +2,7 @@
 api_name: locf()
 excerpt: Carry the last-seen value forward when gapfilling
 topics: [hyperfunctions]
-keywords: [gapfill, interpolate, hyperfunctions, toolkit]
+keywords: [gapfilling, interpolate, hyperfunctions, Toolkit]
 tags: [missing values]
 api:
   license: community

--- a/api/lttb.md
+++ b/api/lttb.md
@@ -2,7 +2,7 @@
 api_name: lttb()
 excerpt: Downsample a time series using the Largest Triangle Three Buckets method
 topics: [hyperfunctions]
-keywords: [downsample, smooth, hyperfunctions, toolkit]
+keywords: [downsample, smooth, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/max_val.md
+++ b/api/max_val.md
@@ -2,7 +2,7 @@
 api_name: max_val()
 excerpt: Calculate the maximum from values in a `tdigest`
 topics: [hyperfunctions]
-keywords: [tdigest, hyperfunctions, toolkit]
+keywords: [tdigest, hyperfunctions, Toolkit]
 tags: [percentiles, maximum]
 api:
   license: community

--- a/api/mean.md
+++ b/api/mean.md
@@ -2,7 +2,7 @@
 api_name: mean()
 excerpt: Calculate the mean from values in a percentile aggregate
 topics: [hyperfunctions]
-keywords: [hyperfunctions, toolkit]
+keywords: [hyperfunctions, Toolkit]
 tags: [average, percentiles]
 api:
   license: community

--- a/api/min_frequency-max_frequency.md
+++ b/api/min_frequency-max_frequency.md
@@ -2,7 +2,7 @@
 api_name: min_frequency() | max_frequency()
 excerpt: Calculate the minimum or maximum estimated frequencies of a value from a frequency aggregate
 topics: [hyperfunctions]
-keywords: [frequency, hyperfunctions, toolkit]
+keywords: [frequency, hyperfunctions, Toolkit]
 tags: [minimum, maximum]
 api:
   license: community

--- a/api/min_val.md
+++ b/api/min_val.md
@@ -2,7 +2,7 @@
 api_name: min_val()
 excerpt: Calculate the minimum from values in a `tdigest`
 topics: [hyperfunctions]
-keywords: [tdigest, hyperfunctions, toolkit]
+keywords: [tdigest, hyperfunctions, Toolkit]
 tags: [minimum, percentiles]
 api:
   license: community

--- a/api/month_normalize.md
+++ b/api/month_normalize.md
@@ -2,7 +2,7 @@
 api_name: month_normalize()
 excerpt: Normalize a monthly metric based on number of days in month
 topics: [hyperfunctions]
-keywords: [hyperfunctions, toolkit, normalization]
+keywords: [hyperfunctions, Toolkit, normalization]
 api:
   license: community
   type: function

--- a/api/num_changes.md
+++ b/api/num_changes.md
@@ -2,7 +2,7 @@
 api_name: num_changes()
 excerpt: Calculate the number of times a value changed within the time period of a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [count, change]
 api:
   license: community

--- a/api/num_elements.md
+++ b/api/num_elements.md
@@ -2,7 +2,7 @@
 api_name: num_elements()
 excerpt: Calculate the number of points with distinct times from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [distinct, count]
 api:
   license: community

--- a/api/num_resets.md
+++ b/api/num_resets.md
@@ -2,7 +2,7 @@
 api_name: num_resets()
 excerpt: Calculate the total number of times a counter is reset
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [resets, count]
 api:
   license: community

--- a/api/num_vals-percentile.md
+++ b/api/num_vals-percentile.md
@@ -2,7 +2,7 @@
 api_name: num_vals()
 excerpt: Calculate the number of values contained in a percentile estimate
 topics: [hyperfunctions]
-keywords: [percentiles, hyperfunctions, toolkit]
+keywords: [percentiles, hyperfunctions, Toolkit]
 tags: [number, count]
 api:
   license: community

--- a/api/percentile-aggregation-methods.md
+++ b/api/percentile-aggregation-methods.md
@@ -1,11 +1,12 @@
 ---
 title: Advanced percentile aggregation
 excerpt: Choose an approximation algorithm for calculating percentiles
-keywords: [percentiles, aggregate, hyperfunctions, toolkit]
+keywords: [percentiles, aggregate, hyperfunctions, Toolkit]
 tags: [approximate]
 ---
 
 # Advanced percentile aggregation <tag type="toolkit">Toolkit</tag>
+
 Timescale uses approximation algorithms to calculate a percentile without
 requiring all of the data. This also makes them more compatible with continuous
 aggregates. By default, Timescale Toolkit uses `uddsketch`, but you can also

--- a/api/percentile-approximation.md
+++ b/api/percentile-approximation.md
@@ -1,11 +1,12 @@
 ---
 title: Percentile approximation
 excerpt: Approximate percentiles from a dataset
-keywords: [percentiles, hyperfunctions, toolkit]
+keywords: [percentiles, hyperfunctions, Toolkit]
 tags: [approximate]
 ---
 
 # Percentile approximation  <tag type="toolkit">Toolkit</tag>
+
 This section contains functions related to percentile approximation.
 Approximation algorithms are used to calculate a percentile without requiring
 all of the data. For more information about percentile approximation functions,

--- a/api/percentile_agg.md
+++ b/api/percentile_agg.md
@@ -2,7 +2,7 @@
 api_name: percentile_agg()
 excerpt: Aggregate data into a percentile aggregate for further analysis
 topics: [hyperfunctions]
-keywords: [percentiles, aggregate, hyperfunctions, toolkit]
+keywords: [percentiles, aggregate, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/rate.md
+++ b/api/rate.md
@@ -2,7 +2,7 @@
 api_name: rate()
 excerpt: Calculate the rate of change from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [rate, change]
 api:
   license: community

--- a/api/rollup-counter.md
+++ b/api/rollup-counter.md
@@ -2,7 +2,7 @@
 api_name: rollup()
 excerpt: Roll up multiple `CounterSummary` aggregates
 topics: [hyperfunctions]
-keywords: [counters, rollup, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/rollup-hyperloglog.md
+++ b/api/rollup-hyperloglog.md
@@ -2,7 +2,7 @@
 api_name: rollup()
 excerpt: Roll up multiple hyperloglogs
 topics: [hyperfunctions]
-keywords: [rollup, hyperloglog, hyperfunctions, toolkit]
+keywords: [hyperloglog, hyperfunctions, Toolkit]
 tags: [approximate, count, distinct]
 api:
   license: community

--- a/api/rollup-percentile.md
+++ b/api/rollup-percentile.md
@@ -2,7 +2,7 @@
 api_name: rollup()
 excerpt: Roll up multiple percentile aggregates, `uddsketch`es, or `tdigest`s
 topics: [hyperfunctions]
-keywords: [rollup, percentiles, hyperfunctions, toolkit]
+keywords: [percentiles, hyperfunctions, Toolkit]
 tags: [uddsketch, tdigest]
 api:
   license: community

--- a/api/rollup-timeweight.md
+++ b/api/rollup-timeweight.md
@@ -2,7 +2,7 @@
 api_name: rollup()
 excerpt: Roll up multiple `TimeWeightSummaries`
 topics: [hyperfunctions]
-keywords: [rollup, time-weighted, hyperfunctions, toolkit]
+keywords: [time-weighted, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/slope-counter.md
+++ b/api/slope-counter.md
@@ -2,7 +2,7 @@
 api_name: slope()
 excerpt: Calculate the slope from values in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 tags: [least squares, linear regression]
 api:
   license: community

--- a/api/state_agg.md
+++ b/api/state_agg.md
@@ -2,7 +2,7 @@
 api_name: state_agg()
 excerpt: Aggregate state data into a state aggregate for further analysis
 topics: [hyperfunctions]
-keywords: [states, aggregate, hyperfunctions, toolkit]
+keywords: [states, aggregate, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/stderror.md
+++ b/api/stderror.md
@@ -2,7 +2,7 @@
 api_name: stderror()
 excerpt: Estimate the relative standard error of a hyperloglog
 topics: [hyperfunctions]
-keywords: [hyperloglog, hyperfunctions, toolkit]
+keywords: [hyperloglog, hyperfunctions, Toolkit]
 tags: [standard error, percentiles]
 api:
   license: community

--- a/api/tdigest.md
+++ b/api/tdigest.md
@@ -2,7 +2,7 @@
 api_name: tdigest()
 excerpt: Aggregate data in a `tdigest` for further calculation of percentile estimates
 topics: [hyperfunctions]
-keywords: [percentiles, aggregate, hyperfunctions, toolkit]
+keywords: [percentiles, aggregate, hyperfunctions, Toolkit]
 tags: [tdigest]
 api:
   license: community

--- a/api/time-weighted-averages.md
+++ b/api/time-weighted-averages.md
@@ -1,11 +1,12 @@
 ---
 title: Time-weighted average functions
 excerpt: Calculate time-weighted averages for unevenly sampled data
-keywords: [time-weighted, average, hyperfunctions, toolkit]
+keywords: [time-weighted, average, hyperfunctions, Toolkit]
 tags: [mean]
 ---
 
 # Time-weighted average functions <tag type="toolkit">Toolkit</tag>
+
 This section contains functions related to time-weighted averages and integrals.
 Time weighted averages and integrals are commonly used in cases where a time
 series is not evenly sampled, so a traditional average gives misleading results.

--- a/api/time_bucket_gapfill.md
+++ b/api/time_bucket_gapfill.md
@@ -2,7 +2,7 @@
 api_name: time_bucket_gapfill()
 excerpt: Bucket rows by time interval while filling gaps in data
 topics: [hyperfunctions]
-keywords: [gapfill, interpolate, aggregate, hyperfunctions, toolkit]
+keywords: [gapfilling, interpolate, aggregate, hyperfunctions, Toolkit]
 tags: [time buckets]
 api:
   license: community

--- a/api/time_delta.md
+++ b/api/time_delta.md
@@ -2,7 +2,7 @@
 api_name: time_delta()
 excerpt: Calculate the difference between the start and end times from data in a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/time_weight.md
+++ b/api/time_weight.md
@@ -2,7 +2,7 @@
 api_name: time_weight()
 excerpt: Aggregate data in a `TimeWeightSummary` for further time-weighted analysis
 topics: [hyperfunctions]
-keywords: [time-weighted, aggregate, hyperfunctions, toolkit]
+keywords: [time-weighted, aggregate, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/topn.md
+++ b/api/topn.md
@@ -2,7 +2,7 @@
 api_name: topn()
 excerpt: Calculate the top N most common values from data in a frequency or top N aggregate
 topics: [hyperfunctions]
-keywords: [frequency, top N, hyperfunctions, toolkit]
+keywords: [frequency, top N, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/topn_agg.md
+++ b/api/topn_agg.md
@@ -2,7 +2,7 @@
 api_name: topn_agg()
 excerpt: Aggregate data in a top N aggregate for further calculation of most frequent values
 topics: [hyperfunctions]
-keywords: [frequency, top N, aggregate, hyperfunctions, toolkit]
+keywords: [frequency, top N, aggregate, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/api/uddsketch.md
+++ b/api/uddsketch.md
@@ -2,7 +2,7 @@
 api_name: uddsketch()
 excerpt: Aggregate data in a `uddsketch` for further calculation of percentile estimates
 topics: [hyperfunctions]
-keywords: [percentiles, hyperfunctions, toolkit]
+keywords: [percentiles, hyperfunctions, Toolkit]
 tags: [uddsketch]
 api:
   license: community

--- a/api/with_bounds.md
+++ b/api/with_bounds.md
@@ -2,7 +2,7 @@
 api_name: with_bounds()
 excerpt: Add bounds to a `CounterSummary`
 topics: [hyperfunctions]
-keywords: [counters, hyperfunctions, toolkit]
+keywords: [counters, hyperfunctions, Toolkit]
 api:
   license: community
   type: function

--- a/cloud/backup-restore-cloud.md
+++ b/cloud/backup-restore-cloud.md
@@ -2,7 +2,7 @@
 title: Backup and restore
 excerpt: Understand how backups and restores work in Timescale Cloud
 product: cloud
-keywords: [backup, restore]
+keywords: [backups, restore]
 tags: [recovery, failures]
 ---
 

--- a/cloud/integrations.md
+++ b/cloud/integrations.md
@@ -2,7 +2,7 @@
 title: Integrate Timescale Cloud services with third-party monitoring
 excerpt: Export telemetry metrics to Datadog or AWS CloudWatch
 product: cloud
-keywords: [integrations, metrics, Datadog, AWS CloudWatch]
+keywords: [integration, metrics, Datadog, AWS CloudWatch]
 tags: [telemetry, monitor]
 ---
 

--- a/cloud/migrate-to-cloud/entire-database.md
+++ b/cloud/migrate-to-cloud/entire-database.md
@@ -2,11 +2,12 @@
 title: Migrate the entire database at once
 excerpt: Migrate an entire TimescaleDB database to Timescale Cloud in one go
 product: cloud
-keywords: [migrate]
+keywords: [data migration]
 tags: [ingest]
 ---
 
 # Migrate the entire database at once
+
 Migrate smaller databases by dumping and restoring the entire database at once.
 This method works best on databases smaller than 100&nbsp;GB. For larger
 databases, consider [migrating your schema and data
@@ -23,7 +24,9 @@ database](http://docs.timescale.com/cloud/latest/migrate-to-cloud/#migrate-an-ac
 </highlight>
 
 ## Prerequisites
+
 Before you begin, check that you have:
+
 *   Installed the PostgreSQL [`pg_dump`][pg_dump] and [`pg_restore`][pg_restore]
     utilities.
 *   Installed a client for connecting to PostgreSQL. These instructions use
@@ -32,7 +35,7 @@ Before you begin, check that you have:
     the [Install Timescale Cloud section][install-timescale-cloud]. Provision
     your database with enough space for all your data.
 *   Checked that any other PostgreSQL extensions you use are compatible with
-    Timescale Cloud. For more information, see the [list of compatible 
+    Timescale Cloud. For more information, see the [list of compatible
     extensions][extensions]. Install your other PostgreSQL extensions.
 *   Checked that you're running the same major version of PostgreSQL on both
     Timescale Cloud and your source database. For information about upgrading
@@ -54,43 +57,54 @@ information about compression and decompression, see the
 <procedure>
 
 ### Migrating the entire database at once
+
 1.  Dump all the data from your source database into a `dump.bak` file, using your
     source database connection details. If you are prompted for a password, use
     your source database credentials:
+
     ```bash
     pg_dump -U <SOURCE_DB_USERNAME> -W \
     -h <SOURCE_DB_HOST> -p <SOURCE_DB_PORT> -Fc -v \
     -f dump.bak <SOURCE_DB_NAME>
     ```
+
 1.  Connect to your Timescale Cloud database using your Timescale Cloud
     connection details. When you are prompted for a password, use your Timescale
     Cloud credentials:
+
     ```bash
     psql “postgres://tsdbadmin:<CLOUD_PASSWORD>@<CLOUD_HOST>:<CLOUD_PORT>/tsdb?sslmode=require”
     ```
+
 1.  Prepare your Timescale Cloud database for data restoration by using
     [`timescaledb_pre_restore`][timescaledb_pre_restore] to stop background
     workers:
+
     ```sql
     SELECT timescaledb_pre_restore();
     ```
+
 1.  At the command prompt, restore the dumped data from the `dump.bak` file into
     your Timescale Cloud database, using your Timescale Cloud connection
     details. To avoid permissions errors, include the `--no-owner` flag:
+
     ```bash
     pg_restore -U tsdbadmin -W \
     -h <CLOUD_HOST> -p <CLOUD_PORT> --no-owner \
     -Fc -v -d tsdb dump.bak
     ```
+
 1.  At the `psql` prompt, return your Timescale Cloud database to normal
     operations by using the
     [`timescaledb_post_restore`][timescaledb_post_restore] command:
+
     ```sql
     SELECT timescaledb_post_restore();
     ```
 
 1.  Update your table statistics by running [`ANALYZE`][analyze] on your entire
     dataset:
+
     ```sql
     ANALYZE;
     ```
@@ -98,6 +112,7 @@ information about compression and decompression, see the
 </procedure>
 
 ## Troubleshooting
+
 If you see these errors during the migration process, you can safely ignore
 them. The migration still occurs successfully.
 
@@ -107,14 +122,17 @@ them. The migration still occurs successfully.
     pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
     pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
     ```
+
 1.  ```bash
     pg_dump: NOTICE:  hypertable data are in the chunks, no data will be copied
     DETAIL:  Data for hypertables are stored in the chunks of a hypertable so COPY TO of a hypertable will not copy any data.
     HINT:  Use "COPY (SELECT * FROM <hypertable>) TO ..." to copy all data in hypertable, or copy each chunk individually.
     ```
+
 1.  `pg_restore` tries to apply the TimescaleDB extension when it copies your
     schema. This can cause a permissions error. Because TimescaleDB is already
     installed by default on Timescale Cloud, you can safely ignore this.
+
     ```bash
     pg_restore: creating EXTENSION "timescaledb"
     pg_restore: creating COMMENT "EXTENSION timescaledb"
@@ -122,9 +140,11 @@ them. The migration still occurs successfully.
     pg_restore: from TOC entry 6239; 0 0 COMMENT EXTENSION timescaledb
     pg_restore: error: could not execute query: ERROR:  must be owner of extension timescaledb
     ```
+
 1.  ```bash
     pg_restore: WARNING:  no privileges were granted for "<..>"
     ```
+
 1.  ```bash
     pg_restore: warning: errors ignored on restore: 1
     ```

--- a/cloud/migrate-to-cloud/index.md
+++ b/cloud/migrate-to-cloud/index.md
@@ -2,7 +2,7 @@
 title: Migrate your TimescaleDB database to Timescale Cloud
 excerpt: Migrate from self-hosted TimescaleDB or Managed Service for TimescaleDB
 product: cloud
-keywords: [migrate, self-hosted, mst]
+keywords: [data migration, self-hosted, mst]
 tags: [ingest]
 ---
 

--- a/cloud/migrate-to-cloud/schema-then-data.md
+++ b/cloud/migrate-to-cloud/schema-then-data.md
@@ -2,7 +2,7 @@
 title: Migrate schema and data separately
 excerpt: Migrate your TimescaleDB data and schema to Timescale Cloud
 product: cloud
-keywords: [migrate]
+keywords: [data migration]
 tags: [ingest]
 ---
 

--- a/cloud/services/create-a-service.md
+++ b/cloud/services/create-a-service.md
@@ -2,10 +2,11 @@
 title: Create a service
 excerpt: Create a service in Timescale Cloud
 product: cloud
-keywords: [services, create, install]
+keywords: [services, create, installation]
 ---
 
 # Create a service
+
 Timescale Cloud is a hosted, cloud-native TimescaleDB service that allows you to
 quickly spin up new TimescaleDB instances. You can
 [try Timescale Cloud for free][sign-up], no credit card required.
@@ -25,6 +26,7 @@ HINT:  Contact your administrator to configure the "tsdb_admin.allowed_databases
 If you need another database, you need to create a new service.
 
 ## Where to next
+
 Now that you have your first service up and running, you can check out the
 [Timescale Cloud][tsc-docs] section in our documentation, and
 find out what you can do with it.
@@ -37,7 +39,6 @@ the [TimescaleDB pricing calculator][timescale-pricing].
 
 You can always [contact us][contact] if you need help working something out, or
 if you want to have a chat.
-
 
 [cloud-install]: /install/:currentVersion:/installation-cloud/
 [contact]: https://www.timescale.com/contact

--- a/getting-started/next-steps.md
+++ b/getting-started/next-steps.md
@@ -1,10 +1,11 @@
 ---
 title: Next steps
 excerpt: Continue exploring TimescaleDB
-keywords: [migrate, ingest, visualize, connect]
+keywords: [data migration, ingest, visualize, connect]
 ---
 
 # Next steps
+
 Now that you've had some hands-on experience with TimescaleDB, hopefully you can
 see how many of Timescale's powerful features can help you manage your
 time-series data while easily mining for deeper insights. 💥
@@ -13,6 +14,7 @@ To continue your exploration of TimescaleDB, here are some valuable next steps
 to help you on your way to becoming a time-series superhero.
 
 ## Migrate data to TimescaleDB
+
 One of the first things most developers want to do is look at the data they're
 currently working with in the database. There are a number of methods for
 importing data that you currently have, whether it exists in another database
@@ -22,6 +24,7 @@ Look at the [how-to guide on Migrating Data][migrate-data] for more help and
 suggestions of where to start.
 
 ## Ingest real-time data
+
 Working with sample data can teach you a lot about TimescaleDB, but you might
 like to try ingesting market data in real time. Check out our
 related tutorial
@@ -29,6 +32,7 @@ related tutorial
 ingesting data directly from the [Twelve Data][twelve-data] financial API.
 
 ## Visualize your data
+
 Time-series data is perfectly suited for viewing with tools like Grafana,
 Tableau, and Power BI, to name a few. Once you can see trends and query
 for specific data features using relational data, a whole new world of insights
@@ -39,6 +43,7 @@ you how to become a Grafana Superhero and connect to other third party
 visualization tools.
 
 ## Connect to your data with code
+
 While this may be the century of big data, the greatest power often happens in
 connected applications that help turn data into value to users. Using
 time-series data effectively means you need to get your code connected and
@@ -48,6 +53,7 @@ See the [growing list of language Quick Starts][connect-with-code] to get you up
 and running with TimescaleDB, including best practices.
 
 ## Examine other sample datasets
+
 Sometimes it's just easier to explore further by having access to additional
 datasets. We have you covered! 🙌
 

--- a/install/index.md
+++ b/install/index.md
@@ -1,7 +1,7 @@
 ---
 title: Install TimescaleDB
 excerpt: Install TimescaleDB, the PostgreSQL database for time series and data analysis
-section: installation
+section: install
 nav-hidden: true
 keywords: [installation]
 ---

--- a/install/index.md
+++ b/install/index.md
@@ -1,9 +1,9 @@
 ---
 title: Install TimescaleDB
 excerpt: Install TimescaleDB, the PostgreSQL database for time series and data analysis
-section: install
+section: installation
 nav-hidden: true
-keywords: [install]
+keywords: [installation]
 ---
 
 # Install TimescaleDB

--- a/install/installation-archlinux.md
+++ b/install/installation-archlinux.md
@@ -1,5 +1,6 @@
 ---
 title: Install self-hosted TimescaleDB on Arch Linux-based systems
+keywords: [installation, self-hosted, Arch Linux]
 ---
 
 # Install self-hosted TimescaleDB on archlinux-based systems

--- a/install/installation-cloud-image.md
+++ b/install/installation-cloud-image.md
@@ -4,7 +4,7 @@ nav-title: Cloud image
 excerpt: Install self-hosted TimescaleDB from a pre-built cloud image
 section: install
 subsection: self-hosted
-keywords: [install, self-hosted]
+keywords: [installation, self-hosted]
 tags: [cloud image]
 ---
 
@@ -19,7 +19,7 @@ from a pre-built, publicly available machine image. These instructions show you
 how to use a pre-built Amazon machine image (AMI), on Amazon Web Services (AWS).
 The currently available pre-built cloud image is:
 
-- Ubuntu 20.04 Amazon EBS-backed AMI
+*   Ubuntu 20.04 Amazon EBS-backed AMI
 
 The Timescale AMI uses Elastic Block Store (EBS) attached volumes. This allows
 you to store image snapshots, dynamic IOPS configuration, and provides some
@@ -75,19 +75,26 @@ set up the TimescaleDB extension.
 
 1.  On your instance, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
+
     ```bash
     sudo -u postgres psql
     ```
+
 1.  At the prompt, create an empty database. For example, to create a database
     called `tsdb`:
+
     ```sql
     CREATE database tsdb;
     ```
+
 1.  Connect to the database you created:
+
     ```sql
     \c tsdb
     ```
+
 1.  Add the TimescaleDB extension:
+
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     ```

--- a/install/installation-cloud.md
+++ b/install/installation-cloud.md
@@ -5,7 +5,7 @@ excerpt: Start a TimescaleDB instance on Timescale Cloud, our hosted, cloud-nati
 product: cloud
 section: install
 order: 1
-keywords: [install]
+keywords: [installation]
 ---
 
 import Install from "versionContent/_partials/_cloud-installation.mdx";

--- a/install/installation-debian.md
+++ b/install/installation-debian.md
@@ -4,12 +4,13 @@ nav-title: Debian and Ubuntu
 excerpt: Install self-hosted TimescaleDB on Debian-based systems
 section: install
 subsection: self-hosted
-keywords: [install, self-hosted, Debian]
+keywords: [installation, self-hosted, Debian]
 ---
 
 import Debian from "versionContent/_partials/_psql-installation-debian-ubuntu.mdx";
 
 # Install self-hosted TimescaleDB on Debian-based systems
+
 You can host TimescaleDB yourself, on your Debian or Ubuntu system. These
 instructions use the `apt` package manager on these distributions:
 
@@ -157,7 +158,7 @@ Restart PostgreSQL and create the TimescaleDB extension:
     ```bash
     \q
     ```
-    
+
 1.  Use `psql` client to connect to PostgreSQL:
 
     ```bash
@@ -216,7 +217,6 @@ TimescaleDB and time-series data, check out our [tutorials][tutorials] section.
 
 You can always [contact us][contact] if you need help working something out, or
 if you want to have a chat.
-
 
 [contact]: https://www.timescale.com/contact
 [install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/

--- a/install/installation-docker.md
+++ b/install/installation-docker.md
@@ -4,7 +4,7 @@ nav-title: Docker
 excerpt: Install self-hosted TimescaleDB from a pre-built Docker container
 section: install
 subsection: self-hosted
-keywords: [install, self-hosted, Docker]
+keywords: [installation, self-hosted, Docker]
 ---
 
 # Install self-hosted TimescaleDB from a pre-built container

--- a/install/installation-kubernetes.md
+++ b/install/installation-kubernetes.md
@@ -4,10 +4,11 @@ nav-title: Kubernetes
 excerpt: Install self-hosted TimescaleDB on Kubernetes
 section: install
 subsection: self-hosted
-keywords: [install, self-hosted, Kubernetes]
+keywords: [installation, self-hosted, Kubernetes]
 ---
 
 # Install TimescaleDB on Kubernetes
+
 You can install a TimescaleDB instance on any Kubernetes deployment. Use the
 `timescaledb-single` Helm chart to deploy a highly available TimescaleDB
 database, and `timescaledb-multinode` to deploy a multi-node distributed
@@ -16,9 +17,10 @@ deployed with these charts, see [TimescaleDB on Kubernetes][timescaledb-k8s].
 
 Before you begin installing TimescaleDB on a Kubernetes deployment, make sure
 you have installed:
-* [kubectl][kubectl-install]
-* [Helm][helm-install]
-* [Kubernetes Cluster][kubernetes-install]
+
+*   [kubectl][kubectl-install]
+*   [Helm][helm-install]
+*   [Kubernetes Cluster][kubernetes-install]
 
 If you want to, you can create your own `.yaml` file to use parameters other
 than those specified in the default `values.yaml`. You can name this file
@@ -26,6 +28,7 @@ than those specified in the default `values.yaml`. You can name this file
 [Administrator Guide][admin-guide].
 
 ## Install TimescaleDB using a Helm chart
+
 Install TimescaleDB on Kubernetes using a Helm chart with the default
 `values.yaml` file. When you use the `values.yaml` file, the user credentials
 are randomly generated during installation. Therefore, the `helm upgrade`
@@ -39,27 +42,36 @@ This section provides instructions to deploy TimescaleDB using the
 <procedure>
 
 ### Installing TimescaleDB using a Helm chart
+
 1.  Add the TimescaleDB Helm chart repository:
+
     ```bash
     helm repo add timescale 'https://charts.timescale.com'
     ```
+
 1.  Verify that the repository is up to date:
+
     ```bash
     helm repo update
     ```
+
 1.  Install the TimescaleDB Helm chart, by replacing `<MY_NAME>` with a name of
     your choice:
+
     ```bash
     helm install <MY_NAME> timescale/timescaledb-single
     ```
+
     If you created a `<MY_VALUES.yaml>` file, use this command instead:
+
     ```bash
     helm install <MY_NAME> -f <MY_VALUES.yaml> charts/timescaledb-single
     ```
 
-</procedure> 
+</procedure>
 
 ## Connect to TimescaleDB
+
 You can connect to TimescaleDB from an external IP address, or from within the
 cluster.
 
@@ -73,40 +85,51 @@ need to decode the passwords. In the following section replace `MY_NAME` with
 the name that you provided during the installation.
 </highlight>
 
-1. Get the name of the host to connect to:
+1.  Get the name of the host to connect to:
+
     ```bash
     kubectl get service/<MY_NAME>
     ```
-1. Decode the `admin` user password `PGPASSWORD_ADMIN` that was generated during
+
+1.  Decode the `admin` user password `PGPASSWORD_ADMIN` that was generated during
    the Helm installation:
+
     ```bash
     PGPASSWORD_ADMIN=$(kubectl get secret --namespace default 
     <MY_NAME>-credentials -o jsonpath="{.data.PATRONI_admin_PASSWORD}" | base64 --decode)
-    ``` 
-1. **OPTIONAL** Decode the super user password `PGPOSTGRESPASSWORD` that was
+    ```
+
+1.  **OPTIONAL** Decode the super user password `PGPOSTGRESPASSWORD` that was
    generated during the Helm installation:
+
     ```bash
     PGPASSWORD_POSTGRES=$(kubectl get secret --namespace default 
     <MY_NAME>-credentials -o jsonpath="{.data.PATRONI_SUPERUSER_PASSWORD}" | base64 --decode)
     ```
-1. Connect to psql as `admin` user:
+
+1.  Connect to psql as `admin` user:
+
     ```bash
     kubectl run -i --tty --rm psql --image=postgres \
       --env "PGPASSWORD=$PGPASSWORD_ADMIN" \
       --command -- psql -U admin \
       -h <MY_NAME>.default.svc.cluster.local postgres
     ```
-    
+
 </procedure>
 
 <procedure>
 
 ### Connecting to TimescaleDB from inside the cluster
-1. Get the Pod on which TimescaleDB is installed:
+
+1.  Get the Pod on which TimescaleDB is installed:
+
    ```bash
    MASTERPOD="$(kubectl get pod -o name --namespace default -l release=test,role=master)"
    ```
-2. Run `psql` inside the Pod containing the primary:
+
+2.  Run `psql` inside the Pod containing the primary:
+
    ```bash
    kubectl exec -i --tty --namespace default ${MASTERPOD} -- psql -U postgres
    ```
@@ -114,6 +137,7 @@ the name that you provided during the installation.
 </procedure>
 
 ## Create a database
+
  After installing and connecting to TimescaleDB you can create a database,
  connect to the database, and also verify that the TimescaleDB extension is
  installed.
@@ -121,17 +145,23 @@ the name that you provided during the installation.
 <procedure>
 
 ### Creating a database
+
 1.  At the prompt, create an empty database. For example, to create a database
     called `tsdb`:
+
     ```sql
     CREATE database tsdb;
     ```
+
 1.  Connect to the database you created:
+
     ```sql
     \c tsdb
     ```
+
 1.  Verify that the TimescaleDB extension is installed by using the `\dx`
     command at the command prompt. The output looks like this:
+
     ```sql
                                       List of installed extensions
     Name     | Version |   Schema   |                            Description                            
@@ -146,19 +176,24 @@ the name that you provided during the installation.
 </procedure>
 
 ## Clean up
+
 You can use Helm to uninstall TimescaleDB on the Kubernetes cluster and clean up
 the Pods, persistent volume claim (PVC), S3 backups, and more.
 
 ### Cleaning up
+
 To remove the spawned Pods:
+
 ```bash
 helm delete <MY_NAME>
 ```
+
 Some items, such as PVCs and S3 backups, are not removed
 immediately. For more information about purging these items, see the
 [Administrator Guide][admin-guide].
 
 ## Where to next
+
 Now that you have your first TimescaleDB database up and running, see
 the [TimescaleDB][tsdb-docs] section to learn what you can do with it.
 
@@ -166,7 +201,6 @@ To work through some tutorials that help you get started with
 TimescaleDB and time-series data, check out the [tutorials][tutorials] section.
 
 To get help or chat with the Timescale team, [get in contact][contact].
-
 
 [kubectl-install]: https://kubernetes.io/docs/tasks/tools/
 [kubernetes-install]: https://kubernetes.io/docs/setup/

--- a/install/installation-macos.md
+++ b/install/installation-macos.md
@@ -4,7 +4,7 @@ nav-title: macOS
 excerpt: Install self-hosted TimescaleDB on macOS
 section: install
 subsection: self-hosted
-keywords: [install, self-hosted, macOS]
+keywords: [installation, self-hosted, macOS]
 ---
 
 import Homebrew from "versionContent/_partials/_psql-installation-homebrew.mdx";
@@ -126,6 +126,7 @@ your local system using the `psql` command-line utility.
 <MacPorts />
 
 ## Set up the TimescaleDB extension
+
 Connect to PostgreSQL from your local system using the `psql` command-line
 utility and set up the TimescaleDB extension.
 

--- a/install/installation-mst.md
+++ b/install/installation-mst.md
@@ -5,7 +5,7 @@ excerpt: Start a TimescaleDB instance on Managed Service for TimescaleDB
 product: mst
 section: install
 order: 2
-keywords: [install]
+keywords: [installation]
 ---
 
 import MSTIntro from "versionContent/_partials/_mst-intro.mdx";

--- a/install/installation-redhat.md
+++ b/install/installation-redhat.md
@@ -4,7 +4,7 @@ nav-title: Red Hat and CentOS
 excerpt: Install self-hosted TimescaleDB on Red Hat-based systems
 section: install
 subsection: self-hosted
-keywords: [install, self-hosted, Red Hat]
+keywords: [installation, self-hosted, Red Hat]
 ---
 
 import CentOS from "versionContent/_partials/_psql-installation-centos.mdx";

--- a/install/installation-source.md
+++ b/install/installation-source.md
@@ -4,10 +4,11 @@ nav-title: From source
 excerpt: Install self-hosted TimescaleDB from source
 section: install
 subsection: self-hosted
-keywords: [install, self-hosted]
+keywords: [installation, self-hosted]
 ---
 
 # Install self-hosted TimescaleDB from source
+
 You can host TimescaleDB yourself, on any system, by downloading the source code
 and compiling it. These instructions do not require the use of a package manager
 or installation tool.
@@ -23,25 +24,33 @@ Before you start, make sure you have installed:
 *   C language compiler for your operating system, such as `gcc` or `clang`.
 
 If you are installing from source on a Microsoft Windows system, you also need:
+
 *   Visual Studio 2015 or later, packaged with CMake version 3.11 or later, and
     Git components.
 
 <procedure>
 
 ### Installing self-hosted TimescaleDB from source
+
 1.  At the command prompt, clone the Timescale GitHub repository:
+
     ```bash
     git clone https://github.com/timescale/timescaledb.git
     ```
+
 1.  Change into the cloned directory:
+
     ```bash
     cd timescaledb
     ```
+
 1.  Checkout the latest release. You can find the latest release tag on
     our [Releases page][gh-releases]:
+
     ```bash
     git checkout 2.5.1
     ```
+
 1.  Bootstrap the build system:
     <terminal>
 
@@ -106,6 +115,7 @@ If you are installing from source on a Microsoft Windows system, you also need:
 </procedure>
 
 ## Configure PostgreSQL after installing from source
+
 When you install TimescaleDB from source, you need to do some additional
 PostgreSQL configuration to add the TimescaleDB library.
 
@@ -119,16 +129,21 @@ to find out which PostgreSQL installation TimescaleDB is using.
 <procedure>
 
 ### Configuring PostgreSQL after installing from source
+
 1.  Locate the `postgresql.conf` configuration file:
+
     ```bash
     psql -d postgres -c "SHOW config_file;"
     ```
+
 1.  Open the `postgresql.conf` file in your preferred text editor, and locate
     the `shared_preload_libraries` parameter. Uncomment the line, and
     add `timescaledb`:
+
     ```bash
     shared_preload_libraries = 'timescaledb'
     ```
+
     If you use other preloaded libraries, make sure they are comma separated.
 1.  Restart the PostgreSQL instance:
     <terminal>
@@ -159,6 +174,7 @@ script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
 ## Set up the TimescaleDB extension
+
 When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't
@@ -167,33 +183,45 @@ installed it yet, check out our [installing psql][install-psql] section.
 <procedure>
 
 ### Setting up the TimescaleDB extension
+
 1.  On your local system, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
+
     ```bash
     psql -U postgres -h localhost
     ```
+
     If your connection is successful, you'll see a message like this, followed
     by the `psql` prompt:
+
     ```
     psql (13.3, server 12.8 (Ubuntu 12.8-1.pgdg21.04+1))
     SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
     Type "help" for help.
     tsdb=>
     ```
+
 1.  At the `psql` prompt, create an empty database. Our database is
     called `example`:
+
     ```sql
     CREATE database example;
     ```
+
 1.  Connect to the database you created:
+
     ```sql
     \c example
     ```
+
 1.  Add the TimescaleDB extension:
+
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     ```
+
 1.  You can now connect to your database using this command:
+
     ```bash
     psql -U postgres -h localhost -d example
     ```
@@ -202,6 +230,7 @@ installed it yet, check out our [installing psql][install-psql] section.
 
 You can check that the TimescaleDB extension is installed by using the `\dx`
 command at the `psql` prompt. It looks like this:
+
 ```sql
 tsdb=> \dx
 List of installed extensions
@@ -230,6 +259,7 @@ tsdb=>
 ```
 
 ## Where to next
+
 Now that you have your first TimescaleDB database up and running, you can check
 out the [TimescaleDB][tsdb-docs] section in our documentation, and find out what
 you can do with it.
@@ -239,7 +269,6 @@ TimescaleDB and time-series data, check out our [tutorials][tutorials] section.
 
 You can always [contact us][contact] if you need help working something out, or
 if you want to have a chat.
-
 
 [contact]: https://www.timescale.com/contact
 [install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/

--- a/install/installation-windows.md
+++ b/install/installation-windows.md
@@ -4,7 +4,7 @@ nav-title: Windows
 excerpt: Install self-hosted TimescaleDB on Windows
 section: install
 subsection: self-hosted
-keywords: [install, self-hosted, Windows]
+keywords: [installation, self-hosted, Windows]
 ---
 
 import Windows from "versionContent/_partials/_psql-installation-windows.mdx";
@@ -61,7 +61,7 @@ information, see the [configuration][config] section.
 ## Set up the TimescaleDB extension
 
 When you have PostgreSQL and TimescaleDB installed, you can connect to it from
-your local system using the `psql` command-line utility. 
+your local system using the `psql` command-line utility.
 
 <Windows />
 

--- a/install/self-hosted.md
+++ b/install/self-hosted.md
@@ -4,7 +4,7 @@ excerpt: Install a self-hosted, self-managed instance of TimescaleDB
 section: install
 subsection: self-hosted
 order: 1
-keywords: [install, self-hosted]
+keywords: [installation, self-hosted]
 ---
 
 <Installation />

--- a/mst/aiven-client/grafana-authentication-plugins.md
+++ b/mst/aiven-client/grafana-authentication-plugins.md
@@ -2,6 +2,7 @@
 title: Integrate authentication plugins in Grafana
 excerpt: Configure Google, GitHub, or GitLab authentication plugins for Grafana
 product: mst
+keywords: [integration]
 ---
 
 # Grafana authentication plugins

--- a/mst/aiven-client/grafana-email.md
+++ b/mst/aiven-client/grafana-email.md
@@ -2,6 +2,7 @@
 title: Send Grafana emails
 excerpt: Configure the Simple Mail Transfer Protocol (SMTP) server in MST for Grafana.
 product: mst
+keywords: [Grafana, integration]
 ---
 
 # Send Grafana emails

--- a/mst/failover.md
+++ b/mst/failover.md
@@ -2,7 +2,7 @@
 title: Failover
 excerpt: Learn how maintenance is automatically handled on Managed Service for TimescaleDB
 product: mst
-keywords: [maintenance, update, upgrade, failover, high availability, replica]
+keywords: [maintenance, updates, upgrades, failover, high availability, replica]
 tags: [failover window]
 ---
 

--- a/mst/google-data-studio-mst.md
+++ b/mst/google-data-studio-mst.md
@@ -2,6 +2,7 @@
 title: Integrate Managed Service for TimescaleDB and Google Data Studio
 excerpt: Integrate Google Data Studio for fully managed services on AWS, Azure, or GCP.
 product: mst
+keyword: [integration]
 ---
 
 # Integrate Managed Service for TimescaleDB and Google Data Studio

--- a/mst/grafana-mst.md
+++ b/mst/grafana-mst.md
@@ -1,7 +1,8 @@
 ---
 title: Integrate Managed Service for TimescaleDB as a data source in Grafana
 excerpt: Integrate Managed Service for TimescaleDB as a data source in Grafana to visualize your data
-keywords: [Grafana, visualizations, analytics]
+product: mst
+keywords: [Grafana, visualizations, analytics, integration]
 ---
 
 # Integrate Managed Service for TimescaleDB and Grafana
@@ -16,8 +17,10 @@ that allow you to query and visualize data from a compatible database.
 *   Create a service for [Grafana in MST][grafana-install]
 
 ## Configure Managed Service for TimescaleDB as a data source
+
 You can configure a TimescaleDB service as a data source to a Grafana service
-to query and visualize the data from the database. 
+to query and visualize the data from the database.
+
 <procedure>
 
 ### Configuring Managed Service for TimescaleDB as a data source

--- a/mst/ingest-data.md
+++ b/mst/ingest-data.md
@@ -2,7 +2,7 @@
 title: Ingest data
 excerpt: Ingest data into Managed Service for Timescaledb
 product: mst
-keywords: [ingest, migrate]
+keywords: [ingest, data migration]
 tags: [JDB, ODBC, client driver, Kafka, csv]
 ---
 

--- a/mst/logging.md
+++ b/mst/logging.md
@@ -2,8 +2,7 @@
 title: Logging
 excerpt: Retrieve logging information on Managed Service for TimescaleDB
 product: mst
-keywords: [logging, loggly]
-tags: [logging, logs, integrations, loggly]
+keywords: [logging, Loggly, integration]
 ---
 
 # Logging

--- a/mst/maintenance.md
+++ b/mst/maintenance.md
@@ -2,11 +2,12 @@
 title: Maintenance
 excerpt: Learn how maintenance is automatically handled on Managed Service for TimescaleDB
 product: mst
-keywords: [maintenance, update, upgrade]
+keywords: [maintenance, updates, upgrades]
 tags: [maintenace window]
 ---
 
 # Maintenance
+
 On Managed Service for TimescaleDB, software updates are handled automatically
 by us, and you do not need to perform any actions to keep up to date.
 
@@ -20,6 +21,7 @@ it points to changes.
 </highlight>
 
 ## Non-critical maintenance updates
+
 Non-critical upgrades are made available before the upgrade is performed
 automatically. During this time you can click `Apply upgrades` to start the
 upgrade at any time. However, after the time expires, usually around a week,
@@ -39,6 +41,7 @@ system during the upgrade.
 <procedure>
 
 ### Adjusting your maintenance window
+
 1.  [Log in to your account][mst-login]. Click the name of the service that
     you want to manage the maintenance window for.
 1.  In the `Maintenance window` section, click `Change`.
@@ -51,6 +54,7 @@ system during the upgrade.
 </procedure>
 
 ## Critical updates
+
 Critical upgrades and security fixes are installed outside normal maintenance windows when
 necessary, and sometimes require a short outage.
 
@@ -62,6 +66,5 @@ retired automatically after the new servers have taken over. The controlled
 failover is a very quick and safe operation and it takes less than a minute to
 get clients connected again. In most cases, there is five to ten second outage
 during this process.
-
 
 [mst-login]: https://portal.managed.timescale.com

--- a/mst/manage-backups.md
+++ b/mst/manage-backups.md
@@ -2,7 +2,7 @@
 title: Back up and restore your Managed Service for TimescaleDB
 excerpt: Understand the various alternative tools that you can use to manage your MST backups
 product: mst
-keywords: [backup, manage, restore, pg_dump]
+keywords: [backups, manage, restore, pg_dump]
 tags: [backup, manage, restore, timescaledb-backup, pg_dump]
 ---
 

--- a/mst/metrics-datadog.md
+++ b/mst/metrics-datadog.md
@@ -2,11 +2,12 @@
 title: Metrics and Datadog
 excerpt: Collect Datadog metrics on your Managed Service for TimescaleDB instance
 product: mst
-keywords: [integrations, metrics]
+keywords: [integration, metrics]
 tags: [datadog]
 ---
 
 # Metrics and Datadog
+
 Datadog is a popular cloud-based monitoring service. You can send metrics to
 Datadog using a metrics collection agent for graphing, service dashboards,
 alerting, and logging. Managed Service for TimescaleDB can send data
@@ -21,6 +22,7 @@ We do not currently support Datadog logging on Managed Service for TimescaleDB.
 </highlight>
 
 ## Create and upload a Datadog API key
+
 You can create an API key in your Datadog account, and upload it to your Managed
 Service for TimescaleDB account.
 
@@ -34,6 +36,7 @@ TimescaleDB service.
 <procedure>
 
 ### Creating a Datadog API key
+
 1.  Log in to your [Datadog dashboard][datadog-login] and navigate to
     `Integrations → APIs`. Click `API Keys`.
 1.  In the `New API key` field, type a name for your new key. For example,
@@ -47,6 +50,7 @@ TimescaleDB service.
 <procedure>
 
 ### Uploading a Datadog API key to MST
+
 1.  [Log in to your Managed Service for TimescaleDB][mst-login]. By default, you start in the
     `Services` view, showing any services you currently have in your project.
 1.  Check that you are in the project that you want to connect to Datadog,
@@ -63,11 +67,13 @@ TimescaleDB service.
 </procedure>
 
 ## Activate Datadog integration for a service
+
 When you have successfully added the endpoint, you can set up one of your services to send data to Datadog.
 
 <procedure>
 
 ### Activating Datadog integration for a service
+
 1.  In the Managed Service for TimescaleDB `Services` view, click the name of the service that you want to
     connect to Datadog.
 1.  In the `Service integrations` section, click `Manage integrations`. Locate
@@ -80,10 +86,10 @@ When you have successfully added the endpoint, you can set up one of your servic
 </procedure>
 
 ## Datadog dashboards
+
 When you have your Datadog integration set up successfully, you can use the
 Datadog dashboard editor to configure your visualizations. See the
 [Datadog Dashboard documentation][datadog-dashboard-docs] for more information.
-
 
 [datadog-login]: https://app.datadoghq.com/
 [mst-login]: https://portal.managed.timescale.com

--- a/mst/migrate-to-cloud.md
+++ b/mst/migrate-to-cloud.md
@@ -2,10 +2,11 @@
 title: Migrate your Managed Service for TimescaleDB data to Timescale Cloud
 excerpt: Migrate to Timescale Cloud from Managed Service for TimescaleDB
 product: mst
-keywords: [migrate]
+keywords: [data migration]
 ---
 
 # Migrate your Managed Service for TimescaleDB data to Timescale Cloud
+
 If you prefer Timescale Cloud's features, you can migrate your data from Managed
 Service for TimescaleDB to Timescale Cloud. To learn about migration, see the
 [migration guide][migration].

--- a/mst/migrate-to-mst.md
+++ b/mst/migrate-to-mst.md
@@ -2,7 +2,7 @@
 title: Migrating from self-hosted TimescaleDB to Managed Service for TimescaleDB
 excerpt: Migrating an existing TimescaleDB database to Managed Service for TimescaleDB
 product: mst
-keywords: [migrate, database]
+keywords: [data migration, database]
 tags: [ingest, backup, restore]
 ---
 
@@ -13,7 +13,7 @@ TimescaleDB and automate most of your most common operational tasks.
 
 Managed Service for TimescaleDB creates a database named `defaultdb` and a
 default user account named `tsdbadmin`. You can use the Web console to create
-additional users and databases using the `Users` and `Databases` tabs. 
+additional users and databases using the `Users` and `Databases` tabs.
 
 You can switch between different plan sizes in Managed Service for TimescaleDB,
 However, during the dumping process choose a plan size that has the same
@@ -33,7 +33,9 @@ not causing downtime to your customers.
 </highlight>
 
 ## Before you begin
+
 Ensure that you have:
+
 *   Installed the PostgreSQL [`pg_dump`][pg_dump] and [`pg_restore`][pg_restore]
     utilities.
 *   Installed a client for connecting to PostgreSQL. These instructions use
@@ -61,26 +63,32 @@ information about compression and decompression, see the
 <procedure>
 
 ### Migrating the database
+
 1.  Dump all the data from your source database into a `dump.bak` file, using
     your source database connection details. If you are prompted for a password,
     use your source database credentials, and to avoid permissions errors,
     include the `--no-owner` flag:
+
     ```bash
     pg_dump -U <SOURCE_DB_USERNAME> -W \
     -h <SOURCE_DB_HOST> -p <SOURCE_DB_PORT> --no-owner -Fc -v \
     -f dump.bak <SOURCE_DB_NAME>
     ```
+
 1.  At the command prompt, restore the dumped data from the `dump.bak` file into
     your Managed Service for TimescaleDB database, using your Managed Service
     for TimescaleDB connection details. To migrate from multiple databases you
     repeat the process of dumping or loading one database after another. The
     `--jobs`  option specifies the number of CPUs to use to dump and restore the
     database concurrently.
+
     ```bash
     pg_restore -d 'postgres://CLICK_TO:REVEAL_PASSWORD@demo.demoproject.timescaledb.io:19335/defaultdb?sslmode=require' --jobs 4 dump.bak 
     ```
+
 1.  Connect to your new database and update your table statistics by running [`ANALYZE`][analyze] on your entire
     dataset:
+
     ```sql
     psql 'postgres://CLICK_TO:REVEAL_PASSWORD@demo.demoproject.timescaledb.io:19335/defaultdb?sslmode=require'
     defaultdb=> ANALYZE;
@@ -89,10 +97,12 @@ information about compression and decompression, see the
 </procedure>
 
 ## Troubleshooting
+
 If you see these errors during the migration process, you can safely ignore
 them. The migration still occurs successfully.
 
 1.  Error when using `pg_dump`:
+
     ```bash
     pg_dump: warning: there are circular foreign-key constraints on this table:
     pg_dump: hypertable
@@ -102,12 +112,15 @@ them. The migration still occurs successfully.
     DETAIL:  Data for hypertables are stored in the chunks of a hypertable so COPY TO of a hypertable will not copy any data.
     HINT:  Use "COPY (SELECT * FROM <hypertable>) TO ..." to copy all data in hypertable, or copy each chunk individually.
     ```
-1. Error when using `pg_restore:
+
+1.  Error when using `pg_restore:
+
    ```bash
    pg_restore: while PROCESSING TOC:
    pg_restore: from TOC entry 4142; 0 0 COMMENT EXTENSION timescaledb 
    pg_restore: error: could not execute query: ERROR:  must be owner of extension timescaledb
    Command was: COMMENT ON EXTENSION timescaledb IS 'Enables scalable inserts and complex queries for time-series data';
+
  ```
 
 [analyze]: https://www.postgresql.org/docs/10/sql-analyze.html
@@ -119,5 +132,3 @@ them. The migration still occurs successfully.
 [upgrading-postgresql]: https://kb-managed.timescale.com/en/articles/5368016-perform-a-postgresql-major-version-upgrade
 [upgrading-postgresql-self-hosted]: /timescaledb/:currentVersion:/how-to-guides/upgrades/upgrade-pg/
 [upgrading-timescaledb]: /timescaledb/:currentVersion:/how-to-guides/upgrades/major-upgrade/
-
-

--- a/mst/restapi.md
+++ b/mst/restapi.md
@@ -2,7 +2,7 @@
 title: Using REST API in Managed Service for TimescaleDB
 excerpt: Use REST API in Managed Service for TimescaleDB for integration and automation
 product: mst
-keywords: [rest api]
+keywords: [REST API, API, integration]
 ---
 
 # Using REST API in Managed Service for TimescaleDB

--- a/promscale/backup-restore.md
+++ b/promscale/backup-restore.md
@@ -2,23 +2,23 @@
 title: Back up and restore Promscale
 excerpt: Learn how to back up and restore a Promscale database
 product: promscale
-keywords: [backup, restore]
+keywords: [backups, restore]
 ---
 
 # Back up and restore Promscale
 
 ## Prerequisites
 
-Trusted extensions were introduced in PostgreSQL 13. If using a PostgreSQL 
-version prior to 13, the database user used to perform the backup and restore 
-must have superuser access. If using version 13 and later, the database user 
+Trusted extensions were introduced in PostgreSQL 13. If using a PostgreSQL
+version prior to 13, the database user used to perform the backup and restore
+must have superuser access. If using version 13 and later, the database user
 must have the `CREATE` privilege on the database.
 
 ## Backup
 
-Assuming you use a database user that has appropriate privileges as listed 
-above, there is nothing special required to take a backup of the Promscale 
-database. There are many ways to backup a PostgreSQL database, the simplest 
+Assuming you use a database user that has appropriate privileges as listed
+above, there is nothing special required to take a backup of the Promscale
+database. There are many ways to backup a PostgreSQL database, the simplest
 being to use pg_dump with the plain format.
 
 For example:
@@ -26,20 +26,22 @@ For example:
 ```bash
 pg_dump -h localhost -p 5432 -U tsdbadmin -d mydb -F p -f dump.sql
 ```
+
 To backup larger databases use the custom format:
 
 ```bash
 pg_dump -h localhost -p 5432 -U tsdbadmin -d mydb -F c -f dump.dat
 ```
+
 ## Restore
 
-Starting with version 0.11.0 of the Promscale connector and 0.5.0 of the 
+Starting with version 0.11.0 of the Promscale connector and 0.5.0 of the
 Promscale extension, database objects are managed by the extension.
 
-If the timescaledb extension is not already installed in the target database, 
-install it. Then, put the timescaledb extension in restore mode. The promscale 
-extension must be created AFTER calling `public.timescaledb_pre_restore()` 
-during a restore. This signals the promscale extension to expect a restore and 
+If the timescaledb extension is not already installed in the target database,
+install it. Then, put the timescaledb extension in restore mode. The promscale
+extension must be created AFTER calling `public.timescaledb_pre_restore()`
+during a restore. This signals the promscale extension to expect a restore and
 create database objects accordingly.
 
 ```sql
@@ -55,17 +57,19 @@ the database with a command like below:
 ```bash
 psql -h localhost p 5432 -U tsdbadmin -d mydb -f dump.sql
 ```
+
 If you used `pg_dump` to backup in custom format, use `pg_restore`:
+
 ```bash
 pg_restore -Fc -d mydb dump.dat
 SELECT public.timescaledb_post_restore();
 ```
 
-Do not use the `-v ON_ERROR_STOP=1` option with the above command. Some 
+Do not use the `-v ON_ERROR_STOP=1` option with the above command. Some
 statements during the restore will fail. For example, pg_dump adds a statement
 to set the comment on the timescaledb extension (for example,
 `COMMENT ON EXTENSION promscale IS 'tables, types and functions supporting Promscale';`
-) which will fail. This is unfortunate, but unavoidable, expected, and does not impact 
+) which will fail. This is unfortunate, but unavoidable, expected, and does not impact
 the validity of the restored database.
 
 After the restore completes, run the following two commands to finalize the

--- a/promscale/guides/index.md
+++ b/promscale/guides/index.md
@@ -2,11 +2,12 @@
 title: How-to guides
 excerpt: Migrate, upgrade, and integrate Promscale
 product: promscale
-keywords: [migrate, upgrade]
+keywords: [migrate, upgrades]
 tags: [docker, kubernetes]
 ---
 
 # How-to Guides
+
 How-to guides for Promscale provide information related to tasks
 such as migrating, upgrading, integrating and others.
 

--- a/promscale/guides/index.md
+++ b/promscale/guides/index.md
@@ -2,7 +2,7 @@
 title: How-to guides
 excerpt: Migrate, upgrade, and integrate Promscale
 product: promscale
-keywords: [migrate, upgrades]
+keywords: [data migration, upgrades]
 tags: [docker, kubernetes]
 ---
 

--- a/promscale/guides/upgrade.md
+++ b/promscale/guides/upgrade.md
@@ -2,12 +2,13 @@
 title: Upgrade Promscale
 excerpt: Upgrade Promscale
 product: promscale
-keywords: [upgrade]
+keywords: [upgrades]
 related_pages:
   - /promscale/:currentVersion:/send-data/
 ---
 
 # Upgrade Promscale
+
 Promscale consists of the Promscale Connector, and the Promscale Database. The
 Promscale Database is PostgreSQL with the TimescaleDB and the Promscale
 extensions. When you upgrade your Promscale installation, you need to check both
@@ -25,6 +26,7 @@ You can upgrade your existing Promscale to Promscale `0.11.0`
 and from the previous [Alpine docker image][alpine-image].
 
 ## Upgrade to Promscale 0.11.0
+
 Promscale 0.11.0 contains significant changes, and the upgrade drops any
 previous tracing data you have stored. Make a backup of your installation, and
 test the new version, before you go ahead with this upgrade.
@@ -37,33 +39,41 @@ you might need to increase the PostgreSQL `max_locks_per_transaction` parameter
 before you start the upgrade. For more information, see [Transaction
 locks][transaction-locks].
 
-<highlight type="warning"> When you upgrade to Promscale 0.11.0, all previous
+<highlight type="warning">
+ When you upgrade to Promscale 0.11.0, all previous
 tracing data is dropped. Make a backup of your installation, and test the new
-version before you upgrade. </highlight>
+version before you upgrade. 
+</highlight>
 
 <procedure>
 
 ### Upgrading to Promscale 0.11.0
-To upgrade to Promscale 0.11.0 you must have installed PostgreSQL 12 or later,
-TimescaleDB 2.6.1 or later, and Promscale extension version 0.5.0 or later. 
 
-1. Check the version of PostgreSQL that is installed:
+To upgrade to Promscale 0.11.0 you must have installed PostgreSQL 12 or later,
+TimescaleDB 2.6.1 or later, and Promscale extension version 0.5.0 or later.
+
+1.  Check the version of PostgreSQL that is installed:
+
    ```sql
    SHOW server_version;
-   ``` 
-1. Check the version of TimescaleDB and Promscale that is installed:
+   ```
+
+1.  Check the version of TimescaleDB and Promscale that is installed:
+
    ```sql
    SELECT extname, extversion FROM pg_extension WHERE extname IN ('timescaledb', 'promscale');
    ```
+
    For information about upgrading TimescaleDB and PostgreSQL, see [Update TimescaleDB][update-timescaledb] and [Upgrade PostgreSQL][upgrade-postgresql].
-1. Stop all Promscale Connector instances connected to the database.
-1. Update the Promscale extension on one instance using the Promscale Connector.
+1.  Stop all Promscale Connector instances connected to the database.
+1.  Update the Promscale extension on one instance using the Promscale Connector.
    For more information, see the [Promscale installation
    instructions][install-promscale] for various installation method.
-   <highlight type="note"> Do not use the `ALTER EXTENSION promscale UPDATE;` command. to update the extension.
+   <highlight type="note">
+ Do not use the `ALTER EXTENSION promscale UPDATE;` command. to update the extension.
    </highlight>
-1. Start one instance with the latest version of the Promscale Connector. The migration happens automatically. After the migration is completed, upgrade the remaining Promscale Connector instances.
-1. Start the other instances of Promscale Connector.
+1.  Start one instance with the latest version of the Promscale Connector. The migration happens automatically. After the migration is completed, upgrade the remaining Promscale Connector instances.
+1.  Start the other instances of Promscale Connector.
 
 </procedure>
 
@@ -84,7 +94,8 @@ then upgrade. For more information about tuning this parameter, see
 [troubleshooting Promscale][max-locks-config].
 
 ## Upgrade from the previous alpine image
-You can upgrade from the previous alpine image on Docker or Kubernetes. 
+
+You can upgrade from the previous alpine image on Docker or Kubernetes.
 
 ### Upgrading from the previous alpine image on Docker
 
@@ -102,20 +113,21 @@ Migrating to Debian version can be a lengthy process and involves downtime.
 
 <procedure>
 
-1. Use `docker inspect` to determine the data volumes used by your database for the data directory.
-1. Shut down all Promscale Connectors.
-1. Shut down the original database Docker image, but make sure you preserve the volume mount
+1.  Use `docker inspect` to determine the data volumes used by your database for the data directory.
+1.  Shut down all Promscale Connectors.
+1.  Shut down the original database Docker image, but make sure you preserve the volume mount
    for the data directory. You need to mount this same directory in the new
    image.
-1. Change ownership of the data directory to the `postgres` user and group in
+1.  Change ownership of the data directory to the `postgres` user and group in
    the new image. For example:
 
    ```
    docker run -v <data_dir_volume_mount>:/var/lib/postgresql/data timescale/timescaledb-ha:pg14-latest chown -R postgres:postgres /var/lib/postgresql/data
    ```
-1. Start the new Docker container with the same volume mounts that the
+
+1.  Start the new Docker container with the same volume mounts that the
    original container used.
-1. Connect to the new database using psql and reindex all the collatable data. Use this query to reindex all the necessary indexes:
+1.  Connect to the new database using psql and reindex all the collatable data. Use this query to reindex all the necessary indexes:
 
    ```
      DO $$DECLARE r record;
@@ -130,31 +142,34 @@ Migrating to Debian version can be a lengthy process and involves downtime.
      END LOOP;
    END$$;
    ```
+
    This is necessary because the collation in the Alpine image is broken and so
    BTREE-based indexes remain incorrect until they are reindexed. It is
    extremely important to execute this step before ingesting new data to avoid
    data corruption. This process can take a long time depending on the indexed
    textual data in the database.  
 
-1. Restart the Promscale Connector
+1.  Restart the Promscale Connector
 
 </procedure>
 
 ## Upgrading from the previous alpine image on Kubernetes
+
 If you are using Kubernetes instead of plain Docker:
 
 <procedure>
 
-1. Shutdown the Promscale Connector pods
-1. Change the database pod to use the Debian Docker image.
-1. Restart the pod.
-1. Change ownership of the data directory to the `postgres` user and group in
+1.  Shutdown the Promscale Connector pods
+1.  Change the database pod to use the Debian Docker image.
+1.  Restart the pod.
+1.  Change ownership of the data directory to the `postgres` user and group in
    the new image by ssh into the database container. For example:
 
    ```
    chown -R postgres:postgres /var/lib/postgresql/data
    ```
-1. Connect to the new database using psql and reindex all the collatable data.
+
+1.  Connect to the new database using psql and reindex all the collatable data.
    Use this query to reindex all the necessary indexes:
 
    ```
@@ -170,7 +185,8 @@ If you are using Kubernetes instead of plain Docker:
      END LOOP;
    END$$;
    ```  
-1. Restart the Promscale Connector pods.
+
+1.  Restart the Promscale Connector pods.
 
 </procedure>
 

--- a/promscale/monitor.md
+++ b/promscale/monitor.md
@@ -2,14 +2,16 @@
 title: Monitor Promscale
 excerpt: Monitor Promscale with out-of-the-box alerts, runbooks, and dashboards
 product: promscale
-keywords: [Promtheus, alert, Alert Manager]
+keywords: [Prometheus, alert, Alert Manager]
 ---
 
 # Monitor Promscale
+
 Promscale includes a set of out-of-the-box alerts, runbooks, and a Grafana
 dashboard that you can use to monitor it.
 
-<highlight type="note"> To monitor Promscale, make sure that a Prometheus
+<highlight type="note">
+ To monitor Promscale, make sure that a Prometheus
 instance is scraping the Promscale HTTP metrics endpoint, which defaults to port `9201`
 port in the `/metrics` API. Use Prometheus to evaluate the Promscale alerting
 rules, and configure Prometheus as a data source in Grafana to visualize the
@@ -21,11 +23,12 @@ You don't want your monitoring tool monitoring itself.
 ## Dashboard
 
 The Grafana dashboard consists of Promscale metrics grouped in several rows:
-* Overview
-* Ingest
-* Query
-* Database
-* Cache
+
+*   Overview
+*   Ingest
+*   Query
+*   Database
+*   Cache
 
 <procedure>
 
@@ -43,7 +46,7 @@ Import the Promscale Grafana dashboard by following the instructions below
     `Load`. The `Importing dashboard from Grafana.com` page appears.
 1.  In  the `Folder` drop-down menu, choose the folder to which you want to add
     the dashboard..
-1.  Select the data source that corresponds to the Prometheus instance that you 
+1.  Select the data source that corresponds to the Prometheus instance that you
     are using to monitor Promcsale in the `Prometheus` drop-down.
 1.  Click `Import`.
 

--- a/promscale/send-data/opentelemetry.md
+++ b/promscale/send-data/opentelemetry.md
@@ -2,11 +2,12 @@
 title: Send OpenTelemetry data to Promscale
 excerpt: Send OpenTelemetry data to Promscale
 product: promscale
-keywords: [OpenTelmetry]
+keywords: [OpenTelemetry]
 tags: [configure, traces]
 ---
 
 # Send OpenTelemetry data to Promscale
+
 Promscale natively supports the OpenTelemetry Line Protocol (OTLP) for traces
 and Prometheus remote write protocol for metrics. You can send traces to
 Promscale using OTLP with any of the OpenTelemetry client SDKs, instrumentation
@@ -17,26 +18,28 @@ Collector. OpenTelemetry Collector converts OTLP metrics to Prometheus remote
 write protocol metrics.
 
 ## Send data using the OpenTelemetry Collector
+
 Although you can send data from OpenTelemetry instrumentation libraries and
 SDKs directly to Promscale using OTLP, we recommend that you use OpenTelemetry
 Collector in a production environment. OpenTelemetry Collector offers batch,
 queued retries, and many other functions that can be configured in the `Processors`.
 
 Set the following in OpenTelemetry Collector components in the configuration file:
-  * **Receivers**: to push or pull data into OpenTelemetry Collector using OTLP
+
+*   **Receivers**: to push or pull data into OpenTelemetry Collector using OTLP
     on gRPC and http endpoints.
-  * **Exporters**: to send data to one or more backends. OTLP to configure the
+*   **Exporters**: to send data to one or more backends. OTLP to configure the
     Promscale gRPC server to export the data to Promscale. Use `queue_size` to
     hold the data before dropping, and `timeout` to set the timeout for the
     write request to the backend. Prometheus remote write exports the OTLP
     metrics to the Prometheus remote storage backend. Configure the Promscale
-    http endpoint to ingest the metrics. 
-  * **Processors**: to run on data between being received and being exported.
+    http endpoint to ingest the metrics.
+*   **Processors**: to run on data between being received and being exported.
     Use the batch processor to batch, compress data, and control the number of
     outgoing connections. Configure the `send_max_batch_size` to set the maximum
     size of the batch, and `timeout` to set the time to send data. Promscale
     recommends 10 seconds.
-  * **Service**: to configure what components are enabled in the Collector based
+*   **Service**: to configure what components are enabled in the Collector based
     on the settings in the `receivers`, `processors`, `exporters`, and
     `extensions` sections. Pipelines to receive the traces and metrics from OTLP,
     batch process them, and export the data to OTLP gRPC and Prometheus remote-write
@@ -44,6 +47,7 @@ Set the following in OpenTelemetry Collector components in the configuration fil
 
 Use the following configuration to send traces from OpenTelemetry applications
 to the Collector and export them to Promscale.
+
 ```yaml
 receivers:
   otlp:
@@ -85,19 +89,21 @@ service:
       exporters: [prometheusremotewrite]
 ```
 
-Where: 
-* `<PROMSCALE_HOST>`: hostname of Promscale
-* `<gRPC_PORT>`: gRPC port of Promscale. The default port is 9202.  
-* `<HTTP_PORT>` : HTTP port of Promscale. The default port is 9201.
+Where:
+
+*   `<PROMSCALE_HOST>`: hostname of Promscale
+*   `<gRPC_PORT>`: gRPC port of Promscale. The default port is 9202.  
+*   `<HTTP_PORT>` : HTTP port of Promscale. The default port is 9201.
 
 If you are running the OTLP Collector and the Promscale Connector on a
 Kubernetes cluster the endpoint parameter is similar to `endpoint:
 "promscale-connector.default.svc.cluster.local:<PORT>"`
 
 The default ports exposed by the OpenTelemetry Collector OTLP receiver are:
-* `4317` : gRPC
-* `4318` : HTTP
-These are the ports where you should send your OpenTelemetry traces. 
+
+*   `4317` : gRPC
+*   `4318` : HTTP
+These are the ports where you should send your OpenTelemetry traces.
 
 ## Send data using OpenTelemetry Instrumentation SDKs
 

--- a/promscale/sql-api.md
+++ b/promscale/sql-api.md
@@ -2,7 +2,7 @@
 title: SQL functions API reference
 excerpt: Learn about all Promscale SQL API functions
 product: promscale
-keywords: [Structured Query Language, API, functions]
+keywords: [API]
 tags: [reference]
 ---
 
@@ -25,13 +25,15 @@ WHERE n.nspname OPERATOR(pg_catalog.~) '^(prom)$' COLLATE pg_catalog.default
 ORDER BY 1, 2, 4;
 -->
 ## General
+
 |Name|Arguments|Type|Description|
 |-|:-:|:-:|:-|
  |`add_prom_node`|node_name text, attach_to_existing_metrics DEFAULT true|boolean||
  |`config_maintenance_jobs`|number_jobs integer, new_schedule_interval interval, new_config jsonb DEFAULT NULL::jsonb|boolean|Configure the number of maintenance jobs run by the job scheduler, as well as their scheduled interval.|
  |`execute_maintenance`|||Execute maintenance tasks like dropping data according to retention policy. This procedure should be run regularly in a cron job.|
- 
+
 ## Labels
+
 |Name|Arguments|Type|Description|
 |-|:-:|:-:|:-|
  |`eq`|labels label_array, json_labels jsonb|boolean|eq returns true if the labels and jsonb are equal, ignoring the metric name.|
@@ -47,17 +49,18 @@ ORDER BY 1, 2, 4;
  |`val`|label_id integer|text|val returns the label value from a label id.|
 
 ## Metrics
+
 |Name|Arguments|Type|Description|
 |-|:-:|:-:|:-|
  |`drop_metric`|metric_name_to_be_dropped text|void||
  |`delete_series_from_metric`|metric_name text, series_ids|boolean|deletes the series from the metric.|
- |`get_default_metric_retention_period`||interval|Returns the current default retention period for metrics.|              
+ |`get_default_metric_retention_period`||interval|Returns the current default retention period for metrics.|
  |`get_metric_metadata`|metric_family_nametext|TABLE(metric_family text, type text, unit text, help text)|
  |`get_metric_retention_period`|metric_name text|interval|Returns the retention period configured for a specific metric.|
  |`get_multiple_metric_metadata`|metric_families text[]|TABLE(metric_family text, type text, unit text, help text)|
  |`is_normal_nan`|value double precision|boolean|is_normal_nan returns true if the value is a NaN.|
  |`is_stale_marker`|value double precision|boolean|is_stale_marker returns true if the value is a Prometheus stale marker.|
- |`register_metric_view`|schema_name text, view_name text, if_not_exists boolean|boolean|Register metric view with Promscale. This enables you to query the data with PromQL and set data retention policies through Promscale. Schema name and view name should be set to the desired schema and view you want to use. Note: underlying view needs to be based on an existing metric in Promscale (should use its table in the FROM clause).| 
+ |`register_metric_view`|schema_name text, view_name text, if_not_exists boolean|boolean|Register metric view with Promscale. This enables you to query the data with PromQL and set data retention policies through Promscale. Schema name and view name should be set to the desired schema and view you want to use. Note: underlying view needs to be based on an existing metric in Promscale (should use its table in the FROM clause).|
  |`reset_metric_chunk_interval`|metric_name text|boolean|reset_metric_chunk_interval resets the chunk interval for a specific metric to using the default.|
  |`reset_metric_compression_setting`|metric_name text|boolean|reset_metric_compression_setting resets the compression setting for a specific metric to using the default.|
  |`reset_metric_retention_period`|metric_name text|boolean|reset_metric_retention_period resets the retention period for a specific metric to using the default.|
@@ -68,4 +71,4 @@ ORDER BY 1, 2, 4;
  |`set_metric_chunk_interval`|metric_name text, chunk_interval interval|boolean|set_metric_chunk_interval set a chunk interval for a specific metric (this overrides the default).|
  |`set_metric_compression_setting`|metric_name text, new_compression_setting boolean|boolean|set_metric_compression_setting set a compression setting for a specific metric and this overrides the default.|
  |`set_metric_retention_period`|metric_name text, new_retention_period interval|boolean|set_metric_retention_period set a retention period for a specific metric (this overrides the default).|
- |`unregister_metric_view`|schema_name text, view_name text, if_not_exists boolean|boolean|Unregister metric view with Promscale. Schema name and view name should be set to the metric view already registered in Promscale.| 
+ |`unregister_metric_view`|schema_name text, view_name text, if_not_exists boolean|boolean|Unregister metric view with Promscale. Schema name and view name should be set to the metric view already registered in Promscale.|

--- a/promscale/tobs/about.md
+++ b/promscale/tobs/about.md
@@ -2,11 +2,12 @@
 title: About the observability stack (tobs) for Kubernetes
 excerpt: Install the observability stack for Kubernetes (tobs)
 product: promscale
-keywords: [tobs, Kubernetes, install]
+keywords: [tobs, Kubernetes, installation]
 tags: [k8s, monitor]
 ---
 
 # About the observability stack (tobs) for Kubernetes
+
 The observability stack (tobs) for Kubernetes is a tool that aims to make it
 simpler to install a full observability stack into a Kubernetes cluster.
 Currently this stack includes:
@@ -24,7 +25,7 @@ Currently this stack includes:
     long-term and allow analysis with both PromQL and SQL
 *   [TimescaleDB][timescaledb] for long term storage of metrics and provides
     ability to query metrics data using SQL
-*   [Opentelemetry-Operator][opentelemetry-operator] to manage the lifecycle of       
+*   [Opentelemetry-Operator][opentelemetry-operator] to manage the lifecycle of
     OpenTelemetryCollector Custom Resource Definition (CRDs)
 
 You can also use the tobs Helm chart directly, or as sub-charts for other

--- a/promscale/visualize-data/apm-experience.md
+++ b/promscale/visualize-data/apm-experience.md
@@ -2,43 +2,49 @@
 title: Application performance monitoring with traces
 excerpt: Application performance monitoring within Grafana using dashboards with SQL queries on traces
 product: promscale
-keywords: [Jaeger, APM]
+keywords: [Jaeger, monitor]
 tags: [configure, opentelemetry, traces]
 ---
 
 # Application performance monitoring (APM) with traces
-Promscale provides application performance monitoring with traces data using SQL. Import the 
+
+Promscale provides application performance monitoring with traces data using SQL. Import the
 Grafana dashboards that are published by the Promscale team using traces.
 
 Before you begin importing the dashboards:
 
-* Add these data sources in Grafana:
-    * [Jaeger data source][promscale-as-jaeger]
-    * [PostgreSQL data source][promscale-as-postgresql]  
-* Check that the `timescaledb_toolkit` extension is installed.
+*   Add these data sources in Grafana:
+    *   [Jaeger data source][promscale-as-jaeger]
+    *   [PostgreSQL data source][promscale-as-postgresql]  
+*   Check that the `timescaledb_toolkit` extension is installed.
   To verify if the extension is installed, run this SQL query:
-  `SELECT * FROM pg_extension WHERE extname='timescaledb_toolkit';` 
-  If the query returns no results, then the extension is not installed. For 
-  more information about installing the extension, see the 
+  `SELECT * FROM pg_extension WHERE extname='timescaledb_toolkit';`
+  If the query returns no results, then the extension is not installed. For
+  more information about installing the extension, see the
   [toolkit extension installation documentation][install-extension].
 
 You can use one of these methods to import dashboards:
-*  From the Grafana community the dashboards published by Promscale.
-*  From Promscale Github repository as JSON files.
+
+*   From the Grafana community the dashboards published by Promscale.
+*   From Promscale Github repository as JSON files.
 
 ## Install the TimescaleDB toolkit extension
 
-<procedure> 
+<procedure>
 
 ### Installing the TimescaleDB toolkit extension
-1. Check if the extension is available:
+
+1.  Check if the extension is available:
+
    ```sql
    SELECT * FROM pg_available_extensions WHERE name='timescaledb_toolkit';
    ```
+
      If the query returns no results, the extension is not available for installation
-     in your database. To make it available follow 
-     [these instructions][install-toolkit]. 
-1. Install the extension using:
+     in your database. To make it available follow
+     [these instructions][install-toolkit].
+1.  Install the extension using:
+
    ```sql
    CREATE EXTENSION timescaledb_toolkit;
    ```
@@ -46,14 +52,16 @@ You can use one of these methods to import dashboards:
 </procedure>
 
 ## Import dashboards from the Grafana community
+
 [Grafana community dashboards][promscale-grafana-dashboards] contain all the
-dashboards published by Promscale. 
+dashboards published by Promscale.
 
 <procedure>
 
 ### Importing dashboards from the Grafana community
-1.  In the [Grafana community dashboard][promscale-grafana-dashboards] select 
-    the dashboard with `APM` prefix, click the `Details` button to open a dashboard. 
+
+1.  In the [Grafana community dashboard][promscale-grafana-dashboards] select
+    the dashboard with `APM` prefix, click the `Details` button to open a dashboard.
 1.  Click `Copy ID to Clipboard` to copy the UID of the dashboard.
 1.  In the Grafana UI, select `Import` from the `+` Create icon on the side
     menu.
@@ -62,9 +70,9 @@ dashboards published by Promscale.
 1.  In  the `Folder` drop-down menu, choose the folder to which you want to add
     the dashboard.
 1.  Select the data sources from which you want the dashboard to query the data:
-    * For application performance monitoring dashboards select `TimescaleDB or PostgreSQL
+    *   For application performance monitoring dashboards select `TimescaleDB or PostgreSQL
       data source` as `Promscale-SQL`.
-    * For application performance monitoring dashboards, select `Promscale Jaeger Tracing data source`
+    *   For application performance monitoring dashboards, select `Promscale Jaeger Tracing data source`
       as `Promscale-Tracing`.
 1.  Click `Import`.
 
@@ -73,11 +81,12 @@ dashboards published by Promscale.
 ## Import dashboards as JSON files
 
 [Promscale dashboards][promscale-github-dashboards] repository contains all the
-dashboards published by Promscale. 
+dashboards published by Promscale.
 
 <procedure>
 
 ### Importing dashboards as JSON files
+
 1.  Download all the `.json` files with `apm` prefix from the
     [Promscale dashboards][promscale-github-dashboards] repository.
 1.  In the Grafana UI, select `Import` from the `+` Create icon on the side
@@ -87,16 +96,16 @@ dashboards published by Promscale.
 1.  In  the `Folder` drop-down menu, choose the folder to which you want to add
     the dashboard.
 1.  Select the data sources from which you want the dashboard to query the data:
-    * For application performance monitoring dashboards, select `TimescaleDB or PostgreSQL data source`
+    *   For application performance monitoring dashboards, select `TimescaleDB or PostgreSQL data source`
       as `Promscale-SQL`.
-    * For application performance monitoring dashboards, select `Promscale Jaeger Tracing data source`
+    *   For application performance monitoring dashboards, select `Promscale Jaeger Tracing data source`
       as `Promscale-Tracing`.
 1.  Click `Import`.
 
 </procedure>
 
 [promscale-grafana-dashboards]: https://grafana.com/orgs/promscale/dashboards
-[promscale-as-jaeger]: /promscale/:currentVersion:/visualize-data/grafana/#configure-promscale-as-jaeger-data-source 
+[promscale-as-jaeger]: /promscale/:currentVersion:/visualize-data/grafana/#configure-promscale-as-jaeger-data-source
 [promscale-as-postgresql]: /promscale/:currentVersion:/visualize-data/grafana/#configure-promscale-as-a-postgresql-data-source
 [install-toolkit]:/timescaledb/latest/how-to-guides/hyperfunctions/install-toolkit
 [promscale-github-dashboards]: https://github.com/timescale/promscale/tree/master/docs/mixin/dashboards

--- a/promscale/visualize-data/jaeger.md
+++ b/promscale/visualize-data/jaeger.md
@@ -3,39 +3,42 @@ title: Visualize Promscale traces in Jaeger
 excerpt: Jaeger to visualize data in Promscale
 product: promscale
 keywords: [Jaeger]
-tags: [configure, opentelemetry, traces]
+tags: [configure, opentelemetry, traces, integration]
 ---
 
 # Visualize Promscale traces in Jaeger
-Jaeger is an open source distributed tracing system used for monitoring and 
-troubleshooting microservices-based distributed systems. To visualize traces 
-stored in Promscale in Jaeger, you need to have the `jaeger-query` component 
-running. This Jaeger component queries and visualizes traces from Promscale. 
+
+Jaeger is an open source distributed tracing system used for monitoring and
+troubleshooting microservices-based distributed systems. To visualize traces
+stored in Promscale in Jaeger, you need to have the `jaeger-query` component
+running. This Jaeger component queries and visualizes traces from Promscale.
 
 This section shows you how to integrate [Jaeger][jaeger-ui] with Promscale.
 
-Before you begin, deploy the `jaeger-query` component from the Jaeger 
+Before you begin, deploy the `jaeger-query` component from the Jaeger
 [deployments page][jaeger-deployments]. Ensure that you are using `jaeger-query`
-version 1.30 or later. 
+version 1.30 or later.
 
 <procedure>
 
 ## Connecting Jaeger Query with Promscale
-    
-1.  Configure the `SPAN_STORAGE_TYPE`, and `GRPC_STORAGE_SERVER` options for `jaeger-query` using the environment variables: 
+
+1.  Configure the `SPAN_STORAGE_TYPE`, and `GRPC_STORAGE_SERVER` options for `jaeger-query` using the environment variables:
+
     ```
     SPAN_STORAGE_TYPE=grpc-plugin
     GRPC_STORAGE_SERVER=<PROMSCALE_HOST>:9202
     ```
+
     where: `<PROMSCALE_HOST>:9202` is the Promscale gRPC endpoint.
 
 1.  Start the `jaeger-query` component, it should be successfully connected with
-    Promscale to visualize the traces. 
+    Promscale to visualize the traces.
 
 </procedure>
 
 You can visualize traces from Promscale in `jaeger-query` home page. Use the
-`Search` panel on the left to filter and query traces from Promscale. 
+`Search` panel on the left to filter and query traces from Promscale.
 
 <img class="main-content__illustration"
 src="https://s3.amazonaws.com/assets.timescale.com/images/misc/jaeger-homepage-query-results.png"
@@ -43,22 +46,26 @@ alt="Sample output for Jaeger query results"/>
 
 ## Use Docker for setting up Jaeger Query with Promscale
 
-To set up `jaeger-query` with Promscale using Docker you need the IP address of the Promscale container or the URL. 
+To set up `jaeger-query` with Promscale using Docker you need the IP address of the Promscale container or the URL.
 
 You can find the IP address of the Promscale container using:
+
 ```bash
 docker inspect <PROMSCALE_CONTAINER_NAME>
 ```
+
 In the output, the IP address is listed under `NetworkSettings` → `Networks` → `IPAddress` section.
 
 You can set the URL as `<PROMSCALE>:9202` where:
-- `<PROMSCALE>` is the name of the container
-- `9202` is the gRPC port of Promscale
+*   `<PROMSCALE>` is the name of the container
+*   `9202` is the gRPC port of Promscale
 
 <procedure>
 
 ### Connecting Promscale and a Jaeger query
+
 1.  Run Jaeger query using the [official Docker image][jaeger-docker]:
+
     ``` bash
     docker run -d \
       -p 16686:16686 \
@@ -67,6 +74,7 @@ You can set the URL as `<PROMSCALE>:9202` where:
       -e "SPAN_STORAGE_TYPE=grpc-plugin" -e "GRPC_STORAGE_SERVER=<PROMSCALE>:9202" \
       jaegertracing/jaeger-query:1.30
     ```
+
 1.  Navigate to `localhost:16686` in your browser, to access the `jaeger-query` homepage.
 
 1.  Use the `Search` panel on the left to filter and start querying traces from

--- a/timescaledb/contribute-to-docs.md
+++ b/timescaledb/contribute-to-docs.md
@@ -1,7 +1,8 @@
 ---
 title: Contribute to TimescaleDB documentation
 excerpt: Advice and style guide for contributing to TimescaleDB documentation
-tags: [contribute, docs, style guide]
+keywords: [contribute]
+tags: [docs, style guide]
 ---
 
 # Contributing to Timescale documentation

--- a/timescaledb/contribute-to-timescaledb.md
+++ b/timescaledb/contribute-to-timescaledb.md
@@ -1,7 +1,8 @@
 ---
 title: Contribute to TimescaleDB
 excerpt: Learn more about how to contribute to TimescaleDB
-tags: [contribute, github]
+keywords: [contribute]
+tags: [github]
 ---
 
 # Contributing to TimescaleDB
@@ -18,12 +19,14 @@ find errors or would like to add content to our docs, this tutorial
 walks you through the process.
 
 ### Making minor changes
+
 If you want to make only minor changes to docs, you can make corrections
 and submit pull requests on the GitHub website. Go to the file you want to
 correct and click the 'pencil' icon to edit. Once done, GitHub gives you
 an option to submit a pull request at the bottom of the page.
 
 ### Making larger contributions to docs
+
 In order to modify documentation, you should have a working knowledge
 of [git][install-git] and [Markdown][markdown-tutorial]. You
 also need to create a GitHub account.
@@ -39,14 +42,14 @@ can ensure that the community is free and confident in its
 ability to use your contributions. You are prompted to sign the
 CLA during the pull request process.
 
-
 ## Contributing to TimescaleDB code
 
 Timescale appreciates any help the community can provide to make TimescaleDB better!
 
 There are multiple ways you can help:
- * Open an issue with a bug report, build issue, feature request, suggestion, etc.
- * Fork this repository and submit a pull request
+
+*   Open an issue with a bug report, build issue, feature request, suggestion, etc.
+*   Fork this repository and submit a pull request
 
 [Head over to our GitHub repository][github-timescaledb] for TimescaleDB to learn more about how you
 can help and to review our coding style guide!

--- a/timescaledb/how-to-guides/alerting.md
+++ b/timescaledb/how-to-guides/alerting.md
@@ -1,7 +1,7 @@
 ---
 title: Alerting
 excerpt: Set up alerting with TimescaleDB
-keywords: [alert, integration, Grafana, DataDog, Nagios, Zabbix]
+keywords: [alert, integration, Grafana, Datadog, Nagios, Zabbix]
 ---
 
 # Alerting
@@ -25,9 +25,9 @@ TimescaleDB works with a variety of alerting tools within the PostgreSQL ecosyst
 
 Some popular alerting tools that work with TimescaleDB include:
 
-- DataDog: get started [here][datadog-install]
-- Nagios: get started [here][nagios-install]
-- Zabbix: get started [here][zabbix-install]
+*   DataDog: get started [here][datadog-install]
+*   Nagios: get started [here][nagios-install]
+*   Zabbix: get started [here][zabbix-install]
 
 [Grafana-install]: https://grafana.com/get
 [PostgreSQL datasource]: https://grafana.com/docs/features/datasources/postgres/

--- a/timescaledb/how-to-guides/backup-and-restore/docker-and-wale.md
+++ b/timescaledb/how-to-guides/backup-and-restore/docker-and-wale.md
@@ -1,13 +1,14 @@
 ---
 title: Ongoing physical backups with Docker & WAL-E
 excerpt: Back up your Docker instance of TimescaleDB
-keywords: [backup, Docker]
+keywords: [backups, Docker]
 tags: [restore, recovery, physical backup]
 ---
 
 import DeprecationNotice from 'versionContent/_partials/_deprecated.mdx';
 
 # Ongoing physical backups with Docker & WAL-E
+
 When you run TimescaleDB in a containerized environment, you can use
 [continuous archiving][pg archiving] with a [WAL-E][wale official] container.
 These containers are sometimes referred to as sidecars, because they run
@@ -22,6 +23,7 @@ run it in an orchestration framework such as Kubernetes.
 <DeprecationNotice />
 
 ## Run the TimescaleDB container in Docker
+
 To make TimescaleDB use the WAL-E sidecar for archiving, the two containers need
 to share a network. To do this, you need to create a Docker  network and then
 launch TimescaleDB with archiving turned on, using the newly created network.
@@ -34,11 +36,15 @@ started TimescaleDB, you can log in and create tables and data.
 <procedure>
 
 ### Running the TimescaleDB container in Docker
+
 1.  Create the docker container:
+
     ```bash
     docker network create timescaledb-net
     ```
+
 1.  Launch TimescaleDB, with archiving turned on:
+
     ```bash
     docker run \
       --name timescaledb \
@@ -54,7 +60,9 @@ started TimescaleDB, you can log in and create tables and data.
       -ccheckpoint_timeout=700 \
       -cmax_wal_senders=1
     ```
+
 1.  Run TimescaleDB within Docker:
+
     ```bash
     docker exec -it timescaledb psql -U postgres
     ```
@@ -62,6 +70,7 @@ started TimescaleDB, you can log in and create tables and data.
 </procedure>
 
 ## Perform the backup using the WAL-E sidecar
+
 The [WAL-E Docker image][wale image] runs a web endpoint that accepts WAL-E
 commands across an HTTP API. This allows PostgreSQL to communicate with the
 WAL-E sidecar over the internal network to trigger archiving. You can also use
@@ -80,8 +89,10 @@ backups to `~/backups` on the Docker host.
 <procedure>
 
 ### Performing the backup using the WAL-E sidecar
+
 1.  Start the WAL-E container with the required information about the container.
     In this example, the container is called `timescaledb-wale`:
+
     ```bash
     docker run \
       --name wale \
@@ -97,13 +108,17 @@ backups to `~/backups` on the Docker host.
       -e WALE_FILE_PREFIX=file://localhost/backups \
       timescale/timescaledb-wale:latest
     ```
+
 1.  Start the backup:
+
     ```bash
     docker exec wale wal-e backup-push /var/lib/postgresql/data/pg_data
     ```
+
     Alternatively, you can start the backup using the sidecar's HTTP endpoint.
     This requires exposing the sidecar's port 80 on the Docker host by mapping
     it to an open port. In this example, we map it to port 8080:
+
     ```bash
     curl http://localhost:8080/backup-push
     ```
@@ -118,13 +133,16 @@ scheduling cron jobs that can invoke base backups using the WAL-E container's
 HTTP API.
 
 ## Recovery
+
 To recover the database instance from the backup archive, create a new
 TimescaleDB container, and restore the database and configuration files from the base backup. Then you can relaunch the sidecar and the database.
 
 <procedure>
 
 ### Restoring database files from backup
+
 1.  Create the docker container:
+
     ```bash
     docker create \
       --name timescaledb-recovered \
@@ -134,7 +152,9 @@ TimescaleDB container, and restore the database and configuration files from the
       -e PGDATA=/var/lib/postgresql/data/pg_data \
       timescale/timescaledb:latest-pg10 postgres
     ```
+
 1.  Restore the database files from the base backup:
+
     ```bash
     docker run -it --rm \
       -v ~/backups:/backups \
@@ -144,7 +164,9 @@ TimescaleDB container, and restore the database and configuration files from the
       timescale/timescaledb-wale:latest \wal-e \
       backup-fetch /var/lib/postgresql/data/pg_data LATEST
     ```
+
 1.  Recreate the configuration files. These are backed up from the original database instance:
+
     ```bash
     docker run -it --rm  \
       --volumes-from timescaledb-recovered \
@@ -163,7 +185,9 @@ TimescaleDB container, and restore the database and configuration files from the
 
     sh -c 'echo "local all postgres trust" > /var/lib/postgresql/data/pg_data/pg_hba.conf'
     ```
+
 1.  Create a `recovery.conf` file that tells PostgreSQL how to recover:
+
     ```bash
     docker run -it --rm  \
       --volumes-from timescaledb-recovered \
@@ -183,7 +207,9 @@ database, and check that recovery was successful.
 <procedure>
 
 ### Relaunch the recovered database
+
 1.  Relaunch the WAL-E sidecar:
+
     ```bash
     docker run \
       --name wale \
@@ -199,14 +225,19 @@ database, and check that recovery was successful.
       -e WALE_FILE_PREFIX=file://localhost/backups \
       timescale/timescaledb-wale:latest
     ```
+
 1.  Relaunch the TimescaleDB docker container:
+
     ```bash
     docker start timescaledb-recovered
     ```
+
 1.  Verify that the database started up and recovered successfully:
+
     ```bash
     docker logs timescaledb-recovered
     ```
+
     Don't worry if you see some archive recovery errors in the log at this
     stage. This happens because the recovery is not completely finalized until
     no more files can be found in the archive. See the PostgreSQL documentation

--- a/timescaledb/how-to-guides/backup-and-restore/index.md
+++ b/timescaledb/how-to-guides/backup-and-restore/index.md
@@ -1,7 +1,7 @@
 ---
 title: Backup and restore
 excerpt: Learn how to back up and restore your TimescaleDB instance
-keywords: [backup, restore]
+keywords: [backups, restore]
 tags: [recovery]
 ---
 
@@ -11,9 +11,9 @@ TimescaleDB takes advantage of the reliable backup and restore functionality
 provided by PostgreSQL. There are a few different mechanisms you can use to
 backup your self-hosted TimescaleDB database:
 
-- Logical backups with [pg_dump and pg_restore][logical-backups].
-- [Physical backups][physical-backups] with `pg_basebackup` or another tool.
-- _DEPRECATED_ [Ongoing physical backups][ongoing-physical-backups] using write-ahead log
+*   Logical backups with [pg_dump and pg_restore][logical-backups].
+*   [Physical backups][physical-backups] with `pg_basebackup` or another tool.
+*   _DEPRECATED_ [Ongoing physical backups][ongoing-physical-backups] using write-ahead log
   (WAL) archiving.
 
 <highlight type="cloud" header="Forget about manually creating and maintaining backups" button="Try for free">
@@ -22,7 +22,6 @@ you might find the automatic backups on Timescale Cloud useful. In addition to a
 the platform also handles automatic restore from backups with no user action required.
 [Learn more](https://docs.timescale.com/cloud/latest/backup-restore-cloud/) about backup
 and restore in Timescale Cloud or [test it out yourself](http://tsdb.co/cloud-signup) with a free trial.
-
 </highlight>
 
 [logical-backups]: /timescaledb/:currentVersion:/how-to-guides/backup-and-restore/pg-dump-and-restore/

--- a/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
+++ b/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
@@ -1,7 +1,7 @@
 ---
 title: Logical backups with pg_dump and pg_restore
 excerpt: Back up and restore a hypertable or entire database with native PostgreSQL commands
-keywords: [backup, restore]
+keywords: [backups, restore]
 tags: [recovery, logical backup, pg_dump, pg_restore]
 ---
 

--- a/timescaledb/how-to-guides/backup-and-restore/physical.md
+++ b/timescaledb/how-to-guides/backup-and-restore/physical.md
@@ -1,7 +1,7 @@
 ---
 title: Physical backups
 excerpt: How to take physical backups of your TimescaleDB instance
-keywords: [backup]
+keywords: [backups]
 tags: [restore, recovery, physical backup]
 ---
 

--- a/timescaledb/how-to-guides/compression/backfill-historical-data.md
+++ b/timescaledb/how-to-guides/compression/backfill-historical-data.md
@@ -1,7 +1,7 @@
 ---
 title: Backfill historical data on compressed chunks
 excerpt: How to backfill a batch of historical data on a compressed hypertable
-keywords: [compression, backfill, hypertables]
+keywords: [compression, backfilling, hypertables]
 ---
 
 # Backfill historical data on compressed chunks
@@ -28,8 +28,8 @@ truncating your table in preparation for the next backfill.
 
 ## Backfill with a supplied function
 
-To make backfilling easier, you can use the 
-[backfilling functions][timescaledb-extras-backfill] in the 
+To make backfilling easier, you can use the
+[backfilling functions][timescaledb-extras-backfill] in the
 [TimescaleDB extras][timescaledb-extras] GitHub repository. In particular, the
 `decompress_backfill` procedure automates many of the backfilling steps for you.
 

--- a/timescaledb/how-to-guides/compression/decompress-chunks.md
+++ b/timescaledb/how-to-guides/compression/decompress-chunks.md
@@ -1,7 +1,7 @@
 ---
 title: Decompression
 excerpt: How to decompress a compressed chunk
-keywords: [compression, hypertables]
+keywords: [compression, hypertables, backfilling]
 tags: [decompression]
 ---
 

--- a/timescaledb/how-to-guides/configuration/postgres-config.md
+++ b/timescaledb/how-to-guides/configuration/postgres-config.md
@@ -1,11 +1,12 @@
 ---
 title: Manual PostgreSQL configuration and tuning
 excerpt: How to manually configure your PostgreSQL instance
-keywords: [configuration]
+keywords: [configuration, settings]
 tags: [tune]
 ---
 
 # Manual PostgreSQL configuration and tuning
+
 If you prefer to tune settings yourself, or for settings not covered by `timescaledb-tune`, you can manually configure your installation using the PostgreSQL configuration file.
 
 For some common configuration settings you might want to adjust, see the
@@ -15,6 +16,7 @@ For more information about the PostgreSQL configuration page, see the
 [PostgreSQL documentation][pg-config].
 
 ## Editing the PostgreSQL configuration file
+
 The location of the PostgreSQL configuration file depends on your operating
 system and installation. You can find the location by querying the database as
 the `postgres` user, from the psql prompt:
@@ -32,6 +34,7 @@ receives a `SIGHUP` signal, or you can manually reload the file uses the
 `pg_ctl` command.
 
 ## Setting parameters at the command prompt
+
 If you don't want to open the configuration file to make changes, you can also
 set parameters directly from the command prompt, using the `postgres` command.
 For example:

--- a/timescaledb/how-to-guides/distributed-hypertables/alter-drop-distributed-hypertables.md
+++ b/timescaledb/how-to-guides/distributed-hypertables/alter-drop-distributed-hypertables.md
@@ -1,7 +1,7 @@
 ---
 title: Alter and drop distributed hypertables
 excerpt: How to alter and drop distributed hypertables
-keywords: [distributed hypertables, alter, drop]
+keywords: [distributed hypertables, alter, delete]
 tags: [change, delete]
 ---
 

--- a/timescaledb/how-to-guides/hyperfunctions/gapfilling-interpolation.md
+++ b/timescaledb/how-to-guides/hyperfunctions/gapfilling-interpolation.md
@@ -1,10 +1,11 @@
 ---
 title: Gapfilling and interpolation
 excerpt: Fill gaps in time-series data
-keywords: [hyperfunctions, Toolkit, gapfill, interpolate]
+keywords: [hyperfunctions, Toolkit, gapfilling, interpolate]
 ---
 
 # Gapfilling and interpolation
+
 Most time-series data analysis techniques aggregate data into fixed time
 intervals, which smooths the data and makes it easier to interpret and analyze.
 When you write queries for data in this form, you need an efficient way to

--- a/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
+++ b/timescaledb/how-to-guides/hyperfunctions/install-toolkit.md
@@ -1,7 +1,7 @@
 ---
 title: Install and update TimescaleDB Toolkit
 excerpt: How to install TimescaleDB Toolkit to access more hyperfunctions and function pipelines
-keywords: [Toolkit, install, hyperfunctions, function pipelines]
+keywords: [Toolkit, installation, hyperfunctions, function pipelines]
 ---
 
 # Install and update TimescaleDB Toolkit

--- a/timescaledb/how-to-guides/hyperfunctions/locf.md
+++ b/timescaledb/how-to-guides/hyperfunctions/locf.md
@@ -1,10 +1,11 @@
 ---
 title: Last observation carried forward
 excerpt: Fill gaps in your data by carrying the last observation forward
-keywords: [hyperfunctions, Toolkit, gapfill, interpolate, locf]
+keywords: [hyperfunctions, Toolkit, gapfilling, interpolate, locf]
 ---
 
 # Last observation carried forward
+
 Last observation carried forward (LOCF) is a form of linear interpolation used
 to fill gaps in your data. It takes the last known value and uses it as a
 replacement for the missing data.

--- a/timescaledb/how-to-guides/hyperfunctions/stats-aggs.md
+++ b/timescaledb/how-to-guides/hyperfunctions/stats-aggs.md
@@ -1,7 +1,7 @@
 ---
 title: Statistical aggregation
 excerpt: Aggregate data to perform common statistical calculations in continuous aggregates and window functions
-keywords: [hyperfunctions, Toolkit, statistics, statistical aggregates]
+keywords: [hyperfunctions, Toolkit, statistics]
 ---
 
 # Statistical aggregation

--- a/timescaledb/how-to-guides/hyperfunctions/time-bucket-gapfill.md
+++ b/timescaledb/how-to-guides/hyperfunctions/time-bucket-gapfill.md
@@ -1,10 +1,11 @@
 ---
 title: Time bucket gapfill
 excerpt: Fill in gaps within your time-series data when calculating time buckets
-keywords: [hyperfunctions, Toolkit, gapfill, interpolate]
+keywords: [hyperfunctions, Toolkit, gapfilling, interpolate]
 ---
 
 # Time bucket gapfill
+
 Sometimes data sorted into time buckets can have gaps. This can happen if you
 have irregular sampling intervals, or you have experienced an outage of some
 sort. If you have a time bucket that has no data at all, the average returned

--- a/timescaledb/how-to-guides/hypertables/drop.md
+++ b/timescaledb/how-to-guides/hypertables/drop.md
@@ -1,13 +1,15 @@
 ---
 title: Drop a hypertable
 excerpt: Delete a hypertable from your database
-keywords: [hypertables, drop]
+keywords: [hypertables, delete]
 tags: [delete]
 ---
 
 # Drop a hypertable
+
 Drop a hypertable using a standard PostgreSQL [`DROP TABLE`][postgres-droptable]
 command. This works for both regular and distributed hypertables:
+
 ```sql
 DROP TABLE <TABLE_NAME>;
 ```

--- a/timescaledb/how-to-guides/migrate-data/about-migrate-data.md
+++ b/timescaledb/how-to-guides/migrate-data/about-migrate-data.md
@@ -1,11 +1,12 @@
 ---
 title: About data migration
 excerpt: Learn how to migrate your data into TimescaleDB
-keywords: [migrate]
+keywords: [data migration]
 tags: [csv, import]
 ---
 
 # About data migration
+
 You can migrate your existing data into TimescaleDB.
 
 *   For data stored in PostgreSQL, see instructions for:
@@ -23,6 +24,7 @@ You can also migrate data between TimescaleDB instances. See instructions for
 a self-hosted database.
 
 ## Considerations for data migration
+
 For a successful migration, your destination database must have enough free disk
 space. In most cases, you need disk space of at least 1.5 times the size of the
 original data and any indexes. If your migration method requires decompression,

--- a/timescaledb/how-to-guides/migrate-data/different-db.md
+++ b/timescaledb/how-to-guides/migrate-data/different-db.md
@@ -1,11 +1,12 @@
 ---
 title: Migrating data to TimescaleDB from a different PostgreSQL database
 excerpt: How to migrate your data into TimescaleDB from a different PostgreSQL database
-keywords: [migrate, PostgreSQL]
+keywords: [data migration, PostgreSQL]
 tags: [import]
 ---
 
 # Migrating data to TimescaleDB from a different PostgreSQL database
+
 You can migrate your data into TimescaleDB from a different PostgreSQL database.
 
 <highlight type="note">
@@ -18,9 +19,9 @@ database to Cloud](https://docs.timescale.com/cloud/latest/migrate-to-cloud/).
 
 Before you begin, check that you have:
 
-- [Installed and set up TimescaleDB][install] within your PostgreSQL instance
-- Installed the PostgreSQL [`pg_dump`][pg_dump] utility
-- Installed a client for connecting to PostgreSQL. These instructions use
+*   [Installed and set up TimescaleDB][install] within your PostgreSQL instance
+*   Installed the PostgreSQL [`pg_dump`][pg_dump] utility
+*   Installed a client for connecting to PostgreSQL. These instructions use
   `psql`, but any client works.
 
 ## Migrate your data into TimescaleDB
@@ -34,17 +35,20 @@ Migrate your data into TimescaleDB from a different PostgreSQL database.
 1.  Copy the database schema from your source database into a backup file named
     `source_db.bak`. This file contains the SQL commands to recreate all the
     tables in your source database.
+
     ```bash
     pg_dump --schema-only -f source_db.bak <SOURCE_DB_NAME>
     ```
 
 1.  Recreate these tables in your destination database by copying out of the
     `source_db.bak` file.
+
     ```bash
     psql -d <DESTINATION_DB_NAME> < source_db.bak
     ```
 
 1.  Connect to your destination database.
+
     ```bash
     psql -d <DESTINATION_DB_NAME>
     ```
@@ -53,14 +57,17 @@ Migrate your data into TimescaleDB from a different PostgreSQL database.
     [`create_hypertable`][create_hypertable] function. This function must be run
     on a table while it's empty. For example, for a time-series table named
     `conditions` that uses `time` as its time partitioning column, run:
+
     ```sql
     \SELECT create_hypertable('conditions', 'time');
     ```
 
 1.  Copy the data from your source database table into a `.csv`.
+
     ```bash
     psql -d <SOURCE_DB_NAME> -c "\COPY (SELECT * FROM <TABLE_NAME>) TO <FILENAME>.csv DELIMITER ',' CSV"
     ```
+
     Repeat for any other tables in your database.
 
 1.  Insert the data from the `.csv` into your destination database's

--- a/timescaledb/how-to-guides/migrate-data/import-csv.md
+++ b/timescaledb/how-to-guides/migrate-data/import-csv.md
@@ -1,18 +1,21 @@
 ---
 title: Import data into TimescaleDB from .csv
 excerpt: Import data into your TimescaleDB instance from an external .csv file
-keywords: [migrate]
+keywords: [data migration]
 tags: [import, csv]
 ---
 
 # Import data into TimescaleDB from .csv
+
 If you have data stored in an external `.csv` file, you can import it into TimescaleDB.
 
 ## Prerequisites
+
 Before beginning, make sure you have [installed and set up][install] TimescaleDB
 within your PostgreSQL instance.
 
 ## Import data
+
 Import data from a `csv`.
 
 <procedure>
@@ -20,17 +23,18 @@ Import data from a `csv`.
 ### Importing data
 
 <highlight type="note">
-Timescale provides an open source 
+Timescale provides an open source
 [parallel importer](https://github.com/timescale/timescaledb-parallel-copy) program,
 `timescaledb-parallel-copy`, to speed up data copying. The program parallelizes
 migration by using several workers to run multiple `COPY`s concurrently. It also
 offers options to improve the copying experience. If you prefer not to download
-`timescaledb-parallel-copy`, you can also use regular PostgreSQL `COPY`. 
+`timescaledb-parallel-copy`, you can also use regular PostgreSQL `COPY`.
 </highlight>
 
 1.  Connect to your database and create a new empty table. Use a schema that
     matches the data in your `.csv` file. In this example, the `.csv` file
     contains the columns `time`, `location`, and `temperature`.
+
     ```sql
     CREATE TABLE <TABLE_NAME> (
         ts        TIMESTAMPTZ           NOT NULL,
@@ -38,22 +42,28 @@ offers options to improve the copying experience. If you prefer not to download
         temperature DOUBLE PRECISION    NULL
     );
     ```
+
 1.  Convert the empty table to a hypertable using the
     [`create_hypertable`][create_hypertable] function. Replace `ts` with the
     name of the column storing time values in your table.
+
     ```sql
     SELECT create_hypertable('<TABLE_NAME>', 'ts')
     ```
+
 1.  At the command line, insert data into the hypertable from your `csv`. Use
     `timescaledb-parallel-copy` to speed up migration. Adjust the number of
     workers as desired. Alternatively see the next step.
+
     ```bash
     timescaledb-parallel-copy --db-name <DATABASE_NAME> --table <TABLE_NAME> \
         --file <FILENAME>.csv --workers 4 --copy-options "CSV"
-    ``` 
+    ```
+
 1.  **OPTIONAL** If you don't want to use `timescaledb-parallel-copy`,
     insert data into the hypertable by using PostgreSQL's native `COPY`command.
     At the command line, run:
+
     ```bash
     psql -d <DATABASE_NAME> -c "\COPY <TABLE_NAME> FROM <FILENAME>.csv CSV"
     ```

--- a/timescaledb/how-to-guides/migrate-data/index.md
+++ b/timescaledb/how-to-guides/migrate-data/index.md
@@ -1,11 +1,12 @@
 ---
 title: Data migration
 excerpt: Migrate your existing data into TimescaleDB
-keywords: [migrate]
+keywords: [data migration]
 tags: [import]
 ---
 
 # Data migration
+
 You can migrate your existing data into TimescaleDB in several ways.
 
 *   [Learn about data migration][about-data-migration] before you start

--- a/timescaledb/how-to-guides/migrate-data/migrate-influxdb.md
+++ b/timescaledb/how-to-guides/migrate-data/migrate-influxdb.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate data to TimescaleDB from InfluxDB
 excerpt: Mgirate data into TimescaleDB using the Outflux tool
-keywords: [migrate, InfluxDB]
+keywords: [data migration, InfluxDB]
 tags: [import, Outflux]
 ---
 

--- a/timescaledb/how-to-guides/migrate-data/same-db.md
+++ b/timescaledb/how-to-guides/migrate-data/same-db.md
@@ -1,17 +1,19 @@
 ---
 title: Migrate data to TimescaleDB from the same PostgreSQL instance
 excerpt: Migrate data into a TimescaleDB hypertable from a regular PostgreSQL table
-keywords: [migrate, PostgreSQL]
+keywords: [data migration, PostgreSQL]
 tags: [import]
 ---
 
 # Migrate data to TimescaleDB from the same PostgreSQL instance
+
 You can migrate data into a TimescaleDB hypertable from a regular PostgreSQL
 table. This method assumes that you have TimescaleDB set up in the same database
 instance as your existing table. To migrate between PostgreSQL instances, see
 the instructions for [migrating data from a different database][different-db].
 
 ## Prerequisites
+
 Before beginning, make sure you have [installed and set up][install] TimescaleDB
 within your PostgreSQL instance.
 
@@ -21,17 +23,19 @@ example also names the destination table `new_table`, but you might want to use
 a more descriptive name.
 
 ## Migrate data
+
 Migrate your data into TimescaleDB from within the same database.
 
 <procedure>
 
 ## Migrating data
+
 1.  Create a new table based on your existing table. You can create your indexes
     at the same time, so you don't have to recreate them manually. Or you can
     create the table without indexes, which makes data migration faster.
 
     <terminal>
-    
+
     <tab label="With indexes">
 
     ```bash
@@ -41,7 +45,7 @@ Migrate your data into TimescaleDB from within the same database.
     ```
 
     </tab>
-    
+
     <tab label="Without indexes">
 
     ```bash
@@ -57,19 +61,24 @@ Migrate your data into TimescaleDB from within the same database.
 1.  Convert the new table to a hypertable using the
     [`create_hypertable`][create_hypertable] function. Replace `ts` with the
     name of the column that holds time values in your table.
+
     ```sql
     SELECT create_hypertable('new_table', 'ts');
     ```
+
 1.  Insert data from the old table to the new table.
+
     ```sql
     INSERT INTO new_table
       SELECT * FROM old_table;
     ```
+
 1.  If you created your new table without indexes, recreate your indexes now.
 
 </procedure>
 
 ## Troubleshooting
+
 If you have unique or primary indexes on your old table, you might get an error
 about indexes and partitioning. See the [hypertables and unique indexes
 section][unique-indexes] section for more information.

--- a/timescaledb/how-to-guides/replication-and-ha/about-ha.md
+++ b/timescaledb/how-to-guides/replication-and-ha/about-ha.md
@@ -1,11 +1,12 @@
 ---
 title: High availability
 excerpt: Strategies for increasing redundancy and resilience of your database
-keywords: [high availability, backup, replicas, failover]
+keywords: [high availability, backups, replicas, failover]
 tags: [redundancy]
 ---
 
 # High availability (HA)
+
 High availability (HA) is achieved by increasing redundancy and
 resilience. To increase redundancy, parts of the system are replicated, so that
 they are on standby in the event of a failure. To increase resilience, recovery
@@ -13,15 +14,16 @@ processes switch between these standby resources as quickly as possible.
 
 <highlight type="cloud" button="Try Timescale Cloud for free" header="Enable high availability in one click">
 Timescale Cloud simplifies the process of configuring and maintaining high availability for your databases.
-You can create replicas with a single click and enjoy automatic recovery and fail-over for all your 
-replicated instances (including multiple availability zones). 
-[Learn more](https://docs.timescale.com/cloud/latest/service-operations/replicas/#create-a-database-replica) 
+You can create replicas with a single click and enjoy automatic recovery and fail-over for all your
+replicated instances (including multiple availability zones).
+[Learn more](https://docs.timescale.com/cloud/latest/service-operations/replicas/#create-a-database-replica)
 about HA replicas on Timescale Cloud.
 </highlight>
 
 ## Backups
+
 For some systems, recovering from backup alone can be a suitable availability
-strategy. 
+strategy.
 
 For more information about backups in self-hosted TimescaleDB, see the
 [backup and restore section][db-backup] in the TimescaleDB documentation.
@@ -30,17 +32,20 @@ For more information about backups in Timescale Cloud, see
 the [backup and restore section][cloud-backup] in the Cloud documentation.
 
 ## Storage redundancy
+
 Storage redundancy refers to having multiple copies of a database's data files.
 If the storage currently attached to a PostgreSQL instance corrupts or otherwise
 becomes unavailable, the system can replace its current storage with one of the
-copies. 
+copies.
 
 ## Instance redundancy
+
 Instance redundancy refers to having replicas of your database running
 simultaneously. In the case of a database failure, a replica is an up-to-date,
 running database that can take over immediately.
 
 ## Zonal redundancy
+
 While the public cloud is highly reliable, entire portions of the cloud can be
 unavailable at times. Timescale Cloud does not protect against Availability Zone
 failures unless the user is using HA replicas. We do not currently offer
@@ -50,6 +55,7 @@ For more information about HA replicas in Timescale Cloud, see
 the [high availability section][cloud-ha] in the Cloud documentation.
 
 ## Replication
+
 TimescaleDB supports replication using PostgreSQL's built-in
 [streaming replication][postgres-streaming-replication-docs]. Using
 [logical replication][postgres-logrep-docs] with TimescaleDB is not recommended,
@@ -65,6 +71,7 @@ Logging, see their
 [WAL Documentation](https://www.postgresql.org/docs/current/static/wal-intro.html).
 
 ## Failover
+
 PostgreSQL offers failover functionality where a replica is promoted to primary
 in the event of a failure on the primary. This is done using
 [pg_ctl][pgctl-docs] or the `trigger_file`, but it does not provide

--- a/timescaledb/how-to-guides/upgrades/about-upgrades.md
+++ b/timescaledb/how-to-guides/upgrades/about-upgrades.md
@@ -1,12 +1,13 @@
 ---
 title: About upgrades
 excerpt: About major and minor upgrades, and best practices for upgrading
-keywords: [upgrade]
+keywords: [upgrades]
 ---
 
 import PlanUpgrade from 'versionContent/_partials/_plan_upgrade.mdx';
 
 # About upgrades
+
 A major upgrade is when you upgrade from one major version of TimescaleDB, to
 the next major version. For example, when you upgrade from TimescaleDB&nbsp;1
 to TimescaleDB&nbsp;2.
@@ -28,9 +29,11 @@ about automatic version upgrades in Timescale Cloud.
 </highlight>
 
 ## Plan your upgrade
+
 <PlanUpgrade />
 
 ## Check your version
+
 You can check which version of TimescaleDB you are running, at the psql command
 prompt. Use this to check which version you are running before you begin your
 upgrade, and again after your upgrade is complete:

--- a/timescaledb/how-to-guides/upgrades/downgrade.md
+++ b/timescaledb/how-to-guides/upgrades/downgrade.md
@@ -1,10 +1,11 @@
 ---
 title: Downgrade to a previous version of TimescaleDB
 excerpt: Roll back to an older version of TimescaleDB
-keywords: [upgrade]
+keywords: [upgrades]
 ---
 
 # Downgrade to a previous version of TimescaleDB
+
 If you upgrade to a new TimescaleDB version and encounter problems, you can roll
 back to a previously installed version. This works in the same way as a minor
 upgrade.
@@ -16,23 +17,25 @@ example, you can downgrade from TimescaleDB 2.5.2 to 2.5.1, or from 2.5.0 to
 [release notes][relnotes].
 
 ## Plan your downgrade
+
 You can downgrade your on-premise TimescaleDB installation in-place. This means
 that you do not need to dump and restore your data. However, it is still
 important that you plan for your downgrade ahead of time.
 
 Before you downgrade:
 
-* Read [the release notes][relnotes] for the TimescaleDB version you are
+*   Read [the release notes][relnotes] for the TimescaleDB version you are
   downgrading to.
-* Check which PostgreSQL version you are currently running. You might need to
+*   Check which PostgreSQL version you are currently running. You might need to
   [upgrade to the latest PostgreSQL version][upgrade-pg]
   before you begin your TimescaleDB downgrade.
-* [Perform a backup][backup] of your database. While TimescaleDB
+*   [Perform a backup][backup] of your database. While TimescaleDB
   downgrades are performed in-place, downgrading is an intrusive operation.
   Always make sure you have a backup on hand, and that the backup is readable in
   the case of disaster.
 
 ## Downgrade TimescaleDB to a previous minor version
+
 This downgrade uses the PostgreSQL `ALTER EXTENSION` function to downgrade to
 the latest version of the TimescaleDB extension. TimescaleDB supports having
 different extension versions on different databases within the same PostgreSQL
@@ -51,10 +54,10 @@ upgrading and downgrading.
 
 ### Downgrading the TimescaleDB extension
 
-1. Connect to psql using the `-X` flag. This prevents any `.psqlrc` commands
+1.  Connect to psql using the `-X` flag. This prevents any `.psqlrc` commands
    from accidentally triggering the load of a previous TimescaleDB version on
    session startup.
-1. At the psql prompt, downgrade the TimescaleDB extension. This must be the
+1.  At the psql prompt, downgrade the TimescaleDB extension. This must be the
    first command you execute in the current session:
 
     ```sql
@@ -62,11 +65,12 @@ upgrading and downgrading.
     ```
 
     For example:
+
     ```sql
     ALTER EXTENSION timescaledb UPDATE TO '2.5.1';
     ```
 
-1. Check that you have downgraded to the correct version of the extension with
+1.  Check that you have downgraded to the correct version of the extension with
    the `\dx` command. The output should show the downgraded version number.
 
     ```sql

--- a/timescaledb/how-to-guides/upgrades/index.md
+++ b/timescaledb/how-to-guides/upgrades/index.md
@@ -1,10 +1,11 @@
 ---
 title: Upgrade TimescaleDB
 excerpt: Upgrade your self-hosted TimescaleDB installation in-place
-keywords: [upgrade]
+keywords: [upgrades]
 ---
 
 # Upgrade TimescaleDB
+
 You can upgrade your on-premise TimescaleDB installation in-place.
 
 A major upgrade is when you upgrade from one major version of TimescaleDB, to

--- a/timescaledb/how-to-guides/upgrades/major-upgrade.md
+++ b/timescaledb/how-to-guides/upgrades/major-upgrade.md
@@ -1,12 +1,13 @@
 ---
 title: Major TimescaleDB upgrades
 excerpt: Upgrade from one major of TimescaleDB to the next major version
-keywords: [upgrade]
+keywords: [upgrades]
 ---
 
 import PlanUpgrade from 'versionContent/_partials/_plan_upgrade.mdx';
 
 # Major TimescaleDB upgrades
+
 A major upgrade is when you upgrade from one major version of TimescaleDB, to
 the next major version. For example, when you upgrade from TimescaleDB&nbsp;1,
 to TimescaleDB&nbsp;2.
@@ -16,6 +17,7 @@ TimescaleDB&nbsp;2.5 to TimescaleDB&nbsp;2.6, see the
 [minor upgrades section][upgrade-minor].
 
 ## Plan your upgrade
+
 <PlanUpgrade />
 
 Additionally, before you begin this major upgrade, read the
@@ -25,6 +27,7 @@ TimescaleDB&nbsp;2. It also includes information about how these major changes
 impact the way your applications and scripts interact with the TimescaleDB API.
 
 ## Breaking changes
+
 When you upgrade from TimescaleDB&nbsp;1, to TimescaleDB&nbsp;2, scripts
 automatically configure updated features to work as expected with the new
 version. However, not everything works in exactly the same way as previously.
@@ -42,11 +45,12 @@ For more information about changes to continuous aggregates and data retention
 policies, see the [release notes][relnotes-20].
 
 ## Upgrade TimescaleDB to the next major version
+
 To perform this major upgrade:
 
-1. Export your TimescaleDB&nbsp;1 policy settings
-1. Upgrade the TimescaleDB extension
-1. Verify updated policy settings and jobs
+1.  Export your TimescaleDB&nbsp;1 policy settings
+1.  Upgrade the TimescaleDB extension
+1.  Verify updated policy settings and jobs
 
 When you perform the upgrade, new policies are automatically configured based on
 your current configuration. This upgrade process allows you to export your
@@ -64,7 +68,7 @@ individually.
 
 ### Exporting TimescaleDB&nbsp;1 policy settings
 
-1. At the psql prompt, use this command to save the current settings for your
+1.  At the psql prompt, use this command to save the current settings for your
    policy statistics to a `.csv` file:
 
     ```sql
@@ -72,7 +76,7 @@ individually.
     TO policy_stats.csv csv header
     ```
 
-1. Use this command to save the current settings for your continuous aggregates
+1.  Use this command to save the current settings for your continuous aggregates
    to a `.csv` file:
 
     ```sql
@@ -80,7 +84,7 @@ individually.
     TO continuous_aggregate_stats.csv csv header
     ```
 
-1. Use this command to save the current settings for your drop chunk policies to
+1.  Use this command to save the current settings for your drop chunk policies to
    a `.csv` file:
 
     ```sql
@@ -88,7 +92,7 @@ individually.
     TO drop_chunk_policies.csv csv header
     ```
 
-1. Use this command to save the current settings for your reorder policies
+1.  Use this command to save the current settings for your reorder policies
    to a `.csv` file:
 
     ```sql
@@ -102,17 +106,17 @@ individually.
 
 ### Upgrading the TimescaleDB extension
 
-1. Connect to psql using the `-X` flag. This prevents any `.psqlrc` commands
+1.  Connect to psql using the `-X` flag. This prevents any `.psqlrc` commands
    from accidentally triggering the load of a previous TimescaleDB version on
    session startup.
-1. At the psql prompt, upgrade the TimescaleDB extension. This must be the first
+1.  At the psql prompt, upgrade the TimescaleDB extension. This must be the first
    command you execute in the current session:
 
     ```sql
     ALTER EXTENSION timescaledb UPDATE;
     ```
 
-1. Check that you have upgraded to the latest version of the extension with the
+1.  Check that you have upgraded to the latest version of the extension with the
    `\dx` command. The output should show the upgraded version number.
 
     ```sql
@@ -125,7 +129,7 @@ individually.
 
 ### Verifying updated policy settings and jobs
 
-1. Use this query to verify the continuous aggregate policy jobs:
+1.  Use this query to verify the continuous aggregate policy jobs:
 
     ```sql
     SELECT * FROM timescaledb_information.jobs
@@ -149,10 +153,10 @@ individually.
     hypertable_name   | _materialized_hypertable_2
     ```
 
-1. Verify the information for each policy type that you exported before you
+1.  Verify the information for each policy type that you exported before you
    upgraded. For continuous aggregates, take note of the `config` information to
    verify that all settings were converted correctly.
-1. Verify that all jobs are scheduled and running as expected using the new
+1.  Verify that all jobs are scheduled and running as expected using the new
    `timescaledb_information.job_stats` view:
 
 ```sql

--- a/timescaledb/how-to-guides/upgrades/minor-upgrade.md
+++ b/timescaledb/how-to-guides/upgrades/minor-upgrade.md
@@ -1,12 +1,13 @@
 ---
 title: Minor TimescaleDB upgrades
 excerpt: Upgrade within the same major version of TimescaleDB
-keywords: [upgrade]
+keywords: [upgrades]
 ---
 
 import PlanUpgrade from 'versionContent/_partials/_plan_upgrade.mdx';
 
 # Minor TimescaleDB upgrades
+
 A minor upgrade is when you upgrade within your current major version of
 TimescaleDB. For example, when you upgrade from TimescaleDB&nbsp;2.5, to
 TimescaleDB&nbsp;2.6.
@@ -16,9 +17,11 @@ TimescaleDB&nbsp;1 to TimescaleDB&nbsp;2, see the
 [major upgrades section][upgrade-major].
 
 ## Plan your upgrade
+
 <PlanUpgrade />
 
 ## Upgrade TimescaleDB to the next minor version
+
 This upgrade uses the PostgreSQL `ALTER EXTENSION` function to upgrade to the
 latest version of the TimescaleDB extension. TimescaleDB supports having
 different extension versions on different databases within the same PostgreSQL
@@ -30,17 +33,17 @@ individually.
 
 ### Upgrading the TimescaleDB extension
 
-1. Connect to psql using the `-X` flag. This prevents any `.psqlrc` commands
+1.  Connect to psql using the `-X` flag. This prevents any `.psqlrc` commands
    from accidentally triggering the load of a previous TimescaleDB version on
    session startup.
-1. At the psql prompt, upgrade the TimescaleDB extension. This must be the first
+1.  At the psql prompt, upgrade the TimescaleDB extension. This must be the first
    command you execute in the current session:
 
     ```sql
     ALTER EXTENSION timescaledb UPDATE;
     ```
 
-1. Check that you have upgraded to the latest version of the extension with the
+1.  Check that you have upgraded to the latest version of the extension with the
    `\dx` command. The output should show the upgraded version number.
 
     ```sql

--- a/timescaledb/how-to-guides/upgrades/upgrade-docker.md
+++ b/timescaledb/how-to-guides/upgrades/upgrade-docker.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrades within a Docker container
 excerpt: Upgrade TimescaleDB within a Docker container
-keywords: [upgrade, Docker]
+keywords: [upgrades, Docker]
 ---
 
 # Upgrades within a Docker container

--- a/timescaledb/how-to-guides/upgrades/upgrade-pg.md
+++ b/timescaledb/how-to-guides/upgrades/upgrade-pg.md
@@ -1,10 +1,11 @@
 ---
 title: Upgrade PostgreSQL
 excerpt: Upgrade the PostgreSQL installation associated with TimescaleDB
-keywords: [upgrade, PostgreSQL]
+keywords: [upgrades, PostgreSQL]
 ---
 
 # Upgrade PostgreSQL
+
 Because TimescaleDB is a PostgreSQL extension, you need to ensure you keep your
 underlying PotsgreSQL installation up to date. When you upgrade your TimescaleDB
 extension to a new version, always take the time to check if you need to also
@@ -31,26 +32,28 @@ that you can make sure each upgrade completes properly. For example, if you are
 running PostgreSQL&nbsp;10 and TimescaleDB&nbsp;1.7.5, and you want to upgrade
 to PostgreSQL&nbsp;13 and TimescaleDB&nbsp;2.2, upgrade in this order:
 
-1. Upgrade PostgreSQL&nbsp;10 to PostgreSQL&nbsp;12
-1. Upgrade TimescaleDB&nbsp;1.7.5 to TimescaleDB&nbsp;2.2 on PostgreSQL&nbsp;12
-1. Upgrade PostgreSQL&nbsp;12 to PostgreSQL&nbsp;13 with TimescaleDB&nbsp;2.2
+1.  Upgrade PostgreSQL&nbsp;10 to PostgreSQL&nbsp;12
+1.  Upgrade TimescaleDB&nbsp;1.7.5 to TimescaleDB&nbsp;2.2 on PostgreSQL&nbsp;12
+1.  Upgrade PostgreSQL&nbsp;12 to PostgreSQL&nbsp;13 with TimescaleDB&nbsp;2.2
    installed
 
 ## Plan your upgrade
+
 You can upgrade your PostgreSQL installation in-place. This means
 that you do not need to dump and restore your data. However, it is still
 important that you plan for your upgrade ahead of time.
 
 Before you upgrade:
 
-* Read [the release notes][pg-relnotes] for the PostgreSQL version you are
+*   Read [the release notes][pg-relnotes] for the PostgreSQL version you are
   upgrading to.
-* [Perform a backup][backup] of your database. While PostgreSQL and
+*   [Perform a backup][backup] of your database. While PostgreSQL and
   TimescaleDB upgrades are performed in-place, upgrading is an intrusive
   operation. Always make sure you have a backup on hand, and that the backup is
   readable in the case of disaster.
 
 ## Upgrade PostgreSQL
+
 You can use the [`pg_upgrade`][pg_upgrade] tool to upgrade PostgreSQL in-place.
 This means that you do not need to dump and restore your data. Instead,
 `pg_upgrade` allows you to retain the data files of your current PostgreSQL
@@ -64,6 +67,7 @@ supported for PostgreSQL&nbsp;8.4 and higher.
 1.  Before you begin, determine the location of the PostgreSQL binary and your
     data directory on your local system.
 1.  At the psql prompt, perform the upgrade:
+
     ```sql
     pg_upgrade -b <OLD_BIN_DIR> -B <NEW_BIN_DIR> -d <OLD_DATA_DIR> -D <NEW_DATA_DIR>
     ```

--- a/timescaledb/how-to-guides/user-defined-actions/example-backfill.md
+++ b/timescaledb/how-to-guides/user-defined-actions/example-backfill.md
@@ -1,6 +1,7 @@
 ---
 title: Use a user-defined action to schedule regular backfilling
 excerpt: Schedule regular backfilling of historical data into a compressed hypertable
+keywords: [action, backfilling]
 ---
 
 # Use a user-defined action to schedule regular backfilling

--- a/timescaledb/how-to-guides/write-data/update.md
+++ b/timescaledb/how-to-guides/write-data/update.md
@@ -1,18 +1,21 @@
 ---
 title: Update data
 excerpt: Update data in a hypertable
-keywords: [update, hypertables]
+keywords: [updates, hypertables]
 ---
 
 # Update data
+
 Update data in a hypertable with a standard [`UPDATE`][postgres-update] SQL
 command.
 
 ## Update a single row
+
 Update a single row with the syntax `UPDATE ... SET ... WHERE`. For example, to
 update a row in the `conditions` hypertable with new `temperature` and
 `humidity` values, run the following. The `WHERE` clause specifies the row to be
 updated.
+
 ```sql
 UPDATE conditions
   SET temperature = 70.2, humidity = 50.0
@@ -21,9 +24,11 @@ UPDATE conditions
 ```
 
 ## Update multiple rows at once
+
 You can also update multiple rows at once, by using a `WHERE` clause that
 filters for more than one row. For example, run the following to update
 all `temperature` values within the given 10-minute span:
+
 ```sql
 UPDATE conditions
   SET temperature = temperature + 0.1

--- a/timescaledb/overview/core-concepts/backup-restore.md
+++ b/timescaledb/overview/core-concepts/backup-restore.md
@@ -1,7 +1,7 @@
 ---
 title: Back up and restore
 excerpt: Back up TimescaleDB
-keywords: [backup, restore]
+keywords: [backups, restore]
 tags: [recovery]
 ---
 
@@ -14,10 +14,10 @@ or logical backups with [`pg_dump`][pg_dump] and [`pg_restore`][pg_restore].
 Physical backups may also be used with write-ahead log (WAL) archiving to
 achieve an ongoing backup.
 
-If you have a multi-node deployment, make sure you can restore to a 
-point that ensures consistency across all nodes. You can create a 
+If you have a multi-node deployment, make sure you can restore to a
+point that ensures consistency across all nodes. You can create a
 restore point with the
-[`create_distributed_restore_point`][create_distributed_restore_point] 
+[`create_distributed_restore_point`][create_distributed_restore_point]
 function, and use it later when you restore from a physical backup.
 
 [create_distributed_restore_point]: /api/:currentVersion:/distributed-hypertables/create_distributed_restore_point/

--- a/timescaledb/overview/core-concepts/compression/architecture.md
+++ b/timescaledb/overview/core-concepts/compression/architecture.md
@@ -1,6 +1,7 @@
 ---
 title: Compression architecture
 excerpt: How compressed chunks are set up in TimescaleDB
+keywords: [compression, architecture]
 ---
 
 # Compression architecture

--- a/timescaledb/overview/core-concepts/compression/index.md
+++ b/timescaledb/overview/core-concepts/compression/index.md
@@ -1,6 +1,7 @@
 ---
 title: Compression
 excerpt: Learn how native compression works in TimescaleDB
+keywords: [compression]
 ---
 
 # Compression

--- a/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertable-architecture.md
+++ b/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertable-architecture.md
@@ -1,6 +1,7 @@
 ---
 title: Hypertable and chunk architecture
 excerpt: Learn how hypertables and chunks and structured in TimescaleDB
+keywords: [hypertables, architecture]
 ---
 
 # Hypertable and chunk architecture

--- a/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertables-and-chunks-benefits.md
+++ b/timescaledb/overview/core-concepts/hypertables-and-chunks/hypertables-and-chunks-benefits.md
@@ -1,6 +1,7 @@
 ---
 title: Benefits of hypertables
 excerpt: Hypertables help you achieve high performance and improved workflows when working with time-series data
+keywords: [hypertables]
 ---
 
 # Benefits of hypertables

--- a/timescaledb/overview/core-concepts/hypertables-and-chunks/index.md
+++ b/timescaledb/overview/core-concepts/hypertables-and-chunks/index.md
@@ -1,6 +1,7 @@
 ---
 title: Hypertables
 excerpt: Learn about hypertables and how they make it easy to handle time-series data
+keywords: [hypertables, chunks]
 ---
 
 # Hypertables

--- a/timescaledb/overview/data-model-flexibility.md
+++ b/timescaledb/overview/data-model-flexibility.md
@@ -1,7 +1,7 @@
 ---
 title: Data model
 excerpt: Learn how to model your data in TimescaleDB, in either a wide or narrow model
-keywords: [data, hypertables]
+keywords: [hypertables]
 tags: [model]
 ---
 

--- a/timescaledb/overview/deployment-options.md
+++ b/timescaledb/overview/deployment-options.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying TimescaleDB
 excerpt: Learn all the ways you can deploy TimescaleDB, on the cloud and on your own hardware
-keywords: [install]
+keywords: [installation]
 tags: [cloud, mst, self-hosted]
 ---
 

--- a/timescaledb/overview/faq/faq-community.md
+++ b/timescaledb/overview/faq/faq-community.md
@@ -1,19 +1,22 @@
 ---
 title: FAQs - Community
 excerpt: Frequently asked questions about our community, contributions, and licensing
-keywords: [community, contribute, license, faq]
+keywords: [community, contribute, license, FAQ]
 ---
 
 # FAQs - Community
 
 ## What is the TimescaleDB open-source license?
+
 Apache 2.0.
 
 ## Is there a TimescaleDB community or group I can join?
+
 Yes! We have a very active [online community in Slack][join_slack], and
 you can report any issues on our [GitHub][] page.
 
 ## Where can I get TimescaleDB source code?
+
 See [GitHub][].
 
 [GitHub]: https://github.com/timescale/timescaledb/issues

--- a/timescaledb/overview/faq/faq-postgres.md
+++ b/timescaledb/overview/faq/faq-postgres.md
@@ -1,26 +1,29 @@
 ---
 title: FAQs - Comparing to PostgreSQL
 excerpt: Why to choose TimescaleDB over regular PostgreSQL
-keywords: [PostgreSQL, faq]
+keywords: [PostgreSQL, FAQ]
 tags: [geospatial data, compare]
 ---
 
 # FAQs - Comparing to PostgreSQL
 
 ## Why would I use TimescaleDB over vanilla PostgreSQL?
+
 Read our TimescaleDB-PostgreSQL benchmarks:
-* [TimescaleDB vs. PostgreSQL for time-series data][PostgreSQL-benchmark]
-* [Problems with PostgreSQL 10 for time-series data][PostgreSQL-problems-time-series]
+
+*   [TimescaleDB vs. PostgreSQL for time-series data][PostgreSQL-benchmark]
+*   [Problems with PostgreSQL 10 for time-series data][PostgreSQL-problems-time-series]
 
 To summarize, TimescaleDB offers:
-* Ease-of-use: TimescaleDB is far easier to use because creating partitions (or what we call
+
+*   Ease-of-use: TimescaleDB is far easier to use because creating partitions (or what we call
 "chunks") is automatically performed for the user. All of the complexity of automatic
 partitioning is abstracted away behind a hypertable, which users interact with just as
 they would with a PostgreSQL table.
-* Much higher ingest scale: TimescaleDB sees throughput more than 20 times that of 
+*   Much higher ingest scale: TimescaleDB sees throughput more than 20 times that of
 <!-- vale Google.Units = NO -->
 PostgreSQL once tables reach moderate size (for example, tens of millions of
-rows). 
+rows).
 <!-- vale Google.Units = YES -->
 While vanilla PostgreSQL is suitable for time-series data at low volumes, it does
 not scale well to the volume of data that most time-series applications produce, especially
@@ -32,21 +35,23 @@ B-Trees. TimescaleDB solves this through its heavy utilization of
 time-space partitioning, even when running _on a single machine_. So all writes
 to recent time intervals are only to tables that remain in memory, and updating any
 secondary indexes is also fast as a result.
-* Superior (or similar) query performance: Queries that can reason
+
+*   Superior (or similar) query performance: Queries that can reason
 specifically about time ordering can be _much_ more performant (thousands of times faster)
 in TimescaleDB. On single disk machines, at least, many simple queries that just perform
 indexed lookups or table scans are similarly performant between PostgreSQL and TimescaleDB.
-* Much faster data deletion: To save space or to implement data retention policies,
+*   Much faster data deletion: To save space or to implement data retention policies,
 vanilla PostgreSQL requires expensive "vacuuming" operations to defragment
 the disk storage associated with such tables. TimescaleDB avoids vacuuming operations
 and easily enforces data retention policies by specifying the data you wish to be
 deleted that is older than a specified time period. For more information, see [Data Retention][data-retention].
-* Extended time-oriented features: TimescaleDB includes time-series specific features
+*   Extended time-oriented features: TimescaleDB includes time-series specific features
 not included in vanilla PostgreSQL and entirely unique to TimescaleDB
-(such as [`time_bucket`][time_bucket],[`first`][first], and [`last`][last]), 
+(such as [`time_bucket`][time_bucket],[`first`][first], and [`last`][last]),
 with more to come.
 
 ## How compatible is TimescaleDB with PostgreSQL?
+
 TimescaleDB is implemented as an extension to PostgreSQL that introduces
 transparent scalability and performance optimizations, as well as time-series
 specific features (for example, arbitrary aggregations, data retention
@@ -57,6 +62,7 @@ your existing PostgreSQL databases and work with your current visualization and
 reporting tools.
 
 ## How does TimescaleDB handle geospatial data?
+
 As an extension of PostgreSQL, TimescaleDB works well with PostGIS. For example,
 [see our tutorial][postgis] using PostGIS and TimescaleDB on NYC taxicab data.
 

--- a/timescaledb/overview/faq/faq-products.md
+++ b/timescaledb/overview/faq/faq-products.md
@@ -1,7 +1,7 @@
 ---
 title: FAQs - About our products
 excerpt: Frequently asked questions about TimescaleDB, Timescale Cloud, and Managed Service for TimescaleDB
-keywords: [Timescale Cloud, Managed Service for TimescaleDB, faq]
+keywords: [Timescale Cloud, Managed Service for TimescaleDB, FAQ]
 tags: [cloud regions, PostgreSQL]
 ---
 

--- a/timescaledb/overview/faq/faq-timeseries.md
+++ b/timescaledb/overview/faq/faq-timeseries.md
@@ -1,12 +1,13 @@
 ---
 title: FAQs - About time-series databases
 excerpt: Frequently asked questions about time-series databases
-keywords: [time-series, faq]
+keywords: [time-series, FAQ]
 ---
 
 # FAQs - About time-series databases
 
 ## Why is time-series data important?
+
 At Timescale, we are dedicated to serving developers worldwide, enabling
 them to build exceptional data-driven products that measure everything that
 matters: software applications, industrial equipment, financial markets,
@@ -25,6 +26,7 @@ the thousands of different ways developers are using time-series data
 to measure everything that matters today.
 
 ## Why build another time-series database?
+
 Time-series data is cropping up in more and more places: monitoring and DevOps,
 sensor data and IoT, financial data, logistics data, app usage data, and more.
 Often this data is high in volume and complex in nature (for example, multiple

--- a/timescaledb/overview/faq/faq-using-timescaledb.md
+++ b/timescaledb/overview/faq/faq-using-timescaledb.md
@@ -1,12 +1,13 @@
 ---
 title: FAQs - Using TimescaleDB
 excerpt: Frequently asked questions about using TimescaleDB
-keywords: [faq]
+keywords: [FAQ]
 ---
 
 # FAQs - Using TimescaleDB
 
 ## What can I use TimescaleDB for?
+
 TimescaleDB is ideal for time-series workloads that would benefit from a SQL interface.
 SQL carries a variety of benefits: a query language that most developers already know;
 rich set of functions and utilities; and a broad ecosystem of tools, connectors, and
@@ -23,12 +24,15 @@ behavior of applications, models, consumers and connected machines; powering ope
 analytical workflows and dashboards; and QA and performance testing.
 
 ## How do I write data?
+
 Just via normal SQL, but here are some [insert examples][INSERT].
 
 ## How do I read data?
+
 Just via normal SQL, but here are some [query examples][SELECT].
 
 ## What are my compression options?
+
 Since v1.5,
 TimescaleDB has supported native compression that uses a hybrid row/columnar
 approach combined with type-specific compression algorithms (for example, different
@@ -38,9 +42,10 @@ leading to significant cost savings (and other query performance improvements).
 Note that compression must be *explicitly turned on and configured* for a
 hypertable; compression is off by default. For more details about how to use
 TimescaleDB compression, please see [our compression docs][compression-docs]
-or a longer technical deep-dive [on our blog ][compression-blog].
+or a longer technical deep-dive [on our blog][compression-blog].
 
 ## How far can TimescaleDB scale?
+
 In our internal benchmarks on standard cloud VMs, we regularly test
 single-node TimescaleDB to hundreds of terabytes of data, while sustaining
 insert rates of 100-200k rows / second (1-2 million metric inserts / second).
@@ -53,11 +58,12 @@ with the native query complexity supported by RDBMS systems. Read on for more
 details on clustering.
 
 ## How does TimescaleDB scale?
+
 TimescaleDB's architecture leverages two key properties of time-series data:
 
-* Time-series data is largely immutable. New data continually arrives, typically
+*   Time-series data is largely immutable. New data continually arrives, typically
 as writes (inserts) to the latest time intervals, not as updates to existing records.
-* Workloads have a natural partitioning across both time and space.
+*   Workloads have a natural partitioning across both time and space.
 
 TimescaleDB leverages these properties by automatically partitioning data into
 two-dimensional chunks that operate like smaller PostgreSQL tables, performing
@@ -69,12 +75,15 @@ a normal table in PostgreSQL does. For more information, see this blog post:
 [Time-series data: Why (and how) to use a relational database instead of NoSQL][rdbms > nosql].
 
 ## What are hypertables and chunks?
+
 Our [documentation][docs-architecture] describes these design elements in more depth.
 
 ## How should I configure chunking?
+
 See the [Best Practices][hypertable-best-practices] section of our documentation.
 
 ## How are hypertable chunks determined across the space dimension?
+
 All hypertable chunks are partitioned automatically across time, which is necessary for
 right-sizing the chunks such that the B-trees for a table's indexes can reside in memory
 during inserts to avoid thrashing that would otherwise occur while modifying arbitrary locations
@@ -87,9 +96,11 @@ performing a range query for a single device/customer/ticker. For more
 details on space partitioning, see [Best Practices][hypertable-best-practices].
 
 ## How do I install TimescaleDB?
+
 See our [install documentation][install].
 
 ## How do I update an existing installation?
+
 See our [updating documentation][update].
 
 [INSERT]: /timescaledb/:currentVersion:/how-to-guides/write-data/insert/

--- a/timescaledb/overview/faq/index.md
+++ b/timescaledb/overview/faq/index.md
@@ -1,7 +1,7 @@
 ---
 title: Frequently asked questions
 excerpt: Frequently asked questions about Timescale, TimescaleDB, and the Timescale community
-keywords: [faq]
+keywords: [FAQ]
 ---
 
 # Frequently asked questions

--- a/timescaledb/overview/release-notes/changes-in-timescaledb-2.md
+++ b/timescaledb/overview/release-notes/changes-in-timescaledb-2.md
@@ -1,7 +1,7 @@
 ---
 title: Changes in TimescaleDB 2.0
 excerpt: New features and capabilities introduced in TimescaleDB 2.0
-keywords: [upgrade, releases]
+keywords: [upgrades, releases]
 ---
 
 # Changes in TimescaleDB 2.0
@@ -46,7 +46,6 @@ to evaluate the effects on your application and infrastructure. Then, for upgrad
 instructions and recommendations, see the [documentation on upgrading to
 TimescaleDB 2.0][upgrade-timescaledb2].
 
-
 ## Why we've made these changes
 
 It's been two years since we released TimescaleDB 1.0 in October 2018 with the ambition
@@ -84,14 +83,12 @@ to enable user-defined actions. User-defined actions are custom background jobs 
 In the rest of this document, we go through each of the features and API changes in detail, and
 what users migrating from an earlier version of TimescaleDB should consider prior to updating to TimescaleDB 2.0.
 
-
 ## Working with hypertables
 
 In TimescaleDB 2.0, we have made changes to existing APIs for working with hypertables, as well
 as improvements to the related information views and size functions. These views and functions
 provide information about basic configuration, partitioning, data chunks, and disk size, and they
 also have been updated to work for distributed hypertables.
-
 
 ### Creating hypertables and changing configuration
 
@@ -177,14 +174,13 @@ has been renamed from `hypertable_approximate_row_count`. It can now also be cal
 In previous versions of TimescaleDB, you could get size information for all hypertables in the `hypertable` view.
 In TimescaleDB 2.0, you can now instead combine the new `hypertables` view with size functions to achieve a similar result:
 
-
 ```SQL
 SELECT hypertable_name, hypertable_size(hypertable_name::regclass) FROM timescaledb_information.hypertables;
 
  hypertable_name | hypertable_size
 -----------------+-----------------
- devices         |      	360448
- conditions      |      	253952
+ devices         |       360448
+ conditions      |       253952
 ```
 
 ## Continuous aggregates
@@ -207,11 +203,10 @@ Action API                    | Policy API for Automation
 `compress_chunk`              | `add_compression_policy`
 `refresh_continuous_aggregate`|`add_continuous_aggregate_policy`
 
-
 In practice, this means that creating a continuous aggregate in TimescaleDB 2.0 is now a two-step process:
 
-1. Create via a [`CREATE MATERIALIZED VIEW`](/api/:currentVersion:/continuous-aggregates/create_materialized_view/) statement
-2. Add an (automation) policy on the continuous aggregate via a separate [API function call](/api/:currentVersion:/continuous-aggregates/add_continuous_aggregate_policy)
+1.  Create via a [`CREATE MATERIALIZED VIEW`](/api/:currentVersion:/continuous-aggregates/create_materialized_view/) statement
+2.  Add an (automation) policy on the continuous aggregate via a separate [API function call](/api/:currentVersion:/continuous-aggregates/add_continuous_aggregate_policy)
 
 ```SQL
 CREATE MATERIALIZED VIEW conditions_by_2h
@@ -231,7 +226,7 @@ SELECT add_continuous_aggregate_policy(
   schedule_interval    => '1 hour');
 ```
 
-In the example above, `CREATE MATERIALIZED VIEW `creates a continuous aggregate without any automation yet
+In the example above, `CREATE MATERIALIZED VIEW`creates a continuous aggregate without any automation yet
 associated with it. Notice also that  `WITH NO DATA` is specified at the end. This prevents the view from
 materializing data at creation time, instead deferring the population of aggregated data until the policy runs
 as a background job or as part of a manual refresh. Therefore, we recommend that users create continuous aggregates
@@ -243,7 +238,6 @@ provided. Inputs to the policy function include the continuous aggregate name, a
 schedule interval. The refresh window is specified by the start and end offsets, which are used to calculate
 a new refresh window every time the policy runs by subtracting the offsets from the current time (as normally
 returned by the function `now()`).
-
 
 ### Understanding continuous aggregate policies
 
@@ -267,18 +261,16 @@ about the latest data, and not just aggregated data more than 2 hours old, based
 specified as before with the `timescaledb.materialized_only=false` parameter. Real-time aggregates are still the default
 setting unless otherwise specified.
 
-Finally, it is recommended that the `end_offset` lags the current time by at least one `time_bucket `as defined
+Finally, it is recommended that the `end_offset` lags the current time by at least one `time_bucket`as defined
 in the aggregate SQL, otherwise it might affect performance when inserting new data, which usually is written to
 what would be the latest bucket. In TimescaleDB 1.x, the `refresh_lag` parameter was used for a similar purpose,
 but we found that  using it correctly was more difficult to understand.
-
 
 ### Manually refreshing regions of continuous aggregates
 
 TimescaleDB 2.0 removes support for `REFRESH MATERIALIZED VIEW` in favor of the new, more flexible function,
 [refresh_continuous_aggregate](/api/:currentVersion:/continuous-aggregates/refresh_continuous_aggregate), which enables
 a user to refresh a specific window in a continuous aggregate:
-
 
 ```SQL
 CALL refresh_continuous_aggregate(
@@ -297,7 +289,6 @@ inside the given refresh window and are in a region that has seen changes in the
 Thus, if no changes have occurred in the underlying source data (that is, no data has been backfilled to the
 region or no updates to existing data have been made), no materialization is performed over that
 region. This behavior is similar to the continuous aggregate policy and ensures more efficient operation.
-
 
 ### Using data retention and continuous aggregates together
 
@@ -338,9 +329,11 @@ prior to dropping chunks in the original hypertable. In practice, it often didn'
 In TimescaleDB 2.0 users can ensure that all updates are processed before dropping data by
 combining the following experimental function, which refreshes updates in the given chunk,
 with `drop_chunks`.
+
 ```sql
 _timescaledb_internal.refresh_continuous_aggregate(continuous_aggregate REGCLASS, chunk REGCLASS)
 ```
+
 The example below demonstrates how to use the chunk-based refresh function to define a
 retention policy, which ensures that all updates to data in the original hypertable are
 refreshed in all continuous aggregates prior to dropping chunks older than 2 weeks:
@@ -410,6 +403,7 @@ dropped due to a data retention policy as discussed in the previous section.
 In TimescaleDB 2.0, views surrounding continuous aggregates (and other policies) have been simplified and generalized.
 
 #### Changes and additions
+
 *   [`timescaledb_information.continuous_aggregates`](/api/:currentVersion:/continuous-aggregates/):
 now provides information related to the materialized view, which includes the view name and owner, the real
 time aggregation flag, the materialization and the view definition (the select statement defining the view).
@@ -419,7 +413,8 @@ all policies including continuous aggregates.
 statistics related to all jobs.
 
 #### Removed
-* [`timescaledb_information.continuous_aggregate_stats`](https://legacy-docs.timescale.com/v1.7/api#timescaledb_information-continuous_aggregate_stats): Removed in favor of the `job_stats` view mentioned above.
+
+*   [`timescaledb_information.continuous_aggregate_stats`](https://legacy-docs.timescale.com/v1.7/api#timescaledb_information-continuous_aggregate_stats): Removed in favor of the `job_stats` view mentioned above.
 
 ### Updating existing continuous aggregates
 
@@ -435,7 +430,7 @@ In particular, the update process should:
 *   Mark all the data older than the interval `ignore_invalidation_older_than` as out-of-date, so that it can be refreshed.
 *   Disable any retention policies that are failing due to being incompatible with the current setting of
 `ignore_invalidation_older_than` on a continuous aggregate (as described above). Disabled policies remain after
-upgrade, but are not scheduled to run (`scheduled=false `in` timescaledb_information.jobs`). If failing policies
+upgrade, but are not scheduled to run (`scheduled=false`in`timescaledb_information.jobs`). If failing policies
 were to be migrated to 2.0 they would start to work again, but likely with unintended consequences. Therefore, any
 retention policies that are disabled post update should have their settings carefully reviewed before being enabled again.
 
@@ -448,6 +443,7 @@ Other minor changes were made to various APIs for greater understandability and 
 ### Data retention
 
 #### Changes and additions
+
 *   [`drop_chunks`](/api/:currentVersion:/hypertable/drop_chunks): This function now requires specifying a
 hypertable or continuous aggregate as the first argument, and does not allow dropping chunks across all hypertables
 in a database. Additionally, the arguments `cascade` and `cascade_to_materializations` were removed (and behave as
@@ -460,15 +456,16 @@ and `cascade_to_materializations` were removed (and behave as if the arguments w
 policies are now available in the main jobs view.
 
 #### Removed
+
 *   [`add_drop_chunks_policy`](https://legacy-docs.timescale.com/v1.7/api#add_drop_chunks_policy): removed in favor of the
 explicit functions above.
 *   [`timescaledb_information.drop_chunks_policies`](https://legacy-docs.timescale.com/v1.7/api#timescaledb_information-drop_chunks_policies):
  view has been removed in favor of the more general jobs view.
 
-
 ### Compression
 
 #### Changes and additions
+
 *   [`add_compression_policy`](/api/:currentVersion:/compression/add_compression_policy), [`remove_compression_policy`](/api/:currentVersion:/compression/remove_compression_policy):  
 Creating (or removing) a compression policy now has explicit functions.
 *   [`hypertable_compression_stats(hypertable)`](/api/:currentVersion:/compression/hypertable_compression_stats): The function
@@ -481,11 +478,12 @@ information about currently compressed chunks.
 compression policies are now available in the main jobs view.
 
 #### Removed
-* [`add_compress_chunk_policy`](https://legacy-docs.timescale.com/v1.7/api#add_compress_chunks_policy): Removed in favor of the
+
+*   [`add_compress_chunk_policy`](https://legacy-docs.timescale.com/v1.7/api#add_compress_chunks_policy): Removed in favor of the
 explicit functions above.
-* [`timescaledb_information.compressed_hypertable_stats`](https://legacy-docs.timescale.com/v1.7/api#timescaledb_information-compressed_hypertable_stats):
+*   [`timescaledb_information.compressed_hypertable_stats`](https://legacy-docs.timescale.com/v1.7/api#timescaledb_information-compressed_hypertable_stats):
 Removed in favor of the new `hypertable_compression_stats(hypertable)` function linked above
-* [`timescaledb_information.compressed_chunk_stats`](https://legacy-docs.timescale.com/v1.7/api#timescaledb_information-compressed_chunk_stats):
+*   [`timescaledb_information.compressed_chunk_stats`](https://legacy-docs.timescale.com/v1.7/api#timescaledb_information-compressed_chunk_stats):
 Removed in favor of the new `chunk_compression_stats(hypertable)` function linked above.
 
 ## Managing policies and other jobs
@@ -503,7 +501,6 @@ built-in actions (for example, `remove_retention_policy`).
 *   [`timescaledb_information.jobs`](/api/:currentVersion:/informational-views/jobs):  The new view provides all job settings available, and it replaces all policy-specific views.
 *   [`timescaledb_information.jobs_stats`](/api/:currentVersion:/informational-views/job_stats):  The view presents statistics of executing jobs for policies and actions.
 
-
 ## License information
 
 In TimescaleDB 2.0, all features which had been classified previously as "enterprise" have become "community" features
@@ -518,7 +515,7 @@ longer applicable. The current license used by the extension can instead be view
 *   `timescaledb.license`: This GUC value (which replaces the former [`timescaledb.license_key`](https://legacy-docs.timescale.com/v1.7/api#timescaledb_license-key) GUC)
 can take the value `timescale` or `apache`. It can be set only at startup (in the postgresql.conf configuration file
 or on the server command line), and allows limiting access to certain features
-by license. For example, setting the 
+by license. For example, setting the
 license to `apache` allows access to only Apache-2 licensed features.
 
 [how-to-guides]: /timescaledb/:currentVersion:/how-to-guides/

--- a/timescaledb/overview/release-notes/index.md
+++ b/timescaledb/overview/release-notes/index.md
@@ -1,7 +1,7 @@
 ---
 title: TimescaleDB release notes and future plans
 excerpt: New features and fixes are released regularly
-keywords: [upgrade, update, releases]
+keywords: [upgrades, updates, releases]
 ---
 
 # TimescaleDB release notes

--- a/timescaledb/timescaledb-edition-comparison.md
+++ b/timescaledb/timescaledb-edition-comparison.md
@@ -1,7 +1,7 @@
 ---
 title: Compare TimescaleDB editions
 excerpt: Compare different editions of TimescaleDB
-keywords: [Apache, community, features]
+keywords: [Apache, community, license]
 tags: [learn, contribute]
 ---
 

--- a/timescaledb/tutorials/grafana/setup-alerts.md
+++ b/timescaledb/tutorials/grafana/setup-alerts.md
@@ -1,7 +1,7 @@
 ---
 title: Set up Grafana alerts
 excerpt: Use Grafana to get alerted when a problem occurs
-keywords: [Grafana, alerts]
+keywords: [Grafana, alert, integration]
 ---
 
 # Set up Grafana alerts
@@ -9,10 +9,10 @@ keywords: [Grafana, alerts]
 Alerts are an important aspect of monitoring because they proactively
 inform us when things go wrong and need our attention. This could be:
 
-- When something crashes
-- You're consuming too many resources (for example, memory, CPU)
-- There's an outage
-- Users report performance degradation, via support tickets
+*   When something crashes
+*   You're consuming too many resources (for example, memory, CPU)
+*   There's an outage
+*   Users report performance degradation, via support tickets
 
 In this tutorial, you'll learn how to setup Grafana to alert you when
 something goes wrong using many of the communication channels you already
@@ -24,8 +24,8 @@ To complete this tutorial, you need a cursory knowledge of the Structured Query
 Language (SQL). The tutorial walks you through each SQL command, but it is
 helpful if you've seen SQL before.
 
-* To start, [install TimescaleDB][install-timescale].
-* Next [setup Grafana][install-grafana].
+*   To start, [install TimescaleDB][install-timescale].
+*   Next [setup Grafana][install-grafana].
 
 Once your installation of TimescaleDB and Grafana are complete, follow the
 [Timescale and Prometheus tutorial][tutorial-prometheus] and configure Grafana to connect
@@ -41,9 +41,9 @@ inform you of which Grafana visualization to create and the query to use.
 
 When setting up alerts for your system, consider the following:
 
-- You should only use alerts when you require human input
-- Be careful not to overuse alerts. If an engineer gets an alert too frequently, it can cease to be useful or serve its purpose.
-- Use alerts that are directly relevant to your scenario: if you're monitoring a SaaS product, set up alerts for site uptime and latency. If you're monitoring infrastructure, set up alerts for disk usage, high CPU or memory usage, and API errors.
+*   You should only use alerts when you require human input
+*   Be careful not to overuse alerts. If an engineer gets an alert too frequently, it can cease to be useful or serve its purpose.
+*   Use alerts that are directly relevant to your scenario: if you're monitoring a SaaS product, set up alerts for site uptime and latency. If you're monitoring infrastructure, set up alerts for disk usage, high CPU or memory usage, and API errors.
 
 ### Introduction to alerts in Grafana
 
@@ -56,13 +56,13 @@ have to integrate services on your back-end. You simply use your dashboard.
 
 There are some downsides to using Grafana for alerts:
 
-- You can only set up alerts on graph visualizations with time-series output
-- Thus, you can't use table output or anything else that is not time-series data
+*   You can only set up alerts on graph visualizations with time-series output
+*   Thus, you can't use table output or anything else that is not time-series data
 
 Ultimately, for most cases, this is okay because:
 
-- You're mainly dealing with time-series data for alerts
-- You can usually turn any other visualization (for example, a Gauge or a Single Stat) into a time-series graph
+*   You're mainly dealing with time-series data for alerts
+*   You can usually turn any other visualization (for example, a Gauge or a Single Stat) into a time-series graph
 
 #### Available data soruces for Grafana alerts
 
@@ -82,9 +82,9 @@ how often rules are evaluated.
 
 In plain language, examples of rules could be:
 
-- When disk usage is greater than 90%
-- When the average memory usage is greater than 90% for 5 minutes (this is an example of an interval-based rule)
-- When the temperatore of a device is outside a given range (this is an example of a rule with many different conditions)
+*   When disk usage is greater than 90%
+*   When the average memory usage is greater than 90% for 5 minutes (this is an example of an interval-based rule)
+*   When the temperatore of a device is outside a given range (this is an example of a rule with many different conditions)
 
 #### Notification channels
 
@@ -93,10 +93,10 @@ If you have no notification channels, then your alerts only show up on Grafana.
 
 Examples of channels include tools your team may already use:
 
-- Slack
-- Email
-- OpsGenie
-- PagerDuty
+*   Slack
+*   Email
+*   OpsGenie
+*   PagerDuty
 
 Grafana provides integration with webhooks, email, and more than a
 dozen external services.
@@ -260,23 +260,23 @@ Select your PagerDuty channel in the 'Notifications' section and provide a descr
 
 Grafana supports a number of notification platforms, including:
 
-- DingDing
-- Discord
-- Email
-- Google Hangouts
-- Hipchat
-- Kafka
-- Line
-- Microsoft Teams
-- OpsGenie
-- PagerDuty
-- Prometheus Alertmanager
-- Pushover
-- Slack
-- Telegram
-- Threema
-- VictorOps
-- Webhooks
+*   DingDing
+*   Discord
+*   Email
+*   Google Hangouts
+*   Hipchat
+*   Kafka
+*   Line
+*   Microsoft Teams
+*   OpsGenie
+*   PagerDuty
+*   Prometheus Alertmanager
+*   Pushover
+*   Slack
+*   Telegram
+*   Threema
+*   VictorOps
+*   Webhooks
 
 Steps for integrating with all of these are similar to the steps you used for Slack (webhooks)
 and PagerDuty (API or Integration Key).

--- a/timescaledb/tutorials/grafana/visualize-missing-data.md
+++ b/timescaledb/tutorials/grafana/visualize-missing-data.md
@@ -1,13 +1,14 @@
 ---
 title: How to visualize and aggregate missing time-series data in Grafana
 excerpt: Handle missing data points when plotting data in Grafana
-keywords: [Grafana, visualizations, analytics, gapfill]
+keywords: [Grafana, visualizations, analytics, gapfilling]
 tags: [time-series]
 ---
 
 # Tutorial: How to visualize and aggregate missing time-series data in Grafana
 
 ### Introduction
+
 Sometimes there are gaps in our time-series data: because systems
 are offline, or devices lose power, etc. This causes problems when you
 want to aggregate data across a large time window, for example,
@@ -22,19 +23,20 @@ handling missing time-series data (using the TimescaleDB/PostgreSQL data
 source natively available in Grafana).
 
 ### Prerequisites
+
 To complete this tutorial, you need a cursory knowledge of the Structured Query
 Language (SQL). The tutorial walks you through each SQL command, but it is
 helpful if you've seen SQL before.
 
 You also need:
 
-* Time-series dataset with missing data (Note: in case you don't have
+*   Time-series dataset with missing data (Note: in case you don't have
 one handy, we include an optional step for creating one below.)
 
-* A working [installation of TimescaleDB][install-timescale]. Once your installation
+*   A working [installation of TimescaleDB][install-timescale]. Once your installation
 is complete, we can proceed to ingesting or creating sample data and finishing the tutorial.
 
-* Grafana dashboard connected to your TimescaleDB instance ([setup
+*   Grafana dashboard connected to your TimescaleDB instance ([setup
 instructions][get-grafana])
 
 ### Step 0 - Load your time-series data into TimescaleDB and simulate missing data (optional)
@@ -121,6 +123,7 @@ have been.
 As you can see, the graph now plots data points at regular intervals for the times where we have missing data.
 
 ### Step 3 - Aggregate across a larger time window
+
 Now, we return to our original problem: wanting to aggregate data across a large time window with missing data.
 
 Here we use our interpolated data and compute the average temperature by 30 minute windows over the past 6 hours.

--- a/timescaledb/tutorials/monitor-mst-with-prometheus.md
+++ b/timescaledb/tutorials/monitor-mst-with-prometheus.md
@@ -2,7 +2,7 @@
 title: How to set up a Prometheus endpoint for Managed Service for TimescaleDB
 excerpt: Use Prometheus to monitor your Managed Service for TimescaleDB
 product: mst
-keywords: [prometheus, monitor]
+keywords: [Prometheus, monitor, integration]
 ---
 
 # How to set up a Prometheus endpoint for a Managed TimescaleDB database


### PR DESCRIPTION
Go through keywords and make sure they return expected results. Remove some keywords that don't have good expected results because they are overly specific or vague.

Rename some other keywords for consistency: For templating reasons, the troubleshooting pages require the main topic (which is also a keyword) to be a noun, not a verb. Rather than creating yet another dictionary to map nouns to verbs, it is easier to just use nouns across the board.