### PR TITLE
Fix state_int_timeline name

### DIFF
--- a/api/_hyperfunctions/state_agg/state_timeline.md
+++ b/api/_hyperfunctions/state_agg/state_timeline.md
@@ -27,7 +27,7 @@ api_details:
             agg StateAgg
         ) RETURNS (TEXT, TIMESTAMPTZ, TIMESTAMPTZ)
 
-        state_int_state(
+        state_int_timeline(
             agg StateAgg
         ) RETURNS (BIGINT, TIMESTAMPTZ, TIMESTAMPTZ)
   parameters:


### PR DESCRIPTION
# Description

Fixes the name of the `state_int_timeline` function – it was written in the docs as `state_int_state`.

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
