### PR TITLE
Fix missing link in financial tick data tutorial

### DIFF
--- a/timescaledb/tutorials/financial-tick-data/financial-tick-query.md
+++ b/timescaledb/tutorials/financial-tick-data/financial-tick-query.md
@@ -25,7 +25,7 @@ lowest prices, you can use the standard PostgreSQL aggregate functions `MIN` and
 In TimescaleDB, the most efficient way to create candlestick views is to use
 [continuous aggregates][caggs].
 In this tutorial, you create a continuous aggregate for a candlestick time
-bucket, and then query the aggregate with different refresh policies. Finally, 
+bucket, and then query the aggregate with different refresh policies. Finally,
 you can use Grafana to visualize your data as a candlestick chart.
 
 ## Create a continuous aggregate
@@ -153,4 +153,4 @@ this, see the [Grafana setup instructions][grafana-setup].
 [last]: /api/:currentVersion:/hyperfunctions/last/
 [time-bucket]: /api/:currentVersion:/hyperfunctions/time_bucket/
 [lag]: https://www.postgresqltutorial.com/postgresql-lag-function/
-[grafana-setup]: FIXME
+[grafana-setup]: /timescaledb/:currentVersion:/tutorials/grafana/grafana-timescalecloud/


### PR DESCRIPTION
# Description

Looks like I missed a link when I redid the tutorial. The other two reports seem to be working just fine, so let's see how this report looks tomorrow 🤞 

# Links

Fixes https://github.com/timescale/docs/issues/1902

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
