### PR TITLE
Correct heading levels for hyperfunction examples

### DIFF
--- a/api/_hyperfunctions/candlestick_agg/examples.md
+++ b/api/_hyperfunctions/candlestick_agg/examples.md
@@ -3,7 +3,7 @@ section: hyperfunction
 subsection: candlestick_agg()
 ---
 
-# Get candlestick values from tick data
+### Get candlestick values from tick data
 
 Query your tick data table for the opening, high, low, and closing prices, and
 the trading volume, for each 1 hour period in the last day:

--- a/api/_hyperfunctions/hyperloglog/examples.md
+++ b/api/_hyperfunctions/hyperloglog/examples.md
@@ -3,7 +3,7 @@ section: hyperfunction
 subsection: hyperloglog()
 ---
 
-# Roll up two hyperloglogs
+### Roll up two hyperloglogs
 
 Roll up two hyperloglogs. The first hyperloglog buckets the integers from 1 to
 100,000, and the second hyperloglog buckets the integers from 50,000 to

--- a/api/_hyperfunctions/max_n/examples.md
+++ b/api/_hyperfunctions/max_n/examples.md
@@ -3,7 +3,7 @@ section: hyperfunction
 subsection: max_n()
 ---
 
-# Get the 10 largest transactions from a table of stock trades
+### Get the 10 largest transactions from a table of stock trades
 
 This example assumes that you have a table of stock trades in this format:
 

--- a/api/_hyperfunctions/ohlc/examples.md
+++ b/api/_hyperfunctions/ohlc/examples.md
@@ -3,7 +3,7 @@ section: hyperfunction
 subsection: ohlc()
 ---
 
-# Calculate by-minute stock-tick prices
+### Calculate by-minute stock-tick prices
 
 Combine stock tick data into one-minute buckets. Return the asset prices and
 timestamps for each minute:

--- a/api/_hyperfunctions/tdigest/examples.md
+++ b/api/_hyperfunctions/tdigest/examples.md
@@ -3,7 +3,7 @@ section: hyperfunction
 subsection: tdigest()
 ---
 
-# Aggregate and roll up percentile data to calculate daily percentiles
+### Aggregate and roll up percentile data to calculate daily percentiles
 
 Create an hourly continuous aggregate that contains a percentile aggregate:
 

--- a/api/_hyperfunctions/time_weight/examples.md
+++ b/api/_hyperfunctions/time_weight/examples.md
@@ -3,7 +3,7 @@ section: hyperfunction
 subsection: time_weight()
 ---
 
-# Aggregate data into a `TimeWeightSummary` and calculate the average
+### Aggregate data into a `TimeWeightSummary` and calculate the average
 
 Given a table `foo` with data in a column `val`, aggregate data into a daily
 `TimeWeightSummary`. Use that to calculate the average for column `val`:

--- a/api/_hyperfunctions/uddsketch/examples.md
+++ b/api/_hyperfunctions/uddsketch/examples.md
@@ -3,7 +3,7 @@ section: hyperfunction
 subsection: uddsketch()
 ---
 
-# Aggregate and roll up percentile data to calculate daily percentiles using `percentile_agg`
+### Aggregate and roll up percentile data to calculate daily percentiles using `percentile_agg`
 
 Create an hourly continuous aggregate that contains a percentile aggregate:
 


### PR DESCRIPTION
# Description

Examples in the `examples.md` file should be `h3` because they sit under the `h2` "Extended examples" heading. As `h1`s, the default styling for the page makes them too big.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
