### PR TITLE
[Update] Self-Hosted 

### DIFF
--- a/_partials/_where-to-next.md
+++ b/_partials/_where-to-next.md
@@ -5,7 +5,7 @@ out the [Use Timescale][tsdb-docs] section, and find out what
 you can do with it.
 
 If you want to work through some tutorials to help you get up and running with
-Timescale and time-series data, check out our [tutorials][tutorials] section.
+Timescale and time-series data, check out the [tutorials][tutorials] section.
 
 You can always [contact us][contact] if you need help working something out, or
 if you want to have a chat.

--- a/_partials/_where-to-next.md
+++ b/_partials/_where-to-next.md
@@ -1,0 +1,15 @@
+## Where to next
+
+Now that you have your first Timescale database up and running, you can check
+out the [Use Timescale][tsdb-docs] section in our documentation, and find out what
+you can do with it.
+
+If you want to work through some tutorials to help you get up and running with
+Timescale and time-series data, check out our [tutorials][tutorials] section.
+
+You can always [contact us][contact] if you need help working something out, or
+if you want to have a chat.
+
+[contact]: https://www.timescale.com/contact
+[tsdb-docs]: /timescaledb/:currentVersion:/use-timescale
+[tutorials]: /timescaledb/:currentVersion:/tutorials/

--- a/_partials/_where-to-next.md
+++ b/_partials/_where-to-next.md
@@ -1,7 +1,7 @@
 ## Where to next
 
 Now that you have your first Timescale database up and running, you can check
-out the [Use Timescale][tsdb-docs] section in our documentation, and find out what
+out the [Use Timescale][tsdb-docs] section, and find out what
 you can do with it.
 
 If you want to work through some tutorials to help you get up and running with

--- a/self-hosted/install/index.md
+++ b/self-hosted/install/index.md
@@ -7,7 +7,7 @@ keywords: [installation]
 
 # Install Timescale
 
-Timescale extends PostgreSQL for time-series data—giving PostgreSQL the
+Timescale extends PostgreSQL for time-series data, giving PostgreSQL the
 high-performance, scalability, and analytical capabilities required by modern
 data-intensive applications.
 

--- a/self-hosted/install/index.md
+++ b/self-hosted/install/index.md
@@ -1,40 +1,24 @@
 ---
-title: Install TimescaleDB
-excerpt: Install TimescaleDB, the PostgreSQL database for time series and data analysis
+title: Install Timescale
+excerpt: Install Timescale, the PostgreSQL database for time series and data analysis
 products: [cloud, mst, self_hosted]
 keywords: [installation]
 ---
 
-# Install TimescaleDB
+# Install Timescale
 
-TimescaleDB extends  PostgreSQL for time-series data—giving PostgreSQL the
+Timescale extends PostgreSQL for time-series data—giving PostgreSQL the
 high-performance, scalability, and analytical capabilities required by modern
 data-intensive applications.
 
-<Highlight type="cloud" header="Timescale Cloud" button="Get started for free">
-The best way to use TimescaleDB is Timescale Cloud, our fully hosted and managed
-database platform. Enjoy all the best  features of TimescaleDB without the
-hassle of managing your database—with automatic backups and failover, high
-availability, flexible scaling, security and data compliance, VPC peering, and
-much more.
-</Highlight>
+You can install Timescale for free from [source][self-hosted-source], a
+[pre-built container][self-hosted-container], or a pre-built
+[cloud image][self-hosted-cloud] on [your own server hardware][self-hosted-install].
 
-See the [Timescale Cloud installation guide][tsc-install] for details.
+<Installation />
 
-If you prefer self-hosting your TimescaleDB database, you can install
-TimescaleDB for free:
-
-*   Install self-hosted TimescaleDB on [your own server hardware][self-hosted-install].
-*   Install self-hosted TimescaleDB [from source][self-hosted-source].
-*   Install self-hosted TimescaleDB [from a pre-built container][self-hosted-container].
-*   Install self-hosted TimescaleDB [from a pre-built cloud image][self-hosted-cloud].
-
-To install Managed Service for TimescaleDB, see the [installation
-guide][mst-install].
-
-[mst-install]: /install/:currentVersion:/installation-mst/
 [self-hosted-install]: /install/:currentVersion:/self-hosted/
 [self-hosted-source]: /install/:currentVersion:/self-hosted/installation-source/
 [self-hosted-container]: /install/:currentVersion:/installation-docker/
 [self-hosted-cloud]: /install/:currentVersion:/self-hosted/installation-linux/
-[tsc-install]: /install/:currentVersion:/installation-cloud/
+

--- a/self-hosted/install/installation-cloud-image.md
+++ b/self-hosted/install/installation-cloud-image.md
@@ -1,18 +1,16 @@
 ---
-title: Install TimescaleDB from cloud image
-excerpt: Install self-hosted TimescaleDB from a pre-built cloud image
+title: Install Timescale from cloud image
+excerpt: Install self-hosted Timescale from a pre-built cloud image
 products: [self_hosted]
 keywords: [installation, self-hosted]
 tags: [cloud image]
 ---
 
