### PR TITLE
metadata: add cloud ui path data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _notes/
 .github/workflows/update-search.yml
 *.swp
 .helper-scripts/hyperfunctions/target/
+.vscode/settings.json

--- a/cloud/billing/account-management.md
+++ b/cloud/billing/account-management.md
@@ -4,6 +4,9 @@ excerpt: Manage billing information for your Timescale Cloud account
 product: cloud
 keywords: [billing, accounts, admin]
 tags: [payment]
+cloud_ui:
+    path:
+        - [billing, details]
 ---
 
 # Billing - Account management

--- a/cloud/billing/index.md
+++ b/cloud/billing/index.md
@@ -4,6 +4,10 @@ excerpt: How billing works for Timescale Cloud
 product: cloud
 keywords: [billing, accounts, admin]
 tags: [payment]
+cloud_ui:
+    path:
+        - [billing, details]
+    priority: 1
 ---
 
 # Billing

--- a/cloud/cloud-multi-node.md
+++ b/cloud/cloud-multi-node.md
@@ -4,6 +4,9 @@ excerpt: Horizontally scale your database by setting up multi-node on Timescale 
 product: cloud
 keywords: [multi-node, scaling]
 tags: [cluster, distributed hypertables]
+cloud_ui:
+    path:
+        - [services]
 ---
 
 # Multi-node on Timescale Cloud

--- a/cloud/data-tiering/index.md
+++ b/cloud/data-tiering/index.md
@@ -4,6 +4,10 @@ excerpt: Save on storage costs by tiering older data to separate storage
 product: cloud
 keywords: [data tiering]
 tags: [storage, data management]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, data-tiering]
+    priority: 1
 ---
 
 import ExperimentalPrivateBeta from 'versionContent/_partials/_experimental-private-beta.mdx';

--- a/cloud/data-tiering/tier-data-object-storage.md
+++ b/cloud/data-tiering/tier-data-object-storage.md
@@ -4,6 +4,9 @@ excerpt: How to tier Timescale Cloud data to object storage
 product: cloud
 keywords: [data tiering]
 tags: [storage, data management]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, data-tiering]
 ---
 
 import ExperimentalPrivateBeta from 'versionContent/_partials/_experimental-private-beta.mdx';

--- a/cloud/integrations.md
+++ b/cloud/integrations.md
@@ -4,6 +4,10 @@ excerpt: Export telemetry metrics to Datadog or AWS CloudWatch
 product: cloud
 keywords: [integration, metrics, Datadog, AWS CloudWatch]
 tags: [telemetry, monitor]
+cloud_ui:
+    path:
+        - [integrations]
+        - [services, :serviceID, operations, integrations]
 ---
 
 import ExporterRegionNote from 'versionContent/_partials/_cloud-integrations-exporter-region.mdx';

--- a/cloud/members/index.md
+++ b/cloud/members/index.md
@@ -1,12 +1,17 @@
 ---
 title: Members
-excerpt: Manage users in your Timescale Cloud project
+excerpt: User management for your Timescale Cloud project
 product: cloud
 keywords: [members, projects, admin, roles]
 tags: [users]
+cloud_ui:
+    path:
+        - [members]
+    priority: 1
 ---
 
 # Members
+
 When you log in to your [Timescale Cloud account][cloud-login], navigate to the
 `Members` page to manage users of your project. From here, you can see the
 current members of your Timescale Cloud project, and add and remove members.
@@ -14,6 +19,7 @@ current members of your Timescale Cloud project, and add and remove members.
 <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-users-list.png" alt="Timescale Cloud Members"/>
 
 ## About Timescale Cloud user management
+
 Timescale Cloud allows you to collaborate with other users on your projects.
 When you have created your project, you can add other users so that they can see
 your project in their Timescale Cloud console. You can add, manage, and delete

--- a/cloud/members/members-list.md
+++ b/cloud/members/members-list.md
@@ -1,9 +1,12 @@
 ---
-title: Members
+title: Manage members
 excerpt: Add or remove members from a project, or leave a project
 product: cloud
 keywords: [members, projects, admin, roles]
 tags: [users]
+cloud_ui:
+    path:
+        - [members]
 ---
 
 # Members

--- a/cloud/service-explorer.md
+++ b/cloud/service-explorer.md
@@ -3,6 +3,9 @@ title: Service explorer
 excerpt: Get insight into the performance and structure of your database
 product: cloud
 keywords: [services, hypertables, schemas, indexes, policies]
