### PR TITLE
Remove legacy k8s manifest section

### DIFF
--- a/promscale/installation/kubernetes.md
+++ b/promscale/installation/kubernetes.md
@@ -189,33 +189,6 @@ can provide the database URI, or specify connection parameters.
 
 </procedure>
 
-## Install Promscale with a manifest file
-
-This section includes instructions to install the Promscale Connector using a
-manifest file. To deploy TimescaleDB on Kubernetes use
-[helm charts][install-helm] instead. Alternatively, you can
-[install TimescaleDB on a host][install-binary].
-
-<procedure>
-
-#### Installing the Promscale Connector with a manifest
-
-1.  Download the [template manifest file][template-manifest]:
-
-    ```bash
-    curl https://raw.githubusercontent.com/timescale/promscale/0.13.0/deploy/static/deploy.yaml --output promscale-connector.yaml
-    ```
-
-1.  Edit the manifest and configure the TimescaleDB database details using the
-    parameters starting with <PROMSCALE_DB>.
-1.  Deploy the manifest:
-
-    ```bash
-    kubectl apply -f promscale-connector.yaml
-    ```
-
-</procedure>
-
 <PromscaleSendData />
 
 [install-binary]: /promscale/:currentVersion:/installation/binary/


### PR DESCRIPTION
# Description

The K8S manifest install instruction are deprecated and the file no it points out no longer exists.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
