### PR TITLE
Update GitHub Actions to remove set-output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set variables
-        run: |
-          echo "::set-output name=DEV_FOLDER::$(echo ${GITHUB_HEAD_REF} | sed 's|/|-|')"
-          echo "::set-output name=STAGING_BRANCH::$(echo ${GITHUB_HEAD_REF})"
-
         id: timescale
+        run: |
+          echo "DEV_FOLDER=$(echo ${GITHUB_HEAD_REF} | sed 's|/|-|')" >> $GITHUB_OUTPUT
+          echo "STAGING_BRANCH=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588


### PR DESCRIPTION
# Description

`set-output` is deprecated and the official GitHub advice is to use environment files instead. This commit updates our actions to match.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
