### PR TITLE
docs: link the Troubleshooting page

### DIFF
--- a/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
+++ b/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
@@ -19,7 +19,8 @@ the [upgrading instructions][timescaledb-upgrade].
 <highlight type="warning">
 If you are using this `pg_dump` backup method regularly, make sure you keep
 track of which versions of PostgreSQL and TimescaleDB you are running. For more
-information, see "Versions are mismatched when dumping and restoring a database" in the section [Troubleshooting](https://docs.timescale.com/timescaledb/latest/how-to-guides/backup-and-restore/troubleshooting/).
+information, see "Versions are mismatched when dumping and restoring a database" 
+in the [Troubleshooting section](https://docs.timescale.com/timescaledb/latest/how-to-guides/backup-and-restore/troubleshooting/).
 </highlight>
 
 ## Back up your entire database

--- a/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
+++ b/timescaledb/how-to-guides/backup-and-restore/pg-dump-and-restore.md
@@ -19,7 +19,7 @@ the [upgrading instructions][timescaledb-upgrade].
 <highlight type="warning">
 If you are using this `pg_dump` backup method regularly, make sure you keep
 track of which versions of PostgreSQL and TimescaleDB you are running. For more
-information, see "Troubleshooting version mismatches" in this section.
+information, see "Versions are mismatched when dumping and restoring a database" in the section [Troubleshooting](https://docs.timescale.com/timescaledb/latest/how-to-guides/backup-and-restore/troubleshooting/).
 </highlight>
 
 ## Back up your entire database


### PR DESCRIPTION
Signed-off-by: Hongbo Miao <3375461+Hongbo-Miao@users.noreply.github.com>

# Description

Close https://github.com/timescale/docs/issues/1922

Just a small improvement to make it more user friendly. 😃

I originally failed to locate the document mentioned in
<img width="715" alt="image" src="https://user-images.githubusercontent.com/3375461/211168027-0c823e67-da7d-4f28-b714-5522e79a5230.png">

# Links

https://docs.timescale.com/timescaledb/latest/how-to-guides/backup-and-restore/pg-dump-and-restore/

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [x] Is the content free from typos?
- [x] Does the content use plain English?
- [x] Does the content contain clear sections for concepts, tasks, and references?
- [x] Have any images been uploaded to the correct location, and are resolvable?
- [x] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
