### PR TITLE
Fix argument name for state/timeline functions

### DIFF
--- a/api/_hyperfunctions/state_agg/interpolated_duration_in.md
+++ b/api/_hyperfunctions/state_agg/interpolated_duration_in.md
@@ -25,7 +25,7 @@ api_details:
       code: |
         interpolated_duration_in(
           state {TEXT | BIGINT},
-          tws StateAgg,
+          agg StateAgg,
           start TIMESTAMPTZ,
           interval INTERVAL
           [, prev StateAgg]
@@ -36,7 +36,7 @@ api_details:
       - name: state
         type: TEXT | BIGINT
         description: The state to query
-      - name: tws
+      - name: agg
         type: StateAgg
         description: A state aggregate created with [`state_agg`](#state_agg)
       - name: start

--- a/api/_hyperfunctions/timeline_agg/interpolated_duration_in.md
+++ b/api/_hyperfunctions/timeline_agg/interpolated_duration_in.md
@@ -25,7 +25,7 @@ api_details:
       code: |
         interpolated_duration_in(
           state {TEXT | BIGINT},
-          tws TimelineAgg,
+          agg TimelineAgg,
           start TIMESTAMPTZ,
           interval INTERVAL
           [, prev TimelineAgg]
@@ -36,7 +36,7 @@ api_details:
       - name: state
         type: TEXT | BIGINT
         description: The state to query
-      - name: tws
+      - name: agg
         type: TimelineAgg
         description: A timeline aggregate created with [`timeline_agg`](#timeline_agg)
       - name: start

--- a/api/_hyperfunctions/timeline_agg/interpolated_state_periods.md
+++ b/api/_hyperfunctions/timeline_agg/interpolated_state_periods.md
@@ -29,7 +29,7 @@ api_details:
       code: |
         interpolated_state_periods(
           state [TEXT | BIGINT],
-          tws TimelineAgg,
+          agg TimelineAgg,
           start TIMESTAMPTZ,
           interval INTERVAL,
           [, prev TimelineAgg]
@@ -40,7 +40,7 @@ api_details:
       - name: state
         type: TEXT | BIGINT
         description: The state to query
-      - name: tws
+      - name: agg
         type: TimelineAgg
         description: A timeline aggregate created with [`timeline_agg`](#timeline_agg)
       - name: start

--- a/api/_hyperfunctions/timeline_agg/interpolated_state_timeline.md
+++ b/api/_hyperfunctions/timeline_agg/interpolated_state_timeline.md
@@ -26,7 +26,7 @@ api_details:
     - language: sql
       code: |
         interpolated_state_timeline(
-            tws TimelineAgg,
+            agg TimelineAgg,
             start TIMESTAMPTZ,
             interval INTERVAL,
             [, prev TimelineAgg]
@@ -37,7 +37,7 @@ api_details:
       - name: state
         type: TEXT | BIGINT
         description: The state to query
-      - name: tws
+      - name: agg
         type: TimelineAgg
         description: A timeline aggregate created with [`timeline_agg`](#timeline_agg)
       - name: start


### PR DESCRIPTION
# Description

For the state/timeline aggregates, the name of the argument for the aggregate is written as `tws` instead of `agg` in a few parts of the documentation. `tws` stands for Time-Weighted Summary, which is not applicable here. I think I copied from the time-weighted average documentation and forgot to change the parameter name.

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
