### PR TITLE
Document changes to state_agg/timeline_agg in Toolkit 1.13

### DIFF
--- a/api/duration_in.md
+++ b/api/duration_in.md
@@ -14,7 +14,7 @@ hyperfunction:
   family: state aggregates
   type: accessor
   aggregates:
-    - state_agg()
+    - state_agg() | timeline_agg()
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';
@@ -29,8 +29,8 @@ Use this function to report the total duration for a given state in a [state agg
 
 |Name|Type|Description|
 |-|-|-|
-|`state`|`TEXT`|State to query|
-|`aggregate`|`stateagg`|Previously created aggregate|
+|`state`|`TEXT` or `BIGINT`|State to query|
+|`aggregate`|`StateAgg` or `TimelineAgg`|Previously created aggregate|
 
 ## Returns
 
@@ -75,4 +75,4 @@ If you prefer to see the result in seconds, [`EXTRACT`][extract] the epoch from
 the returned result.
 
 [extract]: https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
-[state_agg]: /api/:currentVersion:/hyperfunctions/frequency-analysis/state_agg/
+[state_agg]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_agg/

--- a/api/interpolated_duration_in.md
+++ b/api/interpolated_duration_in.md
@@ -14,7 +14,7 @@ hyperfunction:
   family: state aggregates
   type: accessor
   aggregates:
-    - state_agg()
+    - state_agg() | timeline_agg()
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';
@@ -24,16 +24,16 @@ import Experimental from 'versionContent/_partials/_experimental.mdx';
 Calculate the total duration in a given state from a [state aggregate][state_agg].
 Unlike [`duration_in`][duration_in], you can use this function across multiple state
 aggregates that cover different time buckets. Any missing values at the time bucket
-boundaries are interpolated from adjacent StateAggs.
+boundaries are interpolated from adjacent StateAggs/TimelineAggs.
 
-```SQL
+```sql
 interpolated_duration_in(
-    state TEXT,
-    tws StateAgg,
+    state [TEXT | BIGINT],
+    tws [StateAgg | TimelineAgg],
     start TIMESTAMPTZ,
     interval INTERVAL,
-    prev StateAgg,
-    next StateAgg
+    prev [StateAgg | TimelineAgg],
+    next [StateAgg | TimelineAgg]
 ) RETURNS DOUBLE PRECISION
 ```
 
@@ -43,8 +43,8 @@ interpolated_duration_in(
 
 |Name|Type|Description|
 |-|-|-|
-|`state`|`TEXT`|State to query|
-|`aggregate`|`StateAgg`|Previously created state_agg aggregate|
+|`state`|`TEXT` or `BIGINT`|State to query|
+|`aggregate`|`StateAgg` or `TimelineAgg`|Previously created state_agg aggregate|
 |`start`|`TIMESTAMPTZ`|The start of the interval which this function should cover (if there is a preceeding point)|
 |`interval`|`INTERVAL`|The length of the interval|
 
@@ -52,8 +52,8 @@ interpolated_duration_in(
 
 |Name|Type|Description|
 |-|-|-|
-|`prev`|`StateAgg`|The `StateAgg` from the prior interval, used to interpolate the value at `start`. If `NULL`, the first timestamp in `aggregate` will be used as the start of the interval.|
-|`next`|`StateAgg`|The `StateAgg` from the following interval, used to interpolate the value at `start` + `interval`. If `NULL`, the last timestamp in `aggregate` will be used as the end of the interval.|
+|`prev`|`StateAgg` or `TimelineAgg`|The `StateAgg` or `TimelineAgg` from the prior interval, used to interpolate the value at `start`. If `NULL`, the first timestamp in `aggregate` is used as the start of the interval.|
+|`next`|`StateAgg` or `TimelineAgg`|The `StateAgg` or `TimelineAgg` from the following interval, used to interpolate the value at `start` + `interval`. If `NULL`, the last timestamp in `aggregate` is used as the end of the interval.|
 
 ## Returns
 
@@ -113,6 +113,6 @@ Which gives the result:
 If you prefer to see the result in seconds, [`EXTRACT`][extract] the epoch from
 the returned result.
 
-[duration_in]: /api/:currentVersion:/hyperfunctions/frequency-analysis/duration_in/
+[duration_in]: /api/:currentVersion:/hyperfunctions/state-aggregates/duration_in/
 [extract]: https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
-[state_agg]: /api/:currentVersion:/hyperfunctions/frequency-analysis/state_agg/
+[state_agg]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_agg/

--- a/api/interpolated_state_periods.md
+++ b/api/interpolated_state_periods.md
@@ -1,0 +1,91 @@
+---
+api_name: interpolated_state_periods()
+excerpt: Get time periods for a state from a timeline aggregate
+topics: [hyperfunctions]
+keywords: [duration, states, hyperfunctions, Toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+  version:
+    experimental: 1.13.0
+hyperfunction:
+  family: state aggregates
+  type: accessor
+  aggregates:
+    - state_agg() | timeline_agg()
+---
+
+import Experimental from 'versionContent/_partials/_experimental.mdx';
+
+# interpolated_state_periods()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
+Returns the times in a given state in a [timeline aggregate][state_agg].  
+
+Unlike [`state_periods`][state_periods], you can use this function across multiple state
+aggregates that cover different time buckets. Any missing values at the time bucket
+boundaries are interpolated from adjacent TimelineAggs.
+
+```sql
+interpolated_state_periods(
+    state [TEXT | BIGINT],
+    tws [StateAgg | TimelineAgg],
+    start TIMESTAMPTZ,
+    interval INTERVAL,
+    prev [StateAgg | TimelineAgg],
+    next [StateAgg | TimelineAgg]
+) RETURNS (TIMESTAMPTZ, TIMESTAMPTZ)
+```
+
+<Experimental />
+
+## Required arguments
+
+|Name|Type|Description|
+|-|-|-|
+|`state`|`TEXT` or `BIGINT`|State to query|
+|`aggregate`|`TimelineAgg`|Previously created state_agg aggregate|
+|`start`|`TIMESTAMPTZ`|The start of the interval which this function should cover (if there is a preceeding point)|
+|`interval`|`INTERVAL`|The length of the interval|
+
+### Optional arguments
+
+|Name|Type|Description|
+|-|-|-|
+|`prev`|`TimelineAgg`|The `TimelineAgg` from the prior interval, used to interpolate the value at `start`. If `NULL`, the first timestamp in `aggregate` is used as the start of the interval.|
+|`next`|`TimelineAgg`|The `TimelineAgg` from the following interval, used to interpolate the value at `start` + `interval`. If `NULL`, the last timestamp in `aggregate` is used as the end of the interval.|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`start_time`|`TIMESTAMPTZ`|The time the state started at (inclusive)|
+|`end_time`|`TIMESTAMPTZ`|The time the state ended at (exclusive)|
+
+## Sample usage
+
+Getting the interpolated history of states in a timeline aggregate:
+
+```sql
+SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
+    'OK',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '1 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+)
+ORDER BY start_time;
+```
+
+Example output:
+
+```
+       start_time       |        end_time
+------------------------+------------------------
+ 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+ 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+```
+
+[state_agg]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_agg/
+[state_periods]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_periods/

--- a/api/interpolated_state_periods.md
+++ b/api/interpolated_state_periods.md
@@ -68,23 +68,32 @@ interpolated_state_periods(
 Getting the interpolated history of states in a timeline aggregate:
 
 ```sql
-SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
-    'OK',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
-    '2019-12-31', '1 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
-)
-ORDER BY start_time;
+SELECT
+    bucket,
+    (toolkit_experimental.interpolated_state_periods(
+        'OK',
+        summary,
+        bucket,
+        '15 min',
+        LAG(summary) OVER (ORDER by bucket),
+        LEAD(summary) OVER (ORDER by bucket)
+    )).*
+FROM (
+    SELECT
+        time_bucket('1 min'::interval, ts) AS bucket,
+        toolkit_experimental.timeline_agg(ts, state) AS summary
+    FROM states_test
+    GROUP BY time_bucket('1 min'::interval, ts)
+) t;
 ```
 
 Example output:
 
 ```