-# Install self-hosted TimescaleDB from a pre-built cloud image
+import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-<Highlight type="cloud" header="Deploying TimescaleDB to AWS?" button="Try for free">
-Timescale Cloud is the most effective way to use TimescaleDB in AWS, as it saves you the time to manually configure your services, backups, high availability, data recovery, forks, upgrades, and more. You can also connect to Timescale Cloud through your own private infrastructure via [VPC peering](https://docs.timescale.com/cloud/latest/service-operations/vpc/).
-</Highlight>
+# Install Timescale from a pre-built cloud image
 
-You can install a self-hosted TimescaleDB instance on a cloud hosting provider,
+You can install Timescale on a cloud hosting provider,
 from a pre-built, publicly available machine image. These instructions show you
 how to use a pre-built Amazon machine image (AMI), on Amazon Web Services (AWS).
 The currently available pre-built cloud image is:
@@ -35,7 +33,7 @@ supports public AMIs.
 
 <Procedure>
 
-### Installing self-hosted TimescaleDB from a pre-build cloud image
+## Installing Timescale from a pre-build cloud image
 
 1.  Make sure you have an [Amazon Web Services account][aws-signup], and are
     signed in to [your EC2 dashboard][aws-dashboard].
@@ -62,14 +60,14 @@ service for the configuration changes to take effect. To restart the service,
 run `sudo systemctl restart postgresql.service`.
 </Highlight>
 
-## Set up the TimescaleDB extension
+## Set up the Timescale extension
 
-When you have PostgreSQL and TimescaleDB installed, connect to your instance and
-set up the TimescaleDB extension.
+When you have PostgreSQL and Timescale installed, connect to your instance and
+set up the Timescale extension.
 
 <Procedure>
 
-### Setting up the TimescaleDB extension
+### Setting up the Timescale extension
 
 1.  On your instance, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -91,7 +89,7 @@ set up the TimescaleDB extension.
     \c tsdb
     ```
 
-1.  Add the TimescaleDB extension:
+1.  Add the Timescale extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -99,7 +97,7 @@ set up the TimescaleDB extension.
 
 </Procedure>
 
-You can check that the TimescaleDB extension is installed by using the `\dx`
+You can check that the Timescale extension is installed by using the `\dx`
 command at the command prompt. It looks like this:
 
 ```sql
@@ -115,24 +113,11 @@ tsdb=# \dx
 (END)
 ```
 
-## Where to next
-
-Now that you have your first TimescaleDB database up and running, you can check
-out the [TimescaleDB][tsdb-docs] section in our documentation, and find out what
-you can do with it.
-
-If you want to work through some tutorials to help you get up and running with
-TimescaleDB and time-series data, check out our [tutorials][tutorials] section.
-
-You can always [contact us][contact] if you need help working something out, or
-if you want to have a chat.
+<WhereTo />
 
 [aws-signup]: https://portal.aws.amazon.com/billing/signup
 [aws-dashboard]: https://console.aws.amazon.com/ec2/
 [aws-instance-config]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html
 [aws-connect]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstances.html
-[contact]: https://www.timescale.com/contact
 [install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
-[tsdb-docs]: /timescaledb/:currentVersion:/
-[tutorials]: /timescaledb/:currentVersion:/tutorials/
 [config]: /timescaledb/:currentVersion:/how-to-guides/configuration/

--- a/self-hosted/install/installation-docker.md
+++ b/self-hosted/install/installation-docker.md
@@ -1,35 +1,37 @@
 ---
-title: Install TimescaleDB from Docker container
-excerpt: Install self-hosted TimescaleDB from a pre-built Docker container
+title: Install Timescale from Docker container
+excerpt: Install self-hosted Timescale from a pre-built Docker container
 products: [self_hosted]
 keywords: [installation, self-hosted, Docker]
 ---
 
-# Install self-hosted TimescaleDB from a pre-built container
+import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-You can install a self-hosted TimescaleDB instance on any local system, from a
-pre-built container. This is the simplest method to install a self-hosted
-TimescaleDB instance, and it means you always have access to the latest version
-without worrying about local dependencies. You can access the Docker image
-directly from locally installed PostgreSQL client tools such as `psql`.
+# Install Timescale from a pre-built container
+
+You can install a Timescale instance on any local system, from a pre-built
+container. This is the simplest method to install Timescale, and it means you
+always have access to the latest version without worrying about local
+dependencies. You can access the Docker image directly from locally installed
+PostgreSQL client tools such as `psql`.
 
 <Highlight type="warning">
 If you have already installed PostgreSQL using a method other than the pre-built
 container provided here, you could encounter errors following these
 instructions. It is safest to remove any existing PostgreSQL installations
 before you begin. If you want to keep your current PostgreSQL installation, do
-not install TimescaleDB using this method.
+not install Timescale using this method.
 [Install from source](/install/latest/self-hosted/installation-source/)
 instead.
 </Highlight>
 
 <Procedure>
 
-### Installing self-hosted TimescaleDB from a Docker container
+## Installing Timescale from a Docker container
 
 1.  Install Docker, if you don't already have it. For packages and
     instructions, see the [Docker installation documentation][docker-install].
-1.  At the command prompt, run the TimescaleDB Docker image:
+1.  At the command prompt, run the Timescale Docker image:
 
     ```bash
     docker pull timescale/timescaledb-ha:pg14-latest
@@ -37,7 +39,7 @@ instead.
 
 <Highlight type="important">
 The [`timescaledb-ha`](https://hub.docker.com/r/timescale/timescaledb-ha) image
-offers the most complete TimescaleDB experience. It
+offers the most complete Timescale experience. It
 includes the
 [TimescaleDB Toolkit](https://github.com/timescale/timescaledb-toolkit),
 and support for PostGIS and Patroni. If you need the smallest possible image, use
@@ -63,9 +65,9 @@ information, see the [configuration][config] section.
 
 ## More Docker options
 
-The TimescaleDB HA Docker image includes [Ubuntu][ubuntu] as its operating
-system. The lighter-weight TimescaleDB (non-HA) image uses [Alpine][alpine]. The
-commands in this section use the TimescaleDB HA image, but the steps are the
+The Timescale HA Docker image includes [Ubuntu][ubuntu] as its operating
+system. The lighter-weight Timescale (non-HA) image uses [Alpine][alpine]. The
+commands in this section use the Timescale HA image, but the steps are the
 same for both.
 
 You can use the Docker image in different ways, depending on your use case.
@@ -78,8 +80,8 @@ docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password time
 ```
 
 The `-p` flag binds the container port to the host port. This means that
-anything that can access the host port can also access your TimescaleDB
-container, so it's important that you set a PostgreSQL password using the
+anything that can access the host port can also access your Timescale container,
+so it's important that you set a PostgreSQL password using the
 `POSTGRES_PASSWORD` environment variable. Without that variable, the Docker
 container disables password checks for all database users.
 
@@ -116,30 +118,30 @@ docker run -d --name timescaledb -p 5432:5432 \
 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14-latest
 ```
 
-When you install TimescaleDB using a Docker container, the PostgreSQL settings
+When you install Timescale using a Docker container, the PostgreSQL settings
 are inherited from the container. In most cases, you do not need to adjust them.
 However, if you need to change a setting you can add `-c setting=value` to your
 Docker `run` command. For more information, see the
 [Docker documentation][docker-postgres].
 
-The link provided in these instructions is for the latest version of TimescaleDB
+The link provided in these instructions is for the latest version of Timescale
 on PostgreSQL 14. To find other Docker tags you can use, see the
 [Dockerhub repository][dockerhub].
 
-## Set up the TimescaleDB extension
+## Set up the Timescale extension
 
-When you have PostgreSQL and TimescaleDB installed, you can connect to it from
+When you have PostgreSQL and Timescale installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't
 installed it yet, check out the [installing psql][install-psql] section.
 
 <Procedure>
 
-### Setting up the TimescaleDB extension
+### Setting up the Timescale extension
 
 <Highlight type="important">
-If you installed TimescaleDB from the pre-built Docker container, then you
-probably already have the TimescaleDB extension, and you can skip this procedure.
+If you installed Timescale from the pre-built Docker container, then you
+probably already have the Timescale extension, and you can skip this procedure.
 </Highlight>
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
@@ -172,7 +174,7 @@ probably already have the TimescaleDB extension, and you can skip this procedure
     \c example
     ```
 
-1.  Add the TimescaleDB extension:
+1.  Add the Timescale extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -186,7 +188,7 @@ probably already have the TimescaleDB extension, and you can skip this procedure
 
 </Procedure>
 
-You can check that the TimescaleDB extension is installed by using the `\dx`
+You can check that the Timescale extension is installed by using the `\dx`
 command at the `psql` prompt. It looks like this:
 
 ```sql
@@ -216,25 +218,12 @@ Description | timescaledb_toolkit
 tsdb=>
 ```
 
-## Where to next
-
-Now that you have your first TimescaleDB database up and running, you can check
-out the [TimescaleDB][tsdb-docs] section in our documentation, and find out what
-you can do with it.
-
-If you want to work through some tutorials to help you get up and running with
-TimescaleDB and time-series data, check out our [tutorials][tutorials] section.
-
-You can always [contact us][contact] if you need help working something out, or
-if you want to have a chat.
+<WhereTo />
 
 [alpine]: https://alpinelinux.org/
 [config]: /timescaledb/:currentVersion:/how-to-guides/configuration/
-[contact]: https://www.timescale.com/contact
 [docker-install]: https://docs.docker.com/get-docker/
 [docker-postgres]: https://hub.docker.com/_/postgres
 [dockerhub]: https://hub.docker.com/r/timescale/timescaledb/tags?page=1&ordering=last_updated
 [install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
-[tsdb-docs]: /timescaledb/:currentVersion:/
-[tutorials]: /timescaledb/:currentVersion:/tutorials/
 [ubuntu]: https://ubuntu.com

--- a/self-hosted/install/installation-kubernetes.md
+++ b/self-hosted/install/installation-kubernetes.md
@@ -1,19 +1,19 @@
 ---
-title: Install TimescaleDB on Kubernetes
-excerpt: Install self-hosted TimescaleDB on Kubernetes
+title: Install Timescale on Kubernetes
+excerpt: Install self-hosted Timescale on Kubernetes
 products: [self_hosted]
 keywords: [installation, self-hosted, Kubernetes]
 ---
 
-# Install TimescaleDB on Kubernetes
+# Install Timescale on Kubernetes
 
-You can install a TimescaleDB instance on any Kubernetes deployment. Use the
-`timescaledb-single` Helm chart to deploy a highly available TimescaleDB
+You can install a Timescale instance on any Kubernetes deployment. Use the
+`timescaledb-single` Helm chart to deploy a highly available Timescale
 database, and `timescaledb-multinode` to deploy a multi-node distributed
-TimescaleDB database. For more information about the components that are
-deployed with these charts, see [TimescaleDB on Kubernetes][timescaledb-k8s].
+Timescale database. For more information about the components that are
+deployed with these charts, see [Timescale on Kubernetes][timescaledb-k8s].
 
-Before you begin installing TimescaleDB on a Kubernetes deployment, make sure
+Before you begin installing Timescale on a Kubernetes deployment, make sure
 you have installed:
 
 *   [kubectl][kubectl-install]
@@ -25,23 +25,23 @@ than those specified in the default `values.yaml`. You can name this file
 `<MY_VALUES.yaml>`. For details about the parameters you can set, see the
 [Administrator Guide][admin-guide].
 
-## Install TimescaleDB using a Helm chart
+## Install Timescale using a Helm chart
 
-Install TimescaleDB on Kubernetes using a Helm chart with the default
+Install Timescale on Kubernetes using a Helm chart with the default
 `values.yaml` file. When you use the `values.yaml` file, the user credentials
 are randomly generated during installation. Therefore, the `helm upgrade`
 command does not rotate the credentials, because changing the database
 credentials would break the database. Instead, it continues to use the
 credentials generated during `helm install`.
 
-This section provides instructions to deploy TimescaleDB using the
+This section provides instructions to deploy Timescale using the
 `timescaledb-single` Helm chart.
 
 <Procedure>
 
-### Installing TimescaleDB using a Helm chart
+### Installing Timescale using a Helm chart
 
-1.  Add the TimescaleDB Helm chart repository:
+1.  Add the Timescale Helm chart repository:
 
     ```bash
     helm repo add timescale 'https://charts.timescale.com'
@@ -53,7 +53,7 @@ This section provides instructions to deploy TimescaleDB using the
     helm repo update
     ```
 
-1.  Install the TimescaleDB Helm chart, by replacing `<MY_NAME>` with a name of
+1.  Install the Timescale Helm chart, by replacing `<MY_NAME>` with a name of
     your choice:
 
     ```bash
@@ -68,14 +68,14 @@ This section provides instructions to deploy TimescaleDB using the
 
 </Procedure>
 
-## Connect to TimescaleDB
+## Connect to Timescale
 
-You can connect to TimescaleDB from an external IP address, or from within the
+You can connect to Timescale from an external IP address, or from within the
 cluster.
 
 <Procedure>
 
-### Connecting to TimescaleDB using an external IP
+### Connecting to Timescale using an external IP
 
 <Highlight type="note">
 If you configured the user credentials in the `my_values.yaml` file, you don't
@@ -118,9 +118,9 @@ the name that you provided during the installation.
 
 <Procedure>
 
-### Connecting to TimescaleDB from inside the cluster
+### Connecting to Timescale from inside the cluster
 
-1.  Get the Pod on which TimescaleDB is installed:
+1.  Get the Pod on which Timescale is installed:
 
    ```bash
    MASTERPOD="$(kubectl get pod -o name --namespace default -l release=test,role=master)"
@@ -136,8 +136,8 @@ the name that you provided during the installation.
 
 ## Create a database
 
- After installing and connecting to TimescaleDB you can create a database,
- connect to the database, and also verify that the TimescaleDB extension is
+ After installing and connecting to Timescale you can create a database,
+ connect to the database, and also verify that the Timescale extension is
  installed.
 
 <Procedure>
@@ -157,7 +157,7 @@ the name that you provided during the installation.
     \c tsdb
     ```
 
-1.  Verify that the TimescaleDB extension is installed by using the `\dx`
+1.  Verify that the Timescale extension is installed by using the `\dx`
     command at the command prompt. The output looks like this:
 
     ```sql
@@ -175,7 +175,7 @@ the name that you provided during the installation.
 
 ## Clean up
 
-You can use Helm to uninstall TimescaleDB on the Kubernetes cluster and clean up
+You can use Helm to uninstall Timescale on the Kubernetes cluster and clean up
 the Pods, persistent volume claim (PVC), S3 backups, and more.
 
 ### Cleaning up
@@ -190,15 +190,7 @@ Some items, such as PVCs and S3 backups, are not removed
 immediately. For more information about purging these items, see the
 [Administrator Guide][admin-guide].
 
-## Where to next
-
-Now that you have your first TimescaleDB database up and running, see
-the [TimescaleDB][tsdb-docs] section to learn what you can do with it.
-
-To work through some tutorials that help you get started with
-TimescaleDB and time-series data, check out the [tutorials][tutorials] section.
-
-To get help or chat with the Timescale team, [get in contact][contact].
+<WhereTo />
 
 [kubectl-install]: https://kubernetes.io/docs/tasks/tools/
 [kubernetes-install]: https://kubernetes.io/docs/setup/
@@ -206,8 +198,5 @@ To get help or chat with the Timescale team, [get in contact][contact].
 [minikube-install]: https://minikube.sigs.k8s.io/docs/start/
 [aws-eks]: https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html
 [microk8s-install]: https://microk8s.io/docs/getting-started
-[contact]: https://www.timescale.com/contact
-[tsdb-docs]: /timescaledb/:currentVersion:/
 [admin-guide]: https://github.com/timescale/helm-charts/blob/master/charts/timescaledb-single/docs/admin-guide.md
 [timescaledb-k8s]: /timescaledb/:currentVersion:/overview/timescale-kubernetes/
-[tutorials]: /timescaledb/:currentVersion:/tutorials/

--- a/self-hosted/install/installation-linux.md
+++ b/self-hosted/install/installation-linux.md
@@ -1,15 +1,16 @@
 ---
-title: Install TimescaleDB on Debian and Ubuntu
-excerpt: Install self-hosted TimescaleDB on Linux
+title: Install Timescale on Linux
+excerpt: Install self-hosted Timescale on Linux
 products: [self_hosted]
 keywords: [installation, self-hosted, Debian, Ubuntu, RHEL, Fedora]
 ---
 
 import Linux from "versionContent/_partials/_psql-installation-linux.mdx";
+import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-# Install TimescaleDB on Linux
+# Install Timescale on Linux
 
-You can host TimescaleDB yourself, on your Debian-based, Red Hat-based, or Arch
+You can host Timescale yourself, on your Debian-based, Red Hat-based, or Arch
 Linux-based systems. These instructions use the `apt`, `yum`, and `pacman`
 package manager on these distributions:
 
@@ -24,18 +25,18 @@ If you have already installed PostgreSQL using a method other than the `apt`
 package manager maintained by Debian or Ubuntu archive, `yum`, or `pacman` package
 manager, you could encounter errors following these instructions. It is safest
 to remove any existing PostgreSQL installations before you begin. If you want to
-keep your current PostgreSQL installation, do not install TimescaleDB using this
+keep your current PostgreSQL installation, do not install Timescale using this
 method. [Install from source](/install/latest/self-hosted/installation-source/)
 instead.
 </Highlight>
 
-<Tabs label="Install TimescaleDB">
+<Tabs label="Install Timescale">
 
 <Tab title="Debian">
 
 <Procedure>
 
-### Installing self-hosted TimescaleDB on Debian-based systems
+## Installing self-hosted Timescale on Debian-based systems
 
 1.  At the command prompt, as root, add the PostgreSQL third party repository
     to get the latest PostgreSQL packages:
@@ -50,7 +51,7 @@ instead.
     /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
     ```
 
-1.  Add the TimescaleDB third party repository:
+1.  Add the Timescale third party repository:
 
     <Terminal>
 
@@ -90,19 +91,19 @@ instead.
     apt update
     ```
 
-1.  Install TimescaleDB:
+1.  Install Timescale:
 
     ```bash
     apt install timescaledb-2-postgresql-14
     ```
 
     <Highlight type="note">
-    If you want to install a specific version of TimescaleDB, instead of the
+    If you want to install a specific version of Timescale, instead of the
     most recent, you can specify the version like this:
     `apt-get install timescaledb-2-postgresql-12='2.6.0*' timescaledb-2-loader-postgresql-12='2.6.0*'`
 
-    You can see the full list of TimescaleDB releases by visiting our
-    [releases page][releases-page]. Note that older versions of TimescaleDB
+    You can see the full list of Timescale releases by visiting our
+    [releases page][releases-page]. Note that older versions of Timescale
     don't always support all the OS versions listed above.
     </Highlight>
 
@@ -120,7 +121,7 @@ information, see the [configuration][config] section.
 
 <Procedure>
 
-### Installing self-hosted TimescaleDB on Red Hat-based systems
+## Installing self-hosted Timescale on Red Hat-based systems
 
 1.  At the command prompt, as root, add the PostgreSQL third party repository
     to get the latest PostgreSQL packages:
@@ -189,7 +190,7 @@ information, see the [configuration][config] section.
     yum update
     ```
 
-1.  Install TimescaleDB:
+1.  Install Timescale:
 
     ```bash
     yum install timescaledb-2-postgresql-14
@@ -227,9 +228,9 @@ information, see the [configuration][config] section.
 
 <Procedure>
 
-### Installing self-hosted TimescaleDB on ArchLinux-based systems
+## Installing self-hosted Timescale on ArchLinux-based systems
 
-1.  Install TimescaleDB and timescaledb-tune:
+1.  Install Timescale and timescaledb-tune:
 
     ```bash
     sudo pacman -Syu timescaledb timescaledb-tune
@@ -241,7 +242,8 @@ information, see the [configuration][config] section.
     sudo -u postgres initdb --locale=en_US.UTF-8 --encoding=UTF8 -D /var/lib/postgres/data --data-checksums
     ```
 
-1.  Run timescaledb-tune to adjust your `postgresql.conf` file, to use TimescaleDB as PostgreSQL extension:
+1.  Run timescaledb-tune to adjust your `postgresql.conf` file, to use Timescale
+    as PostgreSQL extension:
 
     ```bash
     sudo timescaledb-tune
@@ -260,24 +262,24 @@ information, see the [configuration][config] section.
 
 </Tabs>
 
-## Set up the TimescaleDB extension
+## Set up the Timescale extension
 
-When you have PostgreSQL and TimescaleDB installed, you can connect to it from
+When you have PostgreSQL and Timescale installed, you can connect to it from
 your local system using the `psql` command-line utility.
 
 <Linux />
 
-<Tabs lable="TimescaleDB extension">
+<Tabs lable="Timescale extension">
 
 <Tab title="Debian">
 
 <Procedure>
 
-### Setting up the TimescaleDB extension on Debian-based systems
+### Setting up the Timescale extension on Debian-based systems
 
-Restart PostgreSQL and create the TimescaleDB extension:
+Restart PostgreSQL and create the Timescale extension:
 
-1.  Restart the service after enabling TimescaleDB with `timescaledb-tune`:
+1.  Restart the service after enabling Timescale with `timescaledb-tune`:
 
     ```bash
     systemctl restart postgresql
@@ -330,13 +332,13 @@ Restart PostgreSQL and create the TimescaleDB extension:
     \c tsdb
     ```
 
-1.  Add the TimescaleDB extension:
+1.  Add the Timescale extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     ```
 
-1.  Check that the TimescaleDB extension is installed by using the `\dx`
+1.  Check that the Timescale extension is installed by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql
@@ -357,7 +359,7 @@ Restart PostgreSQL and create the TimescaleDB extension:
 
 <Procedure>
 
-### Setting up the TimescaleDB extension on Red Hat-based systems
+### Setting up the Timescale extension on Red Hat-based systems
 
 1.  Enable and start the service:
 
@@ -409,13 +411,13 @@ Restart PostgreSQL and create the TimescaleDB extension:
     \c tsdb
     ```
 
-1.  Add the TimescaleDB extension:
+1.  Add the Timescale extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     ```
 
-1.  Check that the TimescaleDB extension is installed by using the `\dx`
+1.  Check that the Timescale extension is installed by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql
@@ -436,7 +438,7 @@ Restart PostgreSQL and create the TimescaleDB extension:
 
 <Procedure>
 
-### Setting up the TimescaleDB extension on ArchLinux-based systems
+### Setting up the Timescale extension on ArchLinux-based systems
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -466,7 +468,7 @@ Restart PostgreSQL and create the TimescaleDB extension:
     \c tsdb
     ```
 
-1.  Add the TimescaleDB extension:
+1.  Add the Timescale extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -478,7 +480,7 @@ Restart PostgreSQL and create the TimescaleDB extension:
     sudo -u postgres psql tsdb
     ```
 
-1.  Check that the TimescaleDB extension is installed by using the `\dx`
+1.  Check that the Timescale extension is installed by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql
@@ -504,20 +506,7 @@ database directly using this command:
 psql -U postgres -h localhost -d tsdb
 ```
 
-## Where to next
+<WhereTo />
 
-Now that you have your first TimescaleDB database up and running, you can check
-out the [TimescaleDB][tsdb-docs] section in our documentation, and find out what
-you can do with it.
-
-If you want to work through some tutorials to help you get up and running with
-TimescaleDB and time-series data, check out our [tutorials][tutorials] section.
-
-You can always [contact us][contact] if you need help working something out, or
-if you want to have a chat.
-
-[contact]: https://www.timescale.com/contact
-[tsdb-docs]: /timescaledb/:currentVersion:/
-[tutorials]: /timescaledb/:currentVersion:/tutorials/
 [config]: /timescaledb/:currentVersion:/how-to-guides/configuration/
 [releases-page]: https://packagecloud.io/timescale/timescaledb

--- a/self-hosted/install/installation-linux.md
+++ b/self-hosted/install/installation-linux.md
@@ -102,7 +102,7 @@ instead.
     most recent, you can specify the version like this:
     `apt-get install timescaledb-2-postgresql-12='2.6.0*' timescaledb-2-loader-postgresql-12='2.6.0*'`
 
-    You can see the full list of Timescale releases by visiting our
+    You can see the full list of Timescale releases by visiting the
     [releases page][releases-page]. Note that older versions of Timescale
     don't always support all the OS versions listed above.
     </Highlight>

--- a/self-hosted/install/installation-linux.md
+++ b/self-hosted/install/installation-linux.md
@@ -107,11 +107,10 @@ instead.
     don't always support all the OS versions listed above.
     </Highlight>
 
-When you have completed the installation, you need to configure your database so
-that you can use it. The easiest way to do this is to run the `timescaledb-tune`
-script, which is included with the `timescaledb-tools` package. Run the
-`timescaledb-tune` script using the `sudo timescaledb-tune` command. For more
-information, see the [configuration][config] section.
+1.  Configure your database by running the `timescaledb-tune` script, which is
+    included with the `timescaledb-tools` package. Run the `timescaledb-tune` script
+    using the `sudo timescaledb-tune` command. For more information, see the
+    [configuration][config] section.
 
 </Procedure>
 
@@ -213,12 +212,11 @@ information, see the [configuration][config] section.
     /usr/pgsql-14/bin/postgresql-14-setup initdb
     ```
 
-When you have completed the installation, you need to configure your database so
-that you can use it. The easiest way to do this is to run the `timescaledb-tune`
-script, which is included with the `timescaledb-tools` package. Run the
-`timescaledb-tune` script using the
-`sudo timescaledb-tune --pg-config=/usr/pgsql-14/bin/pg_config` command. For more
-information, see the [configuration][config] section.
+1.  Configure your database by running the `timescaledb-tune` script, which is
+    included with the `timescaledb-tools` package. Run the `timescaledb-tune`
+    script using the 
+    `sudo timescaledb-tune --pg-config=/usr/pgsql-14/bin/pg_config` command.
+    For more information, see the [configuration][config] section.
 
 </Procedure>
 

--- a/self-hosted/install/installation-macos.md
+++ b/self-hosted/install/installation-macos.md
@@ -1,16 +1,17 @@
 ---
-title: Install TimescaleDB on macOS
-excerpt: Install self-hosted TimescaleDB on macOS
+title: Install Timescale on macOS
+excerpt: Install self-hosted Timescale on macOS
 products: [self_hosted]
 keywords: [installation, self-hosted, macOS]
 ---
 
 import Homebrew from "versionContent/_partials/_psql-installation-homebrew.mdx";
 import MacPorts from "versionContent/_partials/_psql-installation-macports.mdx";
+import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-# Install self-hosted TimescaleDB on macOS systems
+# Install self-hosted Timescale on macOS systems
 
-You can host TimescaleDB yourself on your Apple macOS system.
+You can host Timescale yourself on your Apple macOS system.
 These instructions use a Homebrew or MacPorts installer on these versions:
 
 *   Apple macOS 10.15 Catalina
@@ -18,7 +19,7 @@ These instructions use a Homebrew or MacPorts installer on these versions:
 *   Apple macOS 12 Monterey
 
 <Highlight type="important">
-Before you begin installing TimescaleDB, make sure you have installed PostgreSQL
+Before you begin installing Timescale, make sure you have installed PostgreSQL
 version 12 or later.
 </Highlight>
 
@@ -26,18 +27,18 @@ version 12 or later.
 If you have already installed PostgreSQL using a method other than Homebrew, you
 could encounter errors following these instructions. It is safest to remove any
 existing PostgreSQL installations before you begin. If you want to keep your
-current PostgreSQL installation, do not install TimescaleDB using this method.
+current PostgreSQL installation, do not install Timescale using this method.
 [Install from source](/install/latest/self-hosted/installation-source/)
 instead.
 </Highlight>
 
-## Install self-hosted TimescaleDB using Homebrew
+## Install self-hosted Timescale using Homebrew
 
-You can use Homebrew to install TimescaleDB on macOS-based systems.
+You can use Homebrew to install Timescale on macOS-based systems.
 
 <Procedure>
 
-### Installing self-hosted TimescaleDB using Homebrew
+### Installing self-hosted Timescale using Homebrew
 
 1.  Install Homebrew, if you don't already have it:
 
@@ -53,7 +54,7 @@ You can use Homebrew to install TimescaleDB on macOS-based systems.
     brew tap timescale/tap
     ```
 
-1.  Install TimescaleDB:
+1.  Install Timescale:
 
     ```bash
     brew install timescaledb
@@ -81,23 +82,23 @@ You can use Homebrew to install TimescaleDB on macOS-based systems.
 
 </Procedure>
 
-When you have PostgreSQL and TimescaleDB installed, you can connect to it from
+When you have PostgreSQL and Timescale installed, you can connect to it from
 your local system using the `psql` command-line utility.
 
 <Homebrew />
 
-## Install self-hosted TimescaleDB using MacPorts
+## Install self-hosted Timescale using MacPorts
 
-You can use MacPorts to install TimescaleDB on macOS-based systems.
+You can use MacPorts to install Timescale on macOS-based systems.
 
 <Procedure>
 
-### Installing self-hosted TimescaleDB using MacPorts
+### Installing self-hosted Timescale using MacPorts
 
 1.  Install MacPorts by downloading and running the package installer.
     For more information about MacPorts, including installation instructions,
     see the [MacPorts documentation][macports].
-1.  Install TimescaleDB:
+1.  Install Timescale:
 
     ```bash
     sudo port install timescaledb
@@ -118,19 +119,19 @@ section.
 
 </Procedure>
 
-When you have PostgreSQL and TimescaleDB installed, you can connect to it from
+When you have PostgreSQL and Timescale installed, you can connect to it from
 your local system using the `psql` command-line utility.
 
 <MacPorts />
 
-## Set up the TimescaleDB extension
+## Set up the Timescale extension
 
 Connect to PostgreSQL from your local system using the `psql` command-line
-utility and set up the TimescaleDB extension.
+utility and set up the Timescale extension.
 
 <Procedure>
 
-### Setting up the TimescaleDB extension
+### Setting up the Timescale extension
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -159,13 +160,13 @@ utility and set up the TimescaleDB extension.
     \c tsdb
     ```
 
-1.  Add the TimescaleDB extension:
+1.  Add the Timescale extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     ```
 
-1.  Check that the TimescaleDB extension is installed by using the `\dx`
+1.  Check that the Timescale extension is installed by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql
@@ -187,20 +188,8 @@ database directly using this command:
 psql -U postgres -h localhost -d tsdb
 ```
 
-## Where to next
+ <WhereTo />
 
-Now that you have your first TimescaleDB database up and running, you can check
-out the [TimescaleDB][tsdb-docs] section, and find out what you can do with it.
-
-If you want to work through some tutorials to help you get up and running with
-TimescaleDB and time-series data, check out the [tutorials][tutorials] section.
-
-You can always [contact us][contact] if you need help working something out, or
-if you want to have a chat.
-
-[contact]: https://www.timescale.com/contact
-[tsdb-docs]: /timescaledb/:currentVersion:/
-[tutorials]: /timescaledb/:currentVersion:/tutorials/
 [homebrew]: https://docs.brew.sh/Installation
 [install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
 [macports]: https://guide.macports.org/#installing.macports

--- a/self-hosted/install/installation-source.md
+++ b/self-hosted/install/installation-source.md
@@ -1,13 +1,15 @@
 ---
-title: Install TimescaleDB from source
-excerpt: Install self-hosted TimescaleDB from source
+title: Install Timescale from source
+excerpt: Install self-hosted Timescale from source
 products: [self_hosted]
 keywords: [installation, self-hosted]
 ---
 
-# Install self-hosted TimescaleDB from source
+import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-You can host TimescaleDB yourself, on any system, by downloading the source code
+# Install self-hosted Timescale from source
+
+You can host Timescale yourself, on any system, by downloading the source code
 and compiling it. These instructions do not require the use of a package manager
 or installation tool.
 
@@ -22,7 +24,7 @@ You also need:
 *   CMake version 3.11 or later for your operating system. For more information
     about CMake installation, including downloads and instructions, see the [CMake documentation][cmake-download].
 *   C language compiler for your operating system, such as `gcc` or `clang`.
-*   Check the [compatibility matrix][compatibility-matrix] of TimescaleDB versions
+*   Check the [compatibility matrix][compatibility-matrix] of Timescale versions
     with PostgreSQL versions.
 
 <Highlight type="note">
@@ -33,7 +35,7 @@ Visual Studio components for CMake and Git when you run the installer.
 
 <Procedure>
 
-### Installing self-hosted TimescaleDB from source
+## Installing self-hosted Timescale from source
 
 1.  At the command prompt, clone the Timescale GitHub repository:
 
@@ -108,7 +110,7 @@ Visual Studio components for CMake and Git when you run the installer.
 
     </Terminal>
 
-3.  Install TimescaleDB:
+3.  Install Timescale:
 
     <Terminal>
 
@@ -134,14 +136,14 @@ Visual Studio components for CMake and Git when you run the installer.
 
 ## Configure PostgreSQL after installing from source
 
-When you install TimescaleDB from source, you need to do some additional
-PostgreSQL configuration to add the TimescaleDB library.
+When you install Timescale from source, you need to do some additional
+PostgreSQL configuration to add the Timescale library.
 
 <Highlight type="important">
-If you have more than one version of PostgreSQL installed, TimescaleDB can only
-be associated with one of them. The TimescaleDB build scripts use `pg_config` to
+If you have more than one version of PostgreSQL installed, Timescale can only
+be associated with one of them. The Timescale build scripts use `pg_config` to
 find out where PostgreSQL stores its extension files, so you can use `pg_config`
-to find out which PostgreSQL installation TimescaleDB is using.
+to find out which PostgreSQL installation Timescale is using.
 </Highlight>
 
 <Procedure>
@@ -191,16 +193,16 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the TimescaleDB extension
+## Set up the Timescale extension
 
-When you have PostgreSQL and TimescaleDB installed, you can connect to it from
+When you have PostgreSQL and Timescale installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't
 installed it yet, check out our [installing psql][install-psql] section.
 
 <Procedure>
 
-### Setting up the TimescaleDB extension
+### Setting up the Timescale extension
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -232,7 +234,7 @@ installed it yet, check out our [installing psql][install-psql] section.
     \c example
     ```
 
-1.  Add the TimescaleDB extension:
+1.  Add the Timescale extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -246,7 +248,7 @@ installed it yet, check out our [installing psql][install-psql] section.
 
 </Procedure>
 
-You can check that the TimescaleDB extension is installed by using the `\dx`
+You can check that the Timescale extension is installed by using the `\dx`
 command at the `psql` prompt. It looks like this:
 
 ```sql
@@ -276,22 +278,9 @@ Description | timescaledb_toolkit
 tsdb=>
 ```
 
-## Where to next
+<WhereTo />
 
-Now that you have your first TimescaleDB database up and running, you can check
-out the [TimescaleDB][tsdb-docs] section in our documentation, and find out what
-you can do with it.
-
-If you want to work through some tutorials to help you get up and running with
-TimescaleDB and time-series data, check out our [tutorials][tutorials] section.
-
-You can always [contact us][contact] if you need help working something out, or
-if you want to have a chat.
-
-[contact]: https://www.timescale.com/contact
 [install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
-[tsdb-docs]: /timescaledb/:currentVersion:/
-[tutorials]: /timescaledb/:currentVersion:/tutorials/
 [config]: /timescaledb/:currentVersion:/how-to-guides/configuration/
 [postgres-download]: https://www.postgresql.org/download/
 [cmake-download]: https://cmake.org/download/

--- a/self-hosted/install/installation-windows.md
+++ b/self-hosted/install/installation-windows.md
@@ -1,15 +1,16 @@
 ---
-title: Install TimescaleDB on Windows
-excerpt: Install self-hosted TimescaleDB on Windows
+title: Install Timescale on Windows
+excerpt: Install self-hosted Timescale on Windows
 products: [self_hosted]
 keywords: [installation, self-hosted, Windows]
 ---
 
 import Windows from "versionContent/_partials/_psql-installation-windows.mdx";
+import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-# Install self-hosted TimescaleDB on Windows systems
+# Install self-hosted Timescale on Windows systems
 
-You can host TimescaleDB yourself on your Microsoft Windows system.
+You can host Timescale yourself on your Microsoft Windows system.
 These instructions use a `zip` installer on these versions:
 
 *   Microsoft Windows 10
@@ -27,7 +28,7 @@ The minimum supported PostgreSQL versions are:
 If you have already installed PostgreSQL using another method, you could
 encounter errors following these instructions. It is safest to remove any
 existing PostgreSQL installations before you begin. If you want to keep your
-current PostgreSQL installation, do not install TimescaleDB using this method.
+current PostgreSQL installation, do not install Timescale using this method.
 [Install from source](/install/latest/self-hosted/installation-source/) instead.
 </Highlight>
 
@@ -39,7 +40,7 @@ To install PostgreSQL version 15.1.1 or later, make sure you have:
 
 <Procedure>
 
-## Installing self-hosted TimescaleDB on Windows-based systems
+## Installing self-hosted Timescale on Windows-based systems
 
 1.  Download and install the Visual C++ Redistributable for Visual Studio from
     [www.microsoft.com][ms-download].
@@ -47,10 +48,10 @@ To install PostgreSQL version 15.1.1 or later, make sure you have:
     You might need to add the `pg_config` file location to your path. In the Windows
     Search tool, search for `system environment variables`. The path should be
     `C:\Program Files\PostgreSQL\<version>\bin`.
-2.  Download the TimescaleDB installation `.zip` file from
+2.  Download the Timescale installation `.zip` file from
     [Windows releases][windows-releases].
 3.  Locate the downloaded file on your local file system, and extract the files.
-4.  In the extracted TimescaleDB directory, right-click the `setup.exe` file and
+4.  In the extracted Timescale directory, right-click the `setup.exe` file and
     select `Run as Administrator` to start the installer.
 
 </Procedure>
@@ -60,16 +61,16 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the TimescaleDB extension
+## Set up the Timescale extension
 
-When you have PostgreSQL and TimescaleDB installed, you can connect to it from
+When you have PostgreSQL and Timescale installed, you can connect to it from
 your local system using the `psql` command-line utility.
 
 <Windows />
 
 <Procedure>
 
-### Setting up the TimescaleDB extension
+### Setting up the Timescale extension
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -101,7 +102,7 @@ your local system using the `psql` command-line utility.
     \c example
     ```
 
-1.  Add the TimescaleDB extension:
+1.  Add the Timescale extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -115,7 +116,7 @@ your local system using the `psql` command-line utility.
 
 </Procedure>
 
-You can check that the TimescaleDB extension is installed by using the `\dx`
+You can check that the Timescale extension is installed by using the `\dx`
 command at the `psql` prompt. It looks like this:
 
 ```sql
@@ -147,43 +148,30 @@ tsdb=>
 
 ## Windows releases
 
-Here are the latest TimescaleDB releases for PostgreSQL 12, 13, 14, and 15. To see
+Here are the latest Timescale releases for PostgreSQL 12, 13, 14, and 15. To see
 information on releases, check out the
 [GitHub releases page][gh-releases]. Also see the
 [release notes][release-notes].
 
 *   <Tag type="download">
-    [PostgreSQL 15: TimescaleDB release](https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-15_latest-windows-amd64.zip)
+    [PostgreSQL 15: Timescale release](https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-15_latest-windows-amd64.zip)
     </Tag>
 *   <Tag type="download">
-    [PostgreSQL 14: TimescaleDB release](https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-14_latest-windows-amd64.zip)
+    [PostgreSQL 14: Timescale release](https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-14_latest-windows-amd64.zip)
     </Tag>
 *   <Tag type="download">
-    [PostgreSQL 13: TimescaleDB release](https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-13_latest-windows-amd64.zip)
+    [PostgreSQL 13: Timescale release](https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-13_latest-windows-amd64.zip)
     </Tag>
 *   <Tag type="download">
-    [PostgreSQL 12: TimescaleDB release](https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-12_latest-windows-amd64.zip)
+    [PostgreSQL 12: Timescale release](https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-12_latest-windows-amd64.zip)
     </Tag>
 
-## Where to next
+<WhereTo />
 
-Now that you have your first TimescaleDB database up and running, you can check
-out the [TimescaleDB][tsdb-docs] section in our documentation, and find out what
-you can do with it.
-
-If you want to work through some tutorials to help you get up and running with
-TimescaleDB and time-series data, check out our [tutorials][tutorials] section.
-
-You can always [contact us][contact] if you need help working something out, or
-if you want to have a chat.
-
-[config]: /timescaledb/:currentVersion:/how-to-guides/configuration/
-[contact]: https://www.timescale.com/contact
 [gh-releases]: https://github.com/timescale/timescaledb/releases
 [install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
 [ms-download]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 [pg-download]: https://www.postgresql.org/download/windows/
 [release-notes]: /timescaledb/:currentVersion:/overview/release-notes/
-[tsdb-docs]: /timescaledb/:currentVersion:/
 [tutorials]: /timescaledb/:currentVersion:/tutorials/
 [windows-releases]: #windows-releases

--- a/self-hosted/install/self-hosted.md
+++ b/self-hosted/install/self-hosted.md
@@ -1,6 +1,6 @@
 ---
-title: Install self-hosted TimescaleDB
-excerpt: Install a self-hosted, self-managed instance of TimescaleDB
+title: Install self-hosted Timescale
+excerpt: Install a self-hosted, self-managed instance of Timescale
 products: [self_hosted]
 keywords: [installation, self-hosted]
 ---

--- a/self-hosted/page-index/page-index.js
+++ b/self-hosted/page-index/page-index.js
@@ -15,43 +15,46 @@ module.exports = [
           {
             title: "Linux",
             href: "installation-linux",
-            iconSrc: "//assets.iobeam.com/images/docs/linux-icon.svg",
+            iconSrc: "https://assets.iobeam.com/images/docs/linux-icon.svg",
             excerpt: "Install self-hosted Timescale on Linux",
           },
           {
             title: "Windows",
             href: "installation-windows",
-            iconSrc: "//assets.iobeam.com/images/docs/Windows_logo_-_2012.svg",
+            iconSrc: "https://assets.iobeam.com/images/docs/Windows_logo_-_2012.svg",
             excerpt:
             "Install self-hosted Timescale on Microsoft Windows using a zipped .exe file",
           },
           {
             title: "MacOS",
             href: "installation-macos",
-            iconSrc: "//assets.iobeam.com/images/docs/Apple_logo_black.svg",
+            iconSrc: "https://assets.iobeam.com/images/docs/Apple_logo_black.svg",
             excerpt: "Install self-hosted Timescale on MacOS using homebrew",
           },
           {
             title: "From source",
             href: "installation-source",
-            iconSrc: "//assets.iobeam.com/images/docs/source.png",
+            iconSrc: "https://assets.iobeam.com/images/docs/source.png",
             excerpt:
               "Install self-hosted Timescale on any operating system from source",
           },
           {
             title: "Pre-built containers",
             href: "installation-docker",
+            iconSrc: "https://s3.amazonaws.com/assets.iobeam.com/images/docs/moby.png",
             excerpt:
               "Install self-hosted Timescale with a pre-built Docker container",
           },
           {
             title: "Kubernetes",
             href: "installation-kubernetes",
+            iconSrc: "https://s3.amazonaws.com/assets.iobeam.com/images/docs/kubernetes-icon-color.svg",
             excerpt: "Install self-hosted Timescale on Kubernetes",
           },
           {
             title: "Pre-built cloud images",
             href: "installation-cloud-image",
+            iconSrc: "https://s3.amazonaws.com/assets.iobeam.com/images/docs/aws_logo.svg",
             excerpt: "Install self-hosted Timescale on Amazon with an Ubuntu AMI",
           },
           {

--- a/self-hosted/page-index/page-index.js
+++ b/self-hosted/page-index/page-index.js
@@ -11,42 +11,32 @@ module.exports = [
         title: "Install Timescale",
         href: "install",
         excerpt: "Install self-hosted Timescale",
-        children: [
+        children: [  
           {
-            title: "Self hosted",
-            href: "self-hosted",
-            type: "react-page",
-            component: "InstallationPage",
-            showNewsletterForm: true,
-            excerpt: "Install self-hosted Timescale",
-            children: [
-              {
-                title: "Linux",
-                href: "installation-linux",
-                iconSrc: "//assets.iobeam.com/images/docs/linux-icon.svg",
-                excerpt: "Install self-hosted Timescale on Linux",
-              },
-              {
-                title: "Windows",
-                href: "installation-windows",
-                iconSrc: "//assets.iobeam.com/images/docs/Windows_logo_-_2012.svg",
-                excerpt:
-                  "Install self-hosted Timescale on Microsoft Windows using a zipped .exe file",
-              },
-              {
-                title: "MacOS",
-                href: "installation-macos",
-                iconSrc: "//assets.iobeam.com/images/docs/Apple_logo_black.svg",
-                excerpt: "Install self-hosted Timescale on MacOS using homebrew",
-              },
-              {
-                title: "From source",
-                href: "installation-source",
-                iconSrc: "//assets.iobeam.com/images/docs/source.png",
-                excerpt:
-                  "Install self-hosted Timescale on any operating system from source",
-              },
-            ],
+            title: "Linux",
+            href: "installation-linux",
+            iconSrc: "//assets.iobeam.com/images/docs/linux-icon.svg",
+            excerpt: "Install self-hosted Timescale on Linux",
+          },
+          {
+            title: "Windows",
+            href: "installation-windows",
+            iconSrc: "//assets.iobeam.com/images/docs/Windows_logo_-_2012.svg",
+            excerpt:
+            "Install self-hosted Timescale on Microsoft Windows using a zipped .exe file",
+          },
+          {
+            title: "MacOS",
+            href: "installation-macos",
+            iconSrc: "//assets.iobeam.com/images/docs/Apple_logo_black.svg",
+            excerpt: "Install self-hosted Timescale on MacOS using homebrew",
+          },
+          {
+            title: "From source",
+            href: "installation-source",
+            iconSrc: "//assets.iobeam.com/images/docs/source.png",
+            excerpt:
+              "Install self-hosted Timescale on any operating system from source",
           },
           {
             title: "Pre-built containers",
@@ -69,8 +59,8 @@ module.exports = [
             href: "troubleshooting",
             type: "placeholder",
           },
-        ],
-      },
+        ]
+      }, 
       {
         title: "Configuration",
         href: "configuration",


### PR DESCRIPTION
# Description

- aligned content to self-hosted
- replaced references to TimescaleDB with Timescale
- created a partial for Where to next 
- Updated the link in WhereTo Use Timescale
PS: the icons for docker, k8s, and cloud-image are not added in the Install page

Tracking updated: https://docs.google.com/spreadsheets/d/1oQo9EfoGURLFsq4dKgKshRpLLE12gREU3P709Xzq54I/edit?usp=sharing

# Links
Fixes https://github.com/timescale/docs-private/issues/77

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
