### PR TITLE
dispatch unmanipulated branch name to web-docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Set variables
         id: timescale
         run: |
-          echo "DEV_FOLDER=$(echo ${GITHUB_HEAD_REF} | sed 's|/|-|')" >> $GITHUB_OUTPUT
-          echo "STAGING_BRANCH=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
+          echo "DEV_FOLDER=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
@@ -25,7 +24,7 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: timescale/web-documentation
           event-type: build-docs-content
-          client-payload: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "staging_branch": "${{ steps.timescale.outputs.STAGING_BRANCH }}", "pr_number": "${{ env.PR_NUMBER }}"}'
+          client-payload: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'
 
       - name: Write comment
         uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd


### PR DESCRIPTION
# Description

Let web docs handle how the branch name will be manipulated, which is more flexible than predetermining it on the sending end.

# Links

Related to https://github.com/timescale/docs-private/issues/67

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