-       start_time       |        end_time
-------------------------+------------------------
- 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
- 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+         bucket         |       start_time       |        end_time
+------------------------+------------------------+------------------------
+ 2020-01-01 00:00:00+00 | 2020-01-01 00:00:11+00 | 2020-01-01 00:15:00+00
+ 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00 | 2020-01-01 00:16:00+00
 ```
 
 [state_agg]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_agg/

--- a/api/interpolated_state_timeline.md
+++ b/api/interpolated_state_timeline.md
@@ -1,0 +1,92 @@
+---
+api_name: interpolated_state_timeline()
+excerpt: Get time periods for a state from a timeline aggregate
+topics: [hyperfunctions]
+keywords: [duration, states, hyperfunctions, Toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+  version:
+    experimental: 1.13.0
+hyperfunction:
+  family: state aggregates
+  type: accessor
+  aggregates:
+    - state_agg() | timeline_agg()
+---
+
+import Experimental from 'versionContent/_partials/_experimental.mdx';
+
+# interpolated_state_timeline()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
+Returns the interpolated timeline of states in a [timeline aggregate][state_agg].  
+
+Unlike [`state_timeline`][state_timeline], you can use this function across multiple state
+aggregates that cover different time buckets. Any missing values at the time bucket
+boundaries are interpolated from adjacent TimelineAggs.
+
+```sql
+interpolated_state_timeline(
+    tws [StateAgg | TimelineAgg],
+    start TIMESTAMPTZ,
+    interval INTERVAL,
+    prev [StateAgg | TimelineAgg],
+    next [StateAgg | TimelineAgg]
+) RETURNS (TIMESTAMPTZ, TIMESTAMPTZ)
+```
+
+<Experimental />
+
+## Required arguments
+
+|Name|Type|Description|
+|-|-|-|
+|`aggregate`|`TimelineAgg`|Previously created state_agg aggregate|
+|`start`|`TIMESTAMPTZ`|The start of the interval which this function should cover (if there is a preceeding point)|
+|`interval`|`INTERVAL`|The length of the interval|
+
+### Optional arguments
+
+|Name|Type|Description|
+|-|-|-|
+|`prev`|`TimelineAgg`|The `TimelineAgg` from the prior interval, used to interpolate the value at `start`. If `NULL`, the first timestamp in `aggregate` is used as the start of the interval.|
+|`next`|`TimelineAgg`|The `TimelineAgg` from the following interval, used to interpolate the value at `start` + `interval`. If `NULL`, the last timestamp in `aggregate` is used as the end of the interval.|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`state`|`TEXT` or `BIGINT`|A state found in the `TimelineAgg`|
+|`start_time`|`TIMESTAMPTZ`|The time the state started at (inclusive)|
+|`end_time`|`TIMESTAMPTZ`|The time the state ended at (exclusive)|
+
+## Sample usage
+
+Getting the interpolated history of states in a timeline aggregate:
+
+```sql
+SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '1 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+)
+ORDER BY start_time;
+```
+
+Example output:
+
+```
+ state |       start_time       |        end_time
+-------+------------------------+------------------------
+ START | 2019-12-31 00:00:00+00 | 2020-01-01 00:00:11+00
+ OK    | 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
+ OK    | 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+ STOP  | 2020-01-01 00:02:00+00 | 2020-01-01 00:02:00+00
+```
+
+[state_agg]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_agg/
+[state_timeline]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_timeline/

--- a/api/into_values-state_agg.md
+++ b/api/into_values-state_agg.md
@@ -14,7 +14,7 @@ hyperfunction:
   family: state aggregates
   type: accessor
   aggregates:
-    - state_agg()
+    - state_agg() | timeline_agg()
 ---
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';
@@ -25,8 +25,12 @@ Returns the data accumulated in a [state aggregate][state_agg].
 
 ```sql
 into_values (
-    agg StateAgg
+    agg [StateAgg | TimelineAgg]
 ) RETURNS (TEXT, BIGINT)
