### PR TITLE
Improve integral docs

### DIFF
--- a/api/_hyperfunctions/time_weight/integral.md
+++ b/api/_hyperfunctions/time_weight/integral.md
@@ -22,8 +22,8 @@ api_details:
     - language: sql
       code: |
         integral(
-            tws TimeWeightSummary,
-            unit TEXT
+            tws TimeWeightSummary
+            [, unit TEXT]
         ) RETURNS DOUBLE PRECISION
   parameters:
     required:

--- a/api/_hyperfunctions/time_weight/interpolated_integral.md
+++ b/api/_hyperfunctions/time_weight/interpolated_integral.md
@@ -39,6 +39,7 @@ api_details:
             interval INTERVAL
             [, prev TimeWeightSummary]
             [, next TimeWeightSummary]
+            [, unit TEXT]
         ) RETURNS DOUBLE PRECISION
   parameters:
     required:
@@ -48,12 +49,12 @@ api_details:
       - name: start
         type: TIMESTAMPTZ
         description: >
-          The start of the interval which the time-weighted average should cover
+          The start of the interval which the time-weighted integral should cover
           (if there is a preceding point).
       - name: interval
         type: INTERVAL
         description: >
-          The length of the interval which the time-weighted average should
+          The length of the interval which the time-weighted integral should
           cover.
     optional:
       - name: prev
@@ -73,6 +74,12 @@ api_details:
           determined from the PostgreSQL
           [`lead()`](https://www.postgresql.org/docs/current/functions-window.html#FUNCTIONS-WINDOW-TABLE)
           function.
+      - name: unit
+        type: TEXT
+        description: >
+          The unit of time to express the integral in. Can be `microsecond`,
+          `millisecond`, `second`, `minute`, `hour`, or any alias for those units
+          supported by PostgreSQL. Defaults to `second`.
     returns:
       - column: integral
         type: DOUBLE PRECISION


### PR DESCRIPTION
# Description

- Fixes references to "averages" with correct references to "integrals"
- Better indicate `integral`'s `unit` parameter is optional
- Add `unit` to list of optional parameters for `interpolated_integral`

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
