### PR TITLE
Update windows install info for path instructions

### DIFF
--- a/install/installation-source.md
+++ b/install/installation-source.md
@@ -18,15 +18,18 @@ Before you start, make sure you have installed:
 *   PostgreSQL 12 or later, with a development environment. For more information
     about PostgreSQL installation, including downloads and instructions, see the
     [PostgreSQL documentation][postgres-download].
-*   CMake version 3.11 or later. For more information about CMake installation,
-    including downloads and instructions, see the
-    [CMake documentation][cmake-download].
+
+You also need:
+
+*   CMake version 3.11 or later for your operating system. For more information
+    about CMake installation, including downloads and instructions, see the [CMake documentation][cmake-download].
 *   C language compiler for your operating system, such as `gcc` or `clang`.
 
-If you are installing from source on a Microsoft Windows system, you also need:
-
-*   Visual Studio 2015 or later, packaged with CMake version 3.11 or later, and
-    Git components.
+<highlight type="note">
+If you are using a Microsoft Windows system, you can install Visual Studio 2015
+or later instead of CMake and a C language compiler. Ensure you install the
+Visual Studio components for CMake and Git when you run the installer.
+</highlight>
 
 <procedure>
 
@@ -35,7 +38,7 @@ If you are installing from source on a Microsoft Windows system, you also need:
 1.  At the command prompt, clone the Timescale GitHub repository:
 
     ```bash
-    git clone https://github.com/timescale/timescaledb.git
+    git clone https://github.com/timescale/timescaledb
     ```
 
 1.  Change into the cloned directory:
@@ -56,6 +59,7 @@ If you are installing from source on a Microsoft Windows system, you also need:
     not a branch. Continue with the steps in this procedure as normal.
 
 1.  Bootstrap the build system:
+
     <terminal>
 
     <tab label='Linux'>
@@ -75,7 +79,17 @@ If you are installing from source on a Microsoft Windows system, you also need:
     </tab>
 
     </terminal>
-1.  Build the extension:
+
+    <highlight type="important">
+    For installation on Microsoft Windows, you might need to add the `pg_config`
+    and `cmake` file locations to your path. In the Windows Search tool, search
+    for `system environment variables`. The path for `pg_config` should be
+    `C:\Program Files\PostgreSQL\<version>\bin`. The path for `cmake` is within
+    the Visual Studio directory.
+    </highlight>
+
+2.  Build the extension:
+
     <terminal>
 
     <tab label='Linux'>
@@ -95,7 +109,9 @@ If you are installing from source on a Microsoft Windows system, you also need:
     </tab>
 
     </terminal>
-1.  Install TimescaleDB:
+
+3.  Install TimescaleDB:
+
     <terminal>
 
     <tab label='Linux'>

--- a/install/installation-source.md
+++ b/install/installation-source.md
@@ -88,7 +88,7 @@ Visual Studio components for CMake and Git when you run the installer.
     the Visual Studio directory.
     </highlight>
 
-2.  Build the extension:
+1.  Build the extension:
 
     <terminal>
 
@@ -110,7 +110,7 @@ Visual Studio components for CMake and Git when you run the installer.
 
     </terminal>
 
-3.  Install TimescaleDB:
+1.  Install TimescaleDB:
 
     <terminal>
 

--- a/install/installation-windows.md
+++ b/install/installation-windows.md
@@ -40,16 +40,17 @@ current PostgreSQL installation, do not install TimescaleDB using this method.
 1.  Download and install the Visual C++ Redistributable for Visual Studio from
     [www.microsoft.com][ms-download].
 1.  Download and install PostgreSQL from [www.postgresql.org][pg-download].
-1.  In the Windows Search tool, search for `system environment variables`. In
-    the `System Properties` dialog, navigate to the `Advanced` tab, and
-    click `Environment Variables...`. Locate the `Path` variable and
-    click `Edit...`. In the `Edit environment variable` dialog, click `New` and
-    type the path to your PostgreSQL `pg_config` file. It should
-    be `C:\Program Files\PostgreSQL\14\bin\`. Click `OK` to save your changes.
-1.  Download the TimescaleDB installation `.zip` file from our
+
+    <highlight type="important">
+    You might need to add the `pg_config` file location to your path. In the Windows
+    Search tool, search for `system environment variables`. The path should be
+    `C:\Program Files\PostgreSQL\<version>\bin`.
+    </highlight>
+
+2.  Download the TimescaleDB installation `.zip` file from our
     [Windows releases][windows-releases].
-1.  Locate the downloaded file on your local file system, and extract the files.
-1.  In the extracted TimescaleDB directory, right-click the `setup.exe` file and
+3.  Locate the downloaded file on your local file system, and extract the files.
+4.  In the extracted TimescaleDB directory, right-click the `setup.exe` file and
     select `Run as Administrator` to start the installer.
 
 </procedure>

--- a/install/installation-windows.md
+++ b/install/installation-windows.md
@@ -47,10 +47,10 @@ current PostgreSQL installation, do not install TimescaleDB using this method.
     `C:\Program Files\PostgreSQL\<version>\bin`.
     </highlight>
 
-2.  Download the TimescaleDB installation `.zip` file from our
+1.  Download the TimescaleDB installation `.zip` file from our
     [Windows releases][windows-releases].
-3.  Locate the downloaded file on your local file system, and extract the files.
-4.  In the extracted TimescaleDB directory, right-click the `setup.exe` file and
+1.  Locate the downloaded file on your local file system, and extract the files.
+1.  In the extracted TimescaleDB directory, right-click the `setup.exe` file and
     select `Run as Administrator` to start the installer.
 
 </procedure>


### PR DESCRIPTION
# Description

Updates Windows install instructions (source and on prem), to include extra information about pg_config and cmake on the path. Also clarified prereqs on from source install to make it clearer.

@crispynz4 Thanks for the feedback! Hopefully this helps 😄 

# Links

Fixes https://github.com/timescale/docs/issues/1578

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
