### PR TITLE
OpenSSL requirement for installing PG15 on windows

### DIFF
--- a/install/installation-windows.md
+++ b/install/installation-windows.md
@@ -46,6 +46,8 @@ current PostgreSQL installation, do not install TimescaleDB using this method.
     click `Edit...`. In the `Edit environment variable` dialog, click `New` and
     type the path to your PostgreSQL `pg_config` file. It should
     be `C:\Program Files\PostgreSQL\14\bin\`. Click `OK` to save your changes.
+1.  If installing PostgreSQL version 15.1.1 or above, make sure OpenSSL 1.1.1 is
+    installed on the system.
 1.  Download the TimescaleDB installation `.zip` file from our
     [Windows releases][windows-releases].
 1.  Locate the downloaded file on your local file system, and extract the files.


### PR DESCRIPTION
# Description

Installation of timescaledb with PG 15.1.1 or higher installer on windows requires OpenSSL 1.1.1 to be installed on the system.

# Links

Fixes #[insert issue link, if any]

https://github.com/timescale/eng-database/issues/344

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
