### PR TITLE
Remove experimental tag from `{first,last}_{time,val}` accessors

### DIFF
--- a/api/first-last-time-counter.md
+++ b/api/first-last-time-counter.md
@@ -6,10 +6,9 @@ tags: [hyperfunctions, finance]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
-    experimental: 1.11.0
+    stable: 1.11.0
 hyperfunction:
   family: metric aggregation
   type: accessor
@@ -17,9 +16,7 @@ hyperfunction:
     - counter_agg()
 ---
 
-import Experimental from 'versionContent/_partials/_experimental.mdx';
-
-# first_time, last_time <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+# first_time, last_time <tag type="toolkit" content="Toolkit" />
 
 This pair of functions returns the timestamps of the first and last points in a `CounterSummary` aggregate.
 
@@ -34,8 +31,6 @@ last_time(
     cs CounterSummary
 ) RETURNS TIMESTAMPTZ
 ```
-
-<Experimental />
 
 ## Required arguments
 

--- a/api/first-last-time-timeweight.md
+++ b/api/first-last-time-timeweight.md
@@ -6,10 +6,9 @@ tags: [time-weighted, hyperfunctions, toolkit]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
-    experimental: 1.11.0
+    stable: 1.11.0
 hyperfunction:
   family: time-weighted averages
   type: accessor
@@ -17,9 +16,7 @@ hyperfunction:
     - time_weight()
 ---
 
-import Experimental from 'versionContent/_partials/_experimental.mdx';
-
-# first_time, last_time <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+# first_time, last_time <tag type="toolkit" content="Toolkit" />
 
 This pair of functions returns the timestamps of the first and last points in a `TimeWeightSummary` aggregate.
 
@@ -34,8 +31,6 @@ last_time(
     tw TimeWeightSummary
 ) RETURNS TIMESTAMPTZ
 ```
-
-<Experimental />
 
 ## Required arguments
 

--- a/api/first-last-val-counter.md
+++ b/api/first-last-val-counter.md
@@ -6,10 +6,9 @@ tags: [counters, hyperfunctions, toolkit]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
-    experimental: 1.11.0
+    stable: 1.11.0
 hyperfunction:
   family: metric aggregation
   type: accessor
@@ -17,9 +16,7 @@ hyperfunction:
     - counter_agg()
 ---
 
-import Experimental from 'versionContent/_partials/_experimental.mdx';
-
-# first_val, last_val <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+# first_val, last_val <tag type="toolkit" content="Toolkit" />
 
 This pair of functions returns the values of the first and last points in a `CounterSummary` aggregate.
 
@@ -34,8 +31,6 @@ last_val(
     cs CounterSummary
 ) RETURNS DOUBLE PRECISION
 ```
-
-<Experimental />
 
 ## Required arguments
 

--- a/api/first-last-val-timeweight.md
+++ b/api/first-last-val-timeweight.md
@@ -6,10 +6,9 @@ tags: [time-weighted, hyperfunctions, toolkit]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
-    experimental: 1.11.0
+    stable: 1.11.0
 hyperfunction:
   family: time-weighted averages
   type: accessor
@@ -17,9 +16,7 @@ hyperfunction:
     - time_weight()
 ---
 
-import Experimental from 'versionContent/_partials/_experimental.mdx';
-
-# first_val, last_val <tag type="toolkit" content="Toolkit" /><tag type="experimental-toolkit" content="Experimental" />
+# first_val, last_val <tag type="toolkit" content="Toolkit" />
 
 This pair of functions returns the timestamps of the first and last points in a `TimeWeightSummary` aggregate.
 
@@ -34,8 +31,6 @@ last_val(
     tw TimeWeightSummary
 ) RETURNS DOUBLE PRECISION
 ```
-
-<Experimental />
 
 ## Required arguments
 


### PR DESCRIPTION

# Description

These were actually never experimental and have been stable since their introduction in Toolkit 1.11.0

# Links


# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