+cloud_ui:
+    path:
+        - [services, :serviceID, overview]
 ---
 
 # Service explorer
@@ -45,7 +48,7 @@ aggregates, and policies such as data retention policies and data reordering.
 You can also inspect individual hypertables, including their sizes, dimension
 ranges, and compression status.
 
-You can also set a compression policy from this section. For more information, see the 
+You can also set a compression policy from this section. For more information, see the
 [Setting a compression policy from Timescale Cloud console][set-compression] section.
 
 <img class="main-content__illustration"

--- a/cloud/service-logs.md
+++ b/cloud/service-logs.md
@@ -3,6 +3,9 @@ title: Service logs
 excerpt: View your Timescale Cloud service logs
 product: cloud
 keywords: [logs, services]
+cloud_ui:
+    path:
+        - [services, :serviceID, logs]
 ---
 
 # Service logs

--- a/cloud/service-metrics.md
+++ b/cloud/service-metrics.md
@@ -4,6 +4,9 @@ excerpt: View metrics for your Timescale Cloud service, such as CPU, memory, and
 product: cloud
 keywords: [metrics, monitoring, services]
 tags: [dashboard, cpu, memory, storage, disk space]
+cloud_ui:
+    path:
+        - [services, :serviceID, metrics]
 ---
 
 # Service metrics

--- a/cloud/service-operations/autoscaling.md
+++ b/cloud/service-operations/autoscaling.md
@@ -4,9 +4,13 @@ excerpt: Set up Timescale Cloud to automatically resize your compute and storage
 product: cloud
 keywords: [scaling, services, operations]
 tags: [cpu, storage, disk space]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, autoscaling]
 ---
 
 # Service operations - Autoscaling
+
 Timescale Cloud allows you to resize compute (CPU/RAM) and storage independently
 at any time. This is useful when you need to do something like increasing your
 storage capacity, but not your compute size. You can resize compute and storage
@@ -15,6 +19,7 @@ clusters.
 
 Storage changes are applied with no downtime, and the new storage capacity is
 usually available for use within a few seconds.
+
 *   Storage can only be increased in size. You cannot decrease the amount of
     storage capacity your service has available.
 *   Storage size changes can only be made once every six hours.
@@ -23,6 +28,7 @@ usually available for use within a few seconds.
 
 You can increase or decrease the compute size of your service at any time, with
 a short downtime.
+
 *   There is momentary downtime while the new compute settings are applied.
     In most cases, this downtime is less than 30 seconds.
 *   Because compute changes require an interruption to your service, plan
@@ -44,9 +50,11 @@ resources your service has available, as well as change the disk size for your
 service. You can adjust this manually as required, or for disk size you can use autoscaling.
 
 ## Change resource allocations manually
+
 You can manually change both storage and compute resources.
 
 ### Storage resources
+
 When you change the disk size, the changes are applied with no downtime. The
 new size generally becomes available within a few seconds. You can only increase
 your disk size, not decrease it, up to a maximum of 16&nbsp;TB.
@@ -65,6 +73,7 @@ documentation. To prevent this, wait for the recommended time between resizes.
 </highlight>
 
 ### Compute resources
+
 You can change the CPU and memory allocation for your service at any time, with
 minimal downtime, usually less than thirty seconds. The new resources become
 available as soon as the service restarts. You can change the CPU and memory
@@ -78,6 +87,7 @@ plan for this before you begin!
 <procedure>
 
 ### Changing resource allocations manually
+
 1.  In the Timescale Cloud console, from the `Services` list, click the name of
     the service you want to modify.
 1.  In the `Service details` page, navigate to the `Operations` tab, and click
@@ -93,6 +103,7 @@ plan for this before you begin!
 </procedure>
 
 ## Configure autoscaling for disk size
+
 Disk size autoscaling is enabled by default on most services. When you consume
 85% or more of your existing disk space, disk size is automatically increased to
 the next size available, up to a configurable limit.
@@ -125,6 +136,7 @@ have a single scaling threshold that applies across all the data nodes.
 <procedure>
 
 ### Configuring autoscaling for disk size
+
 1.  In the Timescale Cloud console, from the `Services` list, click the name of
     the service you want to modify.
 1.  In the `Service overview` page, navigate to the `Operations` tab, and click
@@ -141,6 +153,7 @@ have a single scaling threshold that applies across all the data nodes.
 </procedure>
 
 ### Limitations of autoscaling
+
 Under very heavy data ingest loads, your data might grow faster than your new
 storage can be optimized. There must be a gap of at least 6 hours between
 resizes. For larger databases, there should be a gap of 6 to 24 hours for each