+
+into_int_values (
+    agg [StateAgg | TimelineAgg]
+) RETURNS (INT, BIGINT)
 ```
 
 <Experimental />
@@ -35,14 +39,14 @@ into_values (
 
 |Name|Type|Description|
 |-|-|-|
-|`agg`|`StateAgg`|The aggregate to display data for|
+|`agg`|`StateAgg` or `TimelineAgg`|The aggregate to display data for|
 
 ## Returns
 
 |Column|Type|Description|
 |-|-|-|
-|`state`|`TEXT`|A state found in the `StateAgg`|
-|`duration`|`BIGINT`|The duration of time spent in that state|
+|`state`|`TEXT`|A state found in the `StateAgg` or `TimelineAgg`|
+|`duration`|`BIGINT` or `INT`|The duration of time spent in that state|
 
 ## Sample usage
 
@@ -66,4 +70,4 @@ OK    | 106000000
 START |  11000000
 ```
 
-[state_agg]: /api/:currentVersion:/hyperfunctions/frequency-analysis/state_agg/
+[state_agg]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_agg/

--- a/api/page-index/page-index.js
+++ b/api/page-index/page-index.js
@@ -636,6 +636,26 @@ module.exports = [
                 title: "into_values (for state_agg)",
                 href: "into_values-state_agg",
               },
