### PR TITLE
Remove connection string from Cloud Connect partial

### DIFF
--- a/_partials/_cloud-connect.md
+++ b/_partials/_cloud-connect.md
@@ -20,7 +20,7 @@ psql][install-psql] section.
     you just created:
 
     ```bash
-    psql -x "postgres://tsdbadmin@t9aggksc24.gspnhi29bv.tsdb.cloud.timescale.com:33251/tsdb?sslmode=require"
+    psql -x "<SERVICE_URL>"
     Password for user tsdbadmin:
     ```
 


### PR DESCRIPTION
# Description

This partial contains a literal connection string, and is used in several pages throughout the docs. This PR updates the literal string to be a replaceable instead.

# Links

Fixes https://github.com/timescale/docs/issues/1892

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