@@ -164,7 +177,9 @@ If you expect your data to grow from 85&nbsp;GB to 118&nbsp;GB within a day, you
 should manually resize your storage to accommodate the heavy load.
 
 ### Size increase gradations
+
 Size increases occur with these gradations:
+
 *   10&nbsp;GB
 *   25&nbsp;GB
 *   50&nbsp;GB

--- a/cloud/service-operations/database-parameters/advanced-parameters.md
+++ b/cloud/service-operations/database-parameters/advanced-parameters.md
@@ -4,6 +4,9 @@ excerpt: Configure advanced parameters for your Timescale Cloud service
 product: cloud
 keywords: [services, settings]
 tags: [configuration, schemas]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, database_parameters]
 ---
 
 # Service settings - advanced parameters

--- a/cloud/service-operations/database-parameters/customize-configuration.md
+++ b/cloud/service-operations/database-parameters/customize-configuration.md
@@ -3,6 +3,10 @@ title: Service operations - Configure database parameters
 excerpt: Customize the configuration of your TimescaleDB database
 product: cloud
 keywords: [configure, services, settings]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, database_parameters]
+    priority: 1
 ---
 
 # Service operations - Configure database parameters

--- a/cloud/service-operations/maintenance.md
+++ b/cloud/service-operations/maintenance.md
@@ -3,6 +3,9 @@ title: Service operations - Maintenance
 excerpt: How your Timescale Cloud service is kept up-to-date
 product: cloud
 keywords: [updates, upgrades, maintenance]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, maintenance]
 ---
 
 # Service operations - Maintenance

--- a/cloud/service-operations/replicas.md
+++ b/cloud/service-operations/replicas.md
@@ -4,9 +4,13 @@ excerpt: Set up replicas on Timescale Cloud for high availability
 product: cloud
 keywords: [high avilability, replicas]
 tags: [failover, availability zones, replication, wal]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, replication]
 ---
 
 # Service operations - Replicas
+
 Replicas are up-to-date, running databases that contain the same data as your
 primary database. If your primary database fails, the replica can take over
 within a few seconds. Having replicas of your database is also known as instance