+              {
+                title: "rollup (for state_agg)",
+                href: "rollup-state_agg",
+              },
+              {
+                title: "state_timeline",
+                href: "state_timeline",
+              },
+              {
+                title: "state_periods",
+                href: "state_periods",
+              },
+              {
+                title: "interpolated_state_periods",
+                href: "interpolated_state_periods",
+              },
+              {
+                title: "interpolated_state_timeline",
+                href: "interpolated_state_timeline",
+              },
             ],
           },
         ],

--- a/api/rollup-state_agg.md
+++ b/api/rollup-state_agg.md
@@ -21,7 +21,7 @@ import Experimental from 'versionContent/_partials/_experimental.mdx';
 
 # rollup()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
 
-Combines multiple `StateAgg` aggregates. Using `rollup`, you can
+Combines multiple `StateAgg`/`TimelineAgg` aggregates. Using `rollup`, you can
 reaggregate a continuous aggregate into larger [time buckets][time_bucket].
 
 ```sql

--- a/api/rollup-state_agg.md
+++ b/api/rollup-state_agg.md
@@ -1,0 +1,61 @@
+---
+api_name: rollup()
+excerpt: Rollup multiple `StateAgg` aggregates
+topics: [hyperfunctions]
+keywords: [hyperfunctions, duration, states, hyperfunctions, Toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+  version:
+    experimental: 1.13.0
+hyperfunction:
+  family: state aggregates
+  type: accessor
+  aggregates:
+    - state_agg() | timeline_agg()
+---
+
+import Experimental from 'versionContent/_partials/_experimental.mdx';
+
+# rollup()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
+Combines multiple `StateAgg` aggregates. Using `rollup`, you can
+reaggregate a continuous aggregate into larger [time buckets][time_bucket].
+
+```sql
+rollup(
+    agg [StateAgg | TimelineAgg]
+) RETURNS [StateAgg | TimelineAgg]
+```
+
+<Experimental />
+
+## Required arguments
+
+|Name|Type|Description|
+|-|-|-|
+|`agg`|`StateAgg` or `TimelineAgg`|The aggregates to roll up|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`agg`|`StateAgg` or `TimelineAgg`|A new aggregate containing the combined rolled-up aggregates.|
+
+## Sample usage
+```sql
+WITH buckets AS (SELECT
+    time_bucket('1 minute', ts) as dt,
+    toolkit_experimental.state_agg(ts, state) AS sa
+FROM states_test
+GROUP BY time_bucket('1 minute', ts))
+SELECT toolkit_experimental.duration_in(
+    'START',
+    toolkit_experimental.rollup(buckets.sa)
+)
+FROM buckets;
+```
+
+[time_bucket]: /api/:currentVersion:/hyperfunctions/time_bucket/

--- a/api/state-aggregates.md
+++ b/api/state-aggregates.md
@@ -15,7 +15,9 @@ For these hyperfunctions, you need to install the [TimescaleDB Toolkit][install-
 `timeline_agg` supports all hyperfunctions that operate on StateAggs, in addition
 to some additional functions that need a full state timeline.
 
-All `state_agg` and `timeline_agg` hyperfunctions support both string (`TEXT`) and integer (`BIGINT`) states. You can't mix different types of states within a single aggregate.
+All `state_agg` and `timeline_agg` hyperfunctions support both string (`TEXT`) and integer (`BIGINT`) states. 
+You can't mix different types of states within a single aggregate.
+Integer states are useful when the state value is a foreign key representing a row in another table that stores all possible states.
 
 ## Hyperfunctions
 

--- a/api/state-aggregates.md
+++ b/api/state-aggregates.md
@@ -10,6 +10,15 @@ This section includes functions used to measure the time spent in a relatively s
 
 For these hyperfunctions, you need to install the [TimescaleDB Toolkit][install-toolkit] PostgreSQL extension.
 
+## Notes on state_agg and timeline_agg
+
+`timeline_agg` supports all hyperfunctions that operate on StateAggs, in addition
+to some additional functions that need a full state timeline.
+
+All `state_agg` and `timeline_agg` hyperfunctions support both string (`TEXT`) and integer (`BIGINT`) states. You can't mix different types of states within a single aggregate.
+
+## Hyperfunctions
+
 <hyperfunctionTable
     hyperfunctionFamily='state aggregates'
     includeExperimental

--- a/api/state_agg.md
+++ b/api/state_agg.md
@@ -1,5 +1,5 @@
 ---
-api_name: state_agg()
+api_name: state_agg() | timeline_agg()
 excerpt: Aggregate state data into a state aggregate for further analysis
 topics: [hyperfunctions]
 keywords: [states, aggregate, hyperfunctions, Toolkit]
@@ -17,12 +17,16 @@ hyperfunction:
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
-# state_agg()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+# state_agg() and timeline_agg() <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
 
 The `state_agg` aggregate measures the amount of time spent in each
 distinct value of a state field. It is designed to work with a relatively small
 number of states and might not perform well on queries where states are
 mostly distinct across rows.
+
+The `timeline_agg` aggregate works the same as `state_agg`, but also tracks when
+states are entered and exited. It has increased memory usage since it needs to
+track more data.
 
 <Experimental />
 
@@ -31,19 +35,22 @@ mostly distinct across rows.
 |Name|Type|Description|
 |-|-|-|
 |`ts`|`TIMESTAMPTZ`|Column of timestamps|
-|`value`|`TEXT`|Column of states|
+|`value`|`TEXT` or `BIGINT`|Column of states|
 
 ## Returns
 
 |Column|Type|Description|
 |-|-|-|
-|`stateagg`|`stateagg`|An object storing the total time spent in each state.|
+|`agg`|`StateAgg` or `TimelineAgg`|An object storing the total time spent in each state.|
 
 ## Sample usage
 
-This example creates a state aggregate over a `status` column in a `devices`
+This example creates an aggregate over a `status` column in a `devices`
 table, with a timestamp column `time`.
 
 ```sql
