### PR TITLE
Add note about multiple dbs to Docker upgrade docs

### DIFF
--- a/timescaledb/how-to-guides/upgrades/upgrade-docker.md
+++ b/timescaledb/how-to-guides/upgrades/upgrade-docker.md
@@ -138,6 +138,10 @@ data.
     ALTER EXTENSION timescaledb_toolkit UPDATE;
     ```
 
+<highlight type="note">
+If you have multiple databases, you need to each database separately.
+</highlight>
+
 </procedure>
 
 [toolkit]: https://docs.timescale.com/timescaledb/latest/how-to-guides/hyperfunctions/install-toolkit/

--- a/timescaledb/how-to-guides/upgrades/upgrade-docker.md
+++ b/timescaledb/how-to-guides/upgrades/upgrade-docker.md
@@ -139,7 +139,7 @@ data.
     ```
 
 <highlight type="note">
-If you have multiple databases, you need to each database separately.
+If you have multiple databases, you need to update each database separately.
 </highlight>
 
 </procedure>


### PR DESCRIPTION
# Description

Adds a brief note about multiple DBs when upgrading Docker comtainers.

# Links

Fixes https://github.com/timescale/docs/issues/1589

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
