### PR TITLE
Add note about detached head state

### DIFF
--- a/install/installation-source.md
+++ b/install/installation-source.md
@@ -48,8 +48,12 @@ If you are installing from source on a Microsoft Windows system, you also need:
     our [Releases page][gh-releases]:
 
     ```bash
-    git checkout 2.5.1
+    git checkout 2.9.1
     ```
+
+    This command produces an error that you are now in `detached head` state. It
+    is expected behavior, and it occurs because you have checked out a tag, and
+    not a branch. Continue with the steps in this procedure as normal.
 
 1.  Bootstrap the build system:
     <terminal>
@@ -151,7 +155,7 @@ to find out which PostgreSQL installation TimescaleDB is using.
     <tab label='Linux'>
 
     ```bash
-    service postgresql restart  
+    service postgresql restart
     ```
 
     </tab>


### PR DESCRIPTION
# Description

Adds note about the detached head state warning. 

@erichosick While you are absolutely correct that `git switch --detach` would work, unfortunately git still has the `switch` command listed as experimental, so I am refraining from using it in official documentation (even though I use it myself, all the time 😅 ). For now, hopefully this note will prevent people from getting too confused.

# Links

Fixes https://github.com/timescale/docs/issues/1848

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