+-- create a state aggregate:
 SELECT toolkit_experimental.state_agg(time, status) FROM devices;
+-- create a timeline aggregate:
+SELECT toolkit_experimental.timeline_agg(time, status) FROM devices;
 ```

--- a/api/state_periods.md
+++ b/api/state_periods.md
@@ -1,0 +1,69 @@
+---
+api_name: state_periods()
+excerpt: Get time periods for a state from a timeline aggregate
+topics: [hyperfunctions]
+keywords: [duration, states, hyperfunctions, Toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+  version:
+    experimental: 1.13.0
+hyperfunction:
+  family: state aggregates
+  type: accessor
+  aggregates:
+    - state_agg() | timeline_agg()
+---
+
+import Experimental from 'versionContent/_partials/_experimental.mdx';
+
+# state_periods()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
+Returns the times in a given state in a [timeline aggregate][state_agg].  
+
+```sql
+state_periods(
+    state [TEXT | BIGINT],
+    agg TimelineAgg
+) RETURNS (TIMESTAMPTZ, TIMESTAMPTZ)
+```
+
+<Experimental />
+
+## Required arguments
+
+|Name|Type|Description|
+|-|-|-|
+|`state`|`TEXT` or `BIGINT`|The state to get data for|
+|`agg`|`TimelineAgg`|The aggregate to get data for|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`start_time`|`TIMESTAMPTZ`|The time the state started at (inclusive)|
+|`end_time`|`TIMESTAMPTZ`|The time the state ended at (exclusive)|
+
+## Sample usage
+
+Getting the history of states in a timeline aggregate:
+
+```sql
+SELECT start_time, end_time FROM toolkit_experimental.state_periods(
+  'OK',
+  (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test)
+);
+```
+
+Example output:
+
+```
+       start_time       |        end_time
+------------------------+------------------------
+ 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+ 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+```
+
+[state_agg]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_agg/

--- a/api/state_timeline.md
+++ b/api/state_timeline.md
@@ -1,0 +1,73 @@
+---
+api_name: state_timeline()
+excerpt: Get all state periods from a timeline aggregate
+topics: [hyperfunctions]
+keywords: [duration, states, hyperfunctions, Toolkit]
+api:
+  license: community
+  type: function
+  experimental: true
+  toolkit: true
+  version:
+    experimental: 1.13.0
+hyperfunction:
+  family: state aggregates
+  type: accessor
+  aggregates:
+    - state_agg() | timeline_agg()
+---
+
+import Experimental from 'versionContent/_partials/_experimental.mdx';
+
+# state_timeline()  <tag type="toolkit">Toolkit</tag><tag type="experimental-toolkit">Experimental</tag>
+
+Returns the timeline of states in a [timeline aggregate][state_agg].  
+
+```sql
+state_timeline(
+    agg TimelineAgg
+) RETURNS (TEXT, TIMESTAMPTZ, TIMESTAMPTZ)
+
+state_int_timeline(
+    agg TimelineAgg
+) RETURNS (BIGINT, TIMESTAMPTZ, TIMESTAMPTZ)
+```
+
+<Experimental />
+
+## Required arguments
+
+|Name|Type|Description|
+|-|-|-|
+|`agg`|`TimelineAgg`|The aggregate to get data for|
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`state`|`TEXT` or `BIGINT`|A state found in the `TimelineAgg`|
+|`start_time`|`TIMESTAMPTZ`|The time the state started at (inclusive)|
+|`end_time`|`TIMESTAMPTZ`|The time the state ended at (exclusive)|
+
+## Sample usage
+
+Getting the history of states in a timeline aggregate:
+
+```sql
+SELECT state, start_time, end_time FROM toolkit_experimental.state_timeline(
+     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test));
+```
+
+Example output:
+
+```
+ state |       start_time       |        end_time
+-------+------------------------+------------------------
+ START | 2020-01-01 00:00:00+00 | 2020-01-01 00:00:11+00
+ OK    | 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
+ OK    | 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+ STOP  | 2020-01-01 00:02:00+00 | 2020-01-01 00:02:00+00
+```
+
+[state_agg]: /api/:currentVersion:/hyperfunctions/state-aggregates/state_agg/


### PR DESCRIPTION
# Description

Documents all of the changes made to `state_agg` and `timeline_agg` (including the new support for integer states and rollup) in TimescaleDB Toolkit 1.13.

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