@@ -24,15 +28,16 @@ To learn how to create a replica, see the section on
 [creating replicas](#create-a-database-replica).
 
 <highlight type="cloud" header="Sign up for Timescale Cloud" button="Try for free">
-
 </highlight>
 
 ## How replicas work
+
 Replicas in Timescale Cloud are asynchronous hot standbys. They use streaming
 replication to minimize the chance of data loss during failover. To learn more,
 see the [blog post on Timescale Cloud replicas][replicas-blog].
 
 ### Asynchronous commits
+
 Timescale Cloud replicas are asynchronous. That means the primary database
 reports success as soon as a transaction is completedly locally. It doesn't wait
 to see if the replica successfully commits the transaction as well. The improves
@@ -43,18 +48,21 @@ fails. To learn more, see the [failover section](#failover).
 Timescale Cloud doesn't currently offer synchronous replicas.
 
 ### Hot standbys
+
 Timescale Cloud replicas are hot standbys. That means they are ready to take
 over as soon as the primary fails. It also means you can read from your replica,
 even when the primary is running. You can reduce the load on your primary by
 distributing your read queries.
 
 ### Streaming replication
+
 To keep data in sync between the primary and the replicas, the primary streams
 its write-ahead log (WAL). WAL records are streamed as soon as they're written,
 rather than waiting to be batched and shipped. This reduces the chance of data
-loss. 
+loss.
 
 ### Failover
+
 In a normal operating state, your application is connected to the primary. It
 can optionally be connected to the replica for read queries. Timescale Cloud
 manages these connections automatically through a load balancer.
@@ -71,24 +79,26 @@ new one is created. This node becomes the new replica, while the promoted node
 remains the primary.
 
 ### Multi-AZ
-By default, Timescale Cloud replicas are created in a different availability 
-zone (AZ) than the primary. This provides additional availability for Timescale 
-Cloud services with replicas, as it protects against entire AZ outages. If a 
-primary is in an AZ that experiences an outage, the service can easily fail 
+
+By default, Timescale Cloud replicas are created in a different availability
+zone (AZ) than the primary. This provides additional availability for Timescale
+Cloud services with replicas, as it protects against entire AZ outages. If a
+primary is in an AZ that experiences an outage, the service can easily fail
 over to the replica.
 
 ## Create a database replica
 
 <highlight type="warning">
-If your service was created before June 2022, adding a replica may cause your 
+If your service was created before June 2022, adding a replica may cause your
 service to restart. Restarts typically take about one minute to complete.
 </highlight>
 
 <procedure>
 
 ### Creating a database replica
+
 1.  [Log in to your Timescale Cloud account][cloud-login] and click
-		the service you want to replicate.
+  the service you want to replicate.
 1.  Navigate to the `Operations` tab, and select `Replication`.
 1.  Check the pricing of the replica, and click `Add a replica`. Confirm the
     action by clicking `Add replica`.
@@ -103,7 +113,6 @@ service to restart. Restarts typically take about one minute to complete.
 <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-replication-add.png" alt="Creating a database replica in Timescale Cloud"/>
 
 </procedure>
-
 
 [cloud-login]: https://console.cloud.timescale.com
 [replicas-blog]: https://www.timescale.com/blog/high-availability-for-your-production-environments-introducing-database-replication-in-timescale-cloud/

--- a/cloud/service-operations/resources.md
+++ b/cloud/service-operations/resources.md
@@ -4,11 +4,16 @@ excerpt: Manage your service resources
 product: cloud
 keywords: [services, operation, storage]
 tags: [disk space, resources, oom, memory]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, resources]
 ---
 
 # Service operation - Resources
+
 Timescale Cloud contains several mechanisms for managing disk space on your
 services. There are four key tasks that Cloud performs to handle disk space:
+
 1.  Detect if storage capacity begins to fill up
 1.  Notify you about the growth of storage consumption
 1.  Automatically activate overload protections
@@ -21,10 +26,10 @@ the maximum limit, or turning autoscaling off, see the
 [autoscaling][autoscaling] section.
 
 <highlight type="cloud" header="Sign up for Timescale Cloud" button="Try for free">
-
 </highlight>
 
 ## Online storage resizing
+
 You can increase your storage size in the Timescale Cloud console.
 
 <highlight type="warning">
@@ -35,6 +40,7 @@ cannot currently decrease your storage size once set.
 <procedure>
 
 ### Increasing service resources
+
 1.  In the Timescale Cloud console, navigate to `Services` and click the service
     you want to adjust. Navigate to the `Operations` tab, and go to
     the `Resources` section.
@@ -53,6 +59,7 @@ cannot currently decrease your storage size once set.
 </procedure>
 
 ## Storage recovery
+
 If you need to perform actions on your database to reduce your data usage, you
 can turn off read-only mode. For example, you need read-write access if you want
 to compress data, delete rows or tables, or drop old data using data retention
@@ -68,17 +75,23 @@ leaving the database in read-only mode.
 <procedure>
 
 ### Enabling read-write access on an individual session
+
 1.  Connect to your database using `psql` and turn off read-only protection
     for the current session:
+
     ```sql
     SET default_transaction_read_only TO off;
     ```
+
 1.  Create a data retention policy to only retain, for example, data for 90
     days. This starts working immediately on old data:
+
     ```sql
     SELECT add_retention_policy('<table_name>', interval '90 days');
     ```
+
 1.  Turn on compression:
+
     ```sql
     ALTER TABLE <table_name> SET (
       timescaledb.compress,
@@ -93,6 +106,7 @@ As soon as the storage consumption drops below the threshold, the read-only
 protection is automatically removed, and you can start writing data again.
 
 ## Out of memory errors
+
 If you run intensive queries on your Timescale Cloud services, you might
 encounter out of memory (OOM) errors. This occurs if your query consumes more
 memory than is available.
@@ -106,6 +120,7 @@ problematic query does not run, but that your PostgreSQL service continues to
 operate normally.
 
 If the normal OOM killer is triggered, the error log looks like this:
+
 ```yml
 2021-09-09 18:15:08 UTC [560567]:TimescaleDB: LOG: server process (PID 2351983) was terminated by signal 9: Killed
 ```
@@ -116,6 +131,7 @@ If Timescale Cloud successfully guards the service against the OOM killer, it sh
 down only the client connection that was using too much memory. This prevents
 the entire PostgreSQL service from shutting down, so you can reconnect
 immediately. The error log looks like this:
+
 ```yml
 2022-02-03 17:12:04 UTC [2253150]:TimescaleDB: tsdbadmin@tsdb,app=psql [53200] ERROR: out of memory
 ```

--- a/cloud/service-operations/service-management.md
+++ b/cloud/service-operations/service-management.md
@@ -4,6 +4,9 @@ excerpt: Manage your service from the Operations dashboard
 product: cloud
 keywords: [services, operations, forks]
 tags: [manage, admin, passwords, pause, stop, terminate]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, management]
 ---
 
 # Services operations - General

--- a/cloud/service-operations/vpc.md
+++ b/cloud/service-operations/vpc.md
@@ -1,9 +1,13 @@
 ---
 title: Service operations - VPC
-excerpt: Peer to Timescale Cloud with VPC to isolate your database
+excerpt: Use VPC peering to secure your Timescale Cloud database
 product: cloud
 keywords: [vpc, services, operations]
 tags: [aws]
+cloud_ui:
+    path:
+        - [services, :serviceID, operations, vpc]
+        - [vpc]
 ---
 
 # Service operations - VPC

--- a/cloud/service-overview.md
+++ b/cloud/service-overview.md
@@ -4,9 +4,14 @@ excerpt: See information on your service's connection parameters, configuration,
 product: cloud
 keywords: [connect, services]
 tags: [storage, resources, disk space]
+cloud_ui:
+    path:
+        - [services, :serviceID, overview]
+    priority: 1
 ---
 
 # Service overview
+
 When you log in to your [Timescale Cloud account][cloud-login], you see the
 `Services` page. Click the service you are interested in to see the `Services
 Overview` tab. This section contains your service's connection information, and
@@ -15,15 +20,16 @@ an overview of the configuration and resource usage for the service.
 <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/tsc-services-overview.png" alt="Timescale Cloud Services Overview"/>
 
 ## Service users
+
 By default, when you create a new service, a new `tsdbadmin` user is created.
 This is the user that you use to connect to your new service.
 
-The `tsdbadmin` user is the owner of the database, but is not a superuser. We 
-do not currently allow access to the `postgres` user, nor creation of multiple 
+The `tsdbadmin` user is the owner of the database, but is not a superuser. We
+do not currently allow access to the `postgres` user, nor creation of multiple
 databases. We recommend using schemas or creating additional services for data
 isolation.
 
-On Timescale Cloud services, the `tsdbadmin` user can create another user 
+On Timescale Cloud services, the `tsdbadmin` user can create another user
 with any other roles. For a complete list of roles available, see the
 [PostgreSQL role attributes documentation][pg-roles-doc].
 

--- a/cloud/services/create-a-service-demo.md
+++ b/cloud/services/create-a-service-demo.md
@@ -3,9 +3,14 @@ title: Create a service with demo data
 excerpt: Create a Timescale Cloud service with demo data to start exploring TimescaleDB
 product: cloud
 keywords: [services, create, demo]
+cloud_ui:
+    path:
+        - [services]
+    priority: 3
 ---
 
 # Create a service with demo data
+
 Timescale Cloud is a hosted, cloud-native TimescaleDB service that allows you to
 quickly spin up new TimescaleDB instances. You can
 [try Timescale Cloud for free][sign-up], no credit card required.
@@ -19,6 +24,7 @@ For installation instructions, and help getting your first service up and
 running, see the [Timescale Cloud installation section][cloud-install].
 
 ## Where to next
+
 Now that you have your first service up and running, you can check out the
 [Timescale Cloud][tsc-docs] section in our documentation, and
 find out what you can do with it.
@@ -32,7 +38,6 @@ TimescaleDB, visit the
 
 You can always [contact us][contact] if you need help working something out, or
 if you want to have a chat.
-
 
 [sign-up]: https://www.timescale.com/timescale-signup
 [timescale-pricing]: https://www.timescale.com/products#cloud-pricing

--- a/cloud/services/create-a-service.md
+++ b/cloud/services/create-a-service.md
@@ -3,6 +3,10 @@ title: Create a service
 excerpt: Create a service in Timescale Cloud
 product: cloud
 keywords: [services, create, installation]
+cloud_ui:
+    path:
+        - [services]
+    priority: 2
 ---
 
 # Create a service

--- a/cloud/services/index.md
+++ b/cloud/services/index.md
@@ -3,6 +3,10 @@ title: Timescale Cloud services
 excerpt: Learn more about Timescale Cloud services
 product: cloud
 keywords: [services]
+cloud_ui:
+    path:
+        - [services]
+    priority: 1
 ---
 
 # Timescale Cloud services


### PR DESCRIPTION
# Description

Having Cloud UI path data in metadata for Cloud pages lets us create two parallel navigations, one that is topic-focused and one that parallels the Cloud UI IA.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
