### PR TITLE
fix branding of self-hosted timescaledb

### DIFF
--- a/self-hosted/backup-and-restore/docker-and-wale.md
+++ b/self-hosted/backup-and-restore/docker-and-wale.md
@@ -1,6 +1,6 @@
 ---
 title: Ongoing physical backups with Docker & WAL-E
-excerpt: Back up your Docker instance of Timescale
+excerpt: Back up your Docker instance of TimescaleDB
 products: [self_hosted]
 keywords: [backups, Docker]
 tags: [restore, recovery, physical backup]
@@ -10,12 +10,12 @@ import Deprecation from "versionContent/_partials/_deprecated.mdx";
 
 # Ongoing physical backups with Docker & WAL-E
 
-When you run Timescale in a containerized environment, you can use
+When you run TimescaleDB in a containerized environment, you can use
 [continuous archiving][pg archiving] with a [WAL-E][wale official] container.
 These containers are sometimes referred to as sidecars, because they run
 alongside the main container. A [WAL-E sidecar image][wale image]
-works with Timescale as well as regular PostgreSQL. In this section, you 
-can set up archiving to your local filesystem with a main Timescale
+works with TimescaleDB as well as regular PostgreSQL. In this section, you
+can set up archiving to your local filesystem with a main TimescaleDB
 container called `timescaledb`, and a WAL-E sidecar called `wale`. When you are
 ready to implement this in your production deployment, you can adapt the
 instructions here to do archiving against cloud providers such as AWS S3, and
@@ -23,20 +23,20 @@ run it in an orchestration framework such as Kubernetes.
 
 <Deprecation />
 
-## Run the Timescale container in Docker
+## Run the TimescaleDB container in Docker
 
-To make Timescale use the WAL-E sidecar for archiving, the two containers need
+To make TimescaleDB use the WAL-E sidecar for archiving, the two containers need
 to share a network. To do this, you need to create a Docker  network and then
-launch Timescale with archiving turned on, using the newly created network.
-When you launch Timescale, you need to explicitly set the location of the
+launch TimescaleDB with archiving turned on, using the newly created network.
+When you launch TimescaleDB, you need to explicitly set the location of the
 write-ahead log (`POSTGRES_INITDB_WALDIR`) and data directory (`PGDATA`) so that
 you can share them with the WAL-E sidecar. Both must reside in a Docker volume,
 by default a volume is created for `/var/lib/postgresql/data`. When you have
-started Timescale, you can log in and create tables and data.
+started TimescaleDB, you can log in and create tables and data.
 
 <Procedure>
 
-### Running the Timescale container in Docker
+### Running the TimescaleDB container in Docker
 
 1.  Create the docker container:
 
@@ -44,7 +44,7 @@ started Timescale, you can log in and create tables and data.
     docker network create timescaledb-net
     ```
 
-1.  Launch Timescale, with archiving turned on:
+1.  Launch TimescaleDB, with archiving turned on:
 
     ```bash
     docker run \
@@ -62,7 +62,7 @@ started Timescale, you can log in and create tables and data.
       -cmax_wal_senders=1
     ```
 
-1.  Run Timescale within Docker:
+1.  Run TimescaleDB within Docker:
 
     ```bash
     docker exec -it timescaledb psql -U postgres
@@ -81,7 +81,7 @@ commands from services such as AWS S3. For information about configuring, see
 the official [WAL-E documentation][wale official].
 
 To enable the WAL-E docker image to perform archiving, it needs to use the same
-network and data volumes as the Timescale container. It also needs to know the
+network and data volumes as the TimescaleDB container. It also needs to know the
 location of the write-ahead log and data directories. You can pass all this
 information to WAL-E when you start it. In this example, the WAL-E image listens
 for commands on the `timescaledb-net` internal network at port 80, and writes
@@ -129,13 +129,13 @@ backups to `~/backups` on the Docker host.
 You should do base backups at regular intervals daily, to minimize
 the amount of WAL-E replay, and to make recoveries faster. To make new base
 backups, re-trigger a base backup as shown here, either manually or on a
-schedule. If you run Timescale on Kubernetes, there is built-in support for
+schedule. If you run TimescaleDB on Kubernetes, there is built-in support for
 scheduling cron jobs that can invoke base backups using the WAL-E container's
 HTTP API.
 
 ## Recovery
 
-To recover the database instance from the backup archive, create a new Timescale
+To recover the database instance from the backup archive, create a new TimescaleDB
 container, and restore the database and configuration files from the base
 backup. Then you can relaunch the sidecar and the database.
 
@@ -229,7 +229,7 @@ database, and check that recovery was successful.
       timescale/timescaledb-wale:latest
     ```
 
-1.  Relaunch the Timescale docker container:
+1.  Relaunch the TimescaleDB docker container:
 
     ```bash
     docker start timescaledb-recovered

--- a/self-hosted/backup-and-restore/index.md
+++ b/self-hosted/backup-and-restore/index.md
@@ -1,6 +1,6 @@
 ---
 title: Backup and restore
-excerpt: Learn how to back up and restore your Timescale instance
+excerpt: Learn how to back up and restore your TimescaleDB instance
 products: [self_hosted]
 keywords: [backups, restore]
 tags: [recovery]
@@ -8,9 +8,9 @@ tags: [recovery]
 
 # Backup and restore
 
-Timescale takes advantage of the reliable backup and restore functionality
+TimescaleDB takes advantage of the reliable backup and restore functionality
 provided by PostgreSQL. There are a few different mechanisms you can use to
-backup your self-hosted Timescale database:
+backup your self-hosted TimescaleDB database:
 
 *   Logical backups with [pg_dump and pg_restore][logical-backups].
 *   [Physical backups][physical-backups] with `pg_basebackup` or another tool.

--- a/self-hosted/backup-and-restore/pg-dump-and-restore.md
+++ b/self-hosted/backup-and-restore/pg-dump-and-restore.md
@@ -13,13 +13,13 @@ the native PostgreSQL [`pg_dump`][pg_dump] and [`pg_restore`][pg_restore]
 commands. This works even for compressed hypertables, without having to
 decompress the chunks before you begin.
 
-Upgrades between different versions of Timescale can be done in place; you
+Upgrades between different versions of TimescaleDB can be done in place; you
 don't need to backup and restore your data. See
 the [upgrading instructions][timescaledb-upgrade].
 
 <Highlight type="warning">
 If you are using this `pg_dump` backup method regularly, make sure you keep
-track of which versions of PostgreSQL and Timescale you are running. For more
+track of which versions of PostgreSQL and TimescaleDB you are running. For more
 information, see "Versions are mismatched when dumping and restoring a database"
 in the [Troubleshooting section](https://docs.timescale.com/timescaledb/latest/self-hosted/backup-and-restore/troubleshooting/).
 </Highlight>
@@ -87,14 +87,14 @@ database and restore the data.
 
 <Highlight type="warning">
 Do not use the `pg_restore` command with -j option. This option does not
-correctly restore the Timescale catalogs.
+correctly restore the TimescaleDB catalogs.
 </Highlight>
 
 ## Back up individual hypertables
 
 The `pg_dump` command provides flags that allow you to specify tables or schemas
 to back up. However, using these flags means that the dump lacks necessary
-information that Timescale requires to understand the relationship between
+information that TimescaleDB requires to understand the relationship between
 them. Even if you explicitly specify both the hypertable and all of its
 constituent chunks, the dump would still not contain all the information it
 needs to recreate the hypertable on restore.
@@ -163,7 +163,7 @@ partitions, or the chunk interval sizes.
 
 </Procedure>
 
-On a self hosted Timescale instance with `postgres` superuser access you can
+On a self hosted TimescaleDB instance with `postgres` superuser access you can
 take a complete dump of all PostgreSQL databases in a cluster including global
 objects that are common to all databases, namely database roles, tablespaces,
 and privilege grants using `pg_dumpall`. For more

--- a/self-hosted/backup-and-restore/physical.md
+++ b/self-hosted/backup-and-restore/physical.md
@@ -1,6 +1,6 @@
 ---
 title: Physical backups
-excerpt: How to take physical backups of your Timescale instance
+excerpt: How to take physical backups of your TimescaleDB instance
 products: [self_hosted]
 keywords: [backups]
 tags: [restore, recovery, physical backup]
@@ -10,7 +10,7 @@ tags: [restore, recovery, physical backup]
 
 For full instance physical backups (which are especially useful for starting up
 new [replicas][replication-tutorial]), [`pg_basebackup`][postgres-pg_basebackup]
-works with all Timescale installation types. You can also use any of several
+works with all TimescaleDB installation types. You can also use any of several
 external backup and restore managers such as [`pg_backrest`][pg-backrest], or [`barman`][pg-barman]. For ongoing physical backups, you can use
 [`wal-e`][wale], although this method is now deprecated. These tools all allow
 you to take online, physical backups of your entire instance, and many offer

--- a/self-hosted/configuration/about-configuration.md
+++ b/self-hosted/configuration/about-configuration.md
@@ -1,19 +1,19 @@
 ---
-title: About configuration in Timescale
-excerpt: About the Timescale configurations
+title: About configuration in TimescaleDB
+excerpt: About the TimescaleDB configurations
 products: [self_hosted]
 keywords: [configuration, memory, workers, settings]
 ---
 
-# About configuration in Timescale
+# About configuration in TimescaleDB
 
-By default, Timescale uses the default PostgreSQL server configuration
+By default, TimescaleDB uses the default PostgreSQL server configuration
 settings. However, in some cases, these settings are not appropriate, especially
 if you have larger servers that use more hardware resources such as CPU, memory,
 and storage. This section explains some of the settings you are most likely to
 need to adjust.
 
-Some of these settings are PostgreSQL settings, and some are Timescale
+Some of these settings are PostgreSQL settings, and some are TimescaleDB
 specific settings. For most changes, you can use the [tuning tool][tstune-conf]
 to adjust your configuration. For more advanced configuration settings, or to
 change settings that aren't included in the `timescaledb-tune` tool, you can
@@ -50,7 +50,7 @@ PostgreSQL uses worker pools to provide workers for live queries and background
 jobs. If you do not configure these settings, your queries and background jobs
 could run more slowly.
 
-Timescale background workers are configured with
+TimescaleDB background workers are configured with
 `timescaledb.max_background_workers`. Each database needs a background worker
 allocated to schedule jobs. Additional workers run background jobs as required.
 This setting should be the sum of the total number of databases and the total
@@ -60,7 +60,7 @@ You can change this setting directly, use the `--max-bg-workers` flag, or adjust
 the `TS_TUNE_MAX_BG_WORKERS`
 [Docker environment variable][docker-conf].
 
-Timescale parallel workers are configured with `max_parallel_workers`. For
+TimescaleDB parallel workers are configured with `max_parallel_workers`. For
 larger queries, PostgreSQL automatically uses parallel workers if they are
 available. Increasing this setting can improve query performance for large
 queries that trigger the use of parallel workers. By default, this setting
@@ -102,7 +102,7 @@ Settings:
 
 *   `max_locks_per_transaction`
 
-Timescale relies on table partitioning to scale time-series workloads. A
+TimescaleDB relies on table partitioning to scale time-series workloads. A
 hypertable needs to acquire locks on many chunks during queries, which can
 exhaust the default limits for the number of allowed locks held. In some cases,
 you might see a warning like this:

--- a/self-hosted/configuration/configuration.md
+++ b/self-hosted/configuration/configuration.md
@@ -1,14 +1,14 @@
 ---
-title: Configuring Timescale
-excerpt: How to configure a Timescale instance
+title: Configuring TimescaleDB
+excerpt: How to configure a TimescaleDB instance
 products: [self_hosted]
 keywords: [configuration]
 tags: [settings]
 ---
 
-# Configuring Timescale
+# Configuring TimescaleDB
 
-Timescale works with the default PostgreSQL server configuration settings.
+TimescaleDB works with the default PostgreSQL server configuration settings.
 However, we find that these settings are typically too conservative and
 can be limiting when using larger servers with more resources (CPU, memory,
 disk, etc). Adjusting these settings, either
@@ -20,8 +20,8 @@ You can determine the location of `postgresql.conf` by running
 `SHOW config_file;` from your PostgreSQL client (for example, `psql`).
 </Highlight>
 
-In addition, other Timescale specific settings can be modified through the
-`postgresql.conf` file as covered in the [Timescale settings][ts-settings] section.
+In addition, other TimescaleDB specific settings can be modified through the
+`postgresql.conf` file as covered in the [TimescaleDB settings][ts-settings] section.
 
 ## Using `timescaledb-tune`
 
@@ -86,8 +86,9 @@ suggestions that `timescaledb-tune` makes, then check these. However,
 
 ### Memory settings
 
-<Highlight type="tip">All of these settings are handled by `timescaledb-tune`.</Highlight>
-
+<Highlight type="tip">
+All of these settings are handled by `timescaledb-tune`.
+</Highlight>
 The settings `shared_buffers`, `effective_cache_size`, `work_mem`, and
 `maintenance_work_mem` need to be adjusted to match the machine's available
 memory. Get the configuration values from the [PgTune][pgtune]
@@ -98,14 +99,15 @@ PgTune may also be helpful.
 
 ### Worker settings
 
-<Highlight type="tip">All of these settings are handled by `timescaledb-tune`.</Highlight>
-
+<Highlight type="tip">
+All of these settings are handled by `timescaledb-tune`.
+</Highlight>
 PostgreSQL utilizes worker pools to provide the required workers needed to
 support both live queries and background jobs. If you do not configure these
 settings, you may observe performance degradation on both queries and
 background jobs.
 
-Timescale background workers are configured using the
+TimescaleDB background workers are configured using the
 `timescaledb.max_background_workers` setting. You should configure this
 setting to the sum of your total number of databases and the
 total number of concurrent background workers you want running at any given
@@ -145,7 +147,7 @@ discourage changing the `fsync` setting.
 
 ### Lock settings
 
-Timescale relies heavily on table partitioning for scaling
+TimescaleDB relies heavily on table partitioning for scaling
 time-series workloads, which has implications for [lock
 management][lock-management]. A hypertable needs to acquire locks on
 many chunks (sub-tables) during queries, which can exhaust the default
@@ -179,9 +181,9 @@ locks allocated for each transaction. For more information, please
 review the official PostgreSQL documentation on
 [lock management][lock-management].
 
-## Timescale configuration and tuning
+## TimescaleDB configuration and tuning
 
-Just as you can tune settings in PostgreSQL, Timescale provides a number of
+Just as you can tune settings in PostgreSQL, TimescaleDB provides a number of
 configuration settings that may be useful to your specific installation and
 performance needs. These can also be set within the `postgresql.conf` file or as
 command-line parameters when starting PostgreSQL.
@@ -190,7 +192,7 @@ command-line parameters when starting PostgreSQL.
 
 #### `timescaledb.max_background_workers (int)`
 
-Max background worker processes allocated to Timescale. Set to at
+Max background worker processes allocated to TimescaleDB. Set to at
 least 1 + number of databases in Postgres instance to use background
 workers. Default value is 8.
 
@@ -215,12 +217,12 @@ inconsistent data. It is by default enabled.
 
 #### `timescaledb.enable_per_data_node_queries (bool)`
 
-If enabled, Timescale combines different chunks belonging to the
+If enabled, TimescaleDB combines different chunks belonging to the
 same hypertable into a single query per data node. It is by default enabled.
 
 #### `timescaledb.max_insert_batch_size (int)`
 
-When acting as a access node, Timescale splits batches of inserted
+When acting as a access node, TimescaleDB splits batches of inserted
 tuples across multiple data nodes. It batches up to
 `max_insert_batch_size` tuples per data node before flushing. Setting
 this to 0 disables batching, reverting to tuple-by-tuple inserts. The
@@ -267,11 +269,11 @@ connecting to data nodes using password authentication.
 
 #### `timescaledb.restoring (bool)`
 
-Set Timescale in restoring mode. It is by default disabled.
+Set TimescaleDB in restoring mode. It is by default disabled.
 
 #### `timescaledb.license (string)`
 
-Timescale license type. Determines which features are enabled. The
+TimescaleDB license type. Determines which features are enabled. The
 variable can be set to `timescale` or `apache`.  Defaults to `timescale`.
 
 #### `timescaledb.telemetry_level (enum)`
@@ -289,7 +291,7 @@ Version of `timescaledb-tune` used to tune when it ran.
 
 ## Changing configuration with Docker
 
-When running Timescale in a [Docker container][docker], there are
+When running TimescaleDB in a [Docker container][docker], there are
 two approaches to modifying your PostgreSQL configuration. In the
 following example, we modify the size of the database instance's
 write-ahead-log (WAL) from 1&nbsp;GB to 2&nbsp;GB in a Docker container named

--- a/self-hosted/configuration/docker-config.md
+++ b/self-hosted/configuration/docker-config.md
@@ -1,13 +1,13 @@
 ---
 title: Configuration with Docker
-excerpt: Configure a Timescale instance running in a Docker container
+excerpt: Configure a TimescaleDB instance running in a Docker container
 products: [self_hosted]
 keywords: [configuration, settings, Docker]
 ---
 
 # Configuration with Docker
 
-If you are running Timescale in a [Docker container][docker], there are two
+If you are running TimescaleDB in a [Docker container][docker], there are two
 different ways to modify your PostgreSQL configuration. You can edit the
 PostgreSQL configuration file inside the Docker container, or you can set
 parameters at the command prompt.

--- a/self-hosted/configuration/index.md
+++ b/self-hosted/configuration/index.md
@@ -1,13 +1,13 @@
 ---
 title: Configuration
-excerpt: Learn about configuring your Timescale instance
+excerpt: Learn about configuring your TimescaleDB instance
 products: [self_hosted]
 keywords: [configuration, settings]
 ---
 
 # Configuration
 
-By default, Timescale uses the default PostgreSQL server configuration
+By default, TimescaleDB uses the default PostgreSQL server configuration
 settings. However, in some cases, these settings are not appropriate, especially
 if you have larger servers that use more hardware resources such as CPU, memory,
 and storage.
@@ -16,7 +16,7 @@ and storage.
     begin using it.
 *   Use the [TimescaleDB tune tool][tstune-conf].
 *   Manually edit the `postgresql.conf` [configuration file][postgresql-conf].
-*   If you run Timescale in a Docker container, configure
+*   If you run TimescaleDB in a Docker container, configure
     [within Docker][docker-conf].
 *   Find out more about the [data that we collect][telemetry].
 

--- a/self-hosted/configuration/telemetry.md
+++ b/self-hosted/configuration/telemetry.md
@@ -1,13 +1,13 @@
 ---
 title: Telemetry and version checking
-excerpt: What telemetry Timescale collects and how to disable telemetry
+excerpt: What telemetry TimescaleDB collects and how to disable telemetry
 products: [self_hosted]
 keywords: [settings, telemetry]
 ---
 
 # Telemetry and version checking
 
-Timescale collects anonymous usage data to help us better understand and assist
+TimescaleDB collects anonymous usage data to help us better understand and assist
 our users. It also helps us provide some services, such as automated version
 checking. Your privacy is the most important thing to us, so we do not collect
 any personally identifying information. In particular, the `UUID` (user ID)
@@ -180,7 +180,7 @@ you can use the [`get_telemetry_report`][get_telemetry_report] API call.
 
 <Highlight type="note">
 Telemetry reports are different if you are using an open source or community
-version of Timescale. For these versions, the report includes an `edition`
+version of TimescaleDB. For these versions, the report includes an `edition`
 field, with a value of either `apache_only` or `community`.
 </Highlight>
 

--- a/self-hosted/configuration/timescaledb-config.md
+++ b/self-hosted/configuration/timescaledb-config.md
@@ -1,14 +1,14 @@
 ---
-title: Timescale configuration and tuning
-excerpt: How to change configuration settings for Timescale
+title: TimescaleDB configuration and tuning
+excerpt: How to change configuration settings for TimescaleDB
 products: [self_hosted]
 keywords: [configuration, settings]
 tags: [tune]
 ---
 
-# Timescale configuration and tuning
+# TimescaleDB configuration and tuning
 
-Just as you can tune settings in PostgreSQL, Timescale provides a number of configuration
+Just as you can tune settings in PostgreSQL, TimescaleDB provides a number of configuration
 settings that may be useful to your specific installation and performance needs. These can
 also be set within the `postgresql.conf` file or as command-line parameters
 when starting PostgreSQL.
@@ -17,8 +17,8 @@ when starting PostgreSQL.
 
 ### `timescaledb.max_background_workers (int)`
 
-Max background worker processes allocated to Timescale. Set to at least 1 +
-the number of databases loaded with a Timescale extension in a PostgreSQL
+Max background worker processes allocated to TimescaleDB. Set to at least 1 +
+the number of databases loaded with a TimescaleDB extension in a PostgreSQL
 instance. Default value is 16.
 
 ## Distributed hypertables
@@ -31,12 +31,12 @@ inconsistent data. It is by default enabled.
 
 ### `timescaledb.enable_per_data_node_queries`
 
-If enabled, Timescale combines different chunks belonging to the
+If enabled, TimescaleDB combines different chunks belonging to the
 same hypertable into a single query per data node. It is by default enabled.
 
 ### `timescaledb.max_insert_batch_size (int)`
 
-When acting as a access node, Timescale splits batches of inserted
+When acting as a access node, TimescaleDB splits batches of inserted
 tuples across multiple data nodes. It batches up to
 `max_insert_batch_size` tuples per data node before flushing. Setting
 this to 0 disables batching, reverting to tuple-by-tuple inserts. The
@@ -83,12 +83,12 @@ connecting to data nodes using password authentication.
 
 ### `timescaledb.restoring (bool)`
 
-Set Timescale in restoring mode. It is disabled by default.
+Set TimescaleDB in restoring mode. It is disabled by default.
 
 ### `timescaledb.license (string)`
 
-Change access to features based on the Timescale license in use. For example,
-setting `timescaledb.license` to `apache` limits Timescale to features that
+Change access to features based on the TimescaleDB license in use. For example,
+setting `timescaledb.license` to `apache` limits TimescaleDB to features that
 are implemented under the Apache 2 license. The default value is `timescale`,
 which allows access to all features.
 

--- a/self-hosted/configuration/timescaledb-tune.md
+++ b/self-hosted/configuration/timescaledb-tune.md
@@ -1,17 +1,17 @@
 ---
-title: Timescale tuning tool
-excerpt: Use the timescaledb-tune tool to automatically configure your Timescale instance
+title: TimescaleDB tuning tool
+excerpt: Use the timescaledb-tune tool to automatically configure your TimescaleDB instance
 products: [self_hosted]
 keywords: [configuration, settings, timescaledb-tune]
 tags: [tune]
 ---
 
-# Timescale tuning tool
+# TimescaleDB tuning tool
 
-To help make configuring Timescale a little easier, you can use the [`timescaledb-tune`][tstune]
+To help make configuring TimescaleDB a little easier, you can use the [`timescaledb-tune`][tstune]
 tool. This tool handles setting the most common parameters to good values based
 on your system. It accounts for memory, CPU, and PostgreSQL version.
-`timescaledb-tune` is packaged with the Timescale binary releases as a
+`timescaledb-tune` is packaged with the TimescaleDB binary releases as a
 dependency, so if you installed Timescale from a binary release (including
 Docker), you should already have access to the tool. Alternatively, you can use
 the `go install` command to install it:

--- a/self-hosted/install/index.md
+++ b/self-hosted/install/index.md
@@ -1,17 +1,17 @@
 ---
-title: Install Timescale
-excerpt: Install Timescale, the PostgreSQL database for time series and data analysis
+title: Install TimescaleDB
+excerpt: Install TimescaleDB, the PostgreSQL database for time series and data analysis
 products: [cloud, mst, self_hosted]
 keywords: [installation]
 ---
 
-# Install Timescale
+# Install TimescaleDB
 
-Timescale extends PostgreSQL for time-series data, giving PostgreSQL the
+TimescaleDB extends PostgreSQL for time-series data, giving PostgreSQL the
 high-performance, scalability, and analytical capabilities required by modern
 data-intensive applications.
 
-You can install Timescale for free from [source][self-hosted-source], a
+You can install TimescaleDB for free from [source][self-hosted-source], a
 [pre-built container][self-hosted-container], or a pre-built
 [cloud image][self-hosted-cloud] on [your own server hardware][self-hosted-install].
 
@@ -21,4 +21,3 @@ You can install Timescale for free from [source][self-hosted-source], a
 [self-hosted-source]: /install/:currentVersion:/self-hosted/installation-source/
 [self-hosted-container]: /install/:currentVersion:/installation-docker/
 [self-hosted-cloud]: /install/:currentVersion:/self-hosted/installation-linux/
-

--- a/self-hosted/install/installation-cloud-image.md
+++ b/self-hosted/install/installation-cloud-image.md
@@ -1,6 +1,6 @@
 ---
-title: Install Timescale from cloud image
-excerpt: Install self-hosted Timescale from a pre-built cloud image
+title: Install TimescaleDB from cloud image
+excerpt: Install self-hosted TimescaleDB from a pre-built cloud image
 products: [self_hosted]
 keywords: [installation, self-hosted]
 tags: [cloud image]
@@ -8,16 +8,16 @@ tags: [cloud image]
 
 import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-# Install Timescale from a pre-built cloud image
+# Install TimescaleDB from a pre-built cloud image
 
-You can install Timescale on a cloud hosting provider,
+You can install TimescaleDB on a cloud hosting provider,
 from a pre-built, publicly available machine image. These instructions show you
 how to use a pre-built Amazon machine image (AMI), on Amazon Web Services (AWS).
 The currently available pre-built cloud image is:
 
 *   Ubuntu 20.04 Amazon EBS-backed AMI
 
-The Timescale AMI uses Elastic Block Store (EBS) attached volumes. This allows
+The TimescaleDB AMI uses Elastic Block Store (EBS) attached volumes. This allows
 you to store image snapshots, dynamic IOPS configuration, and provides some
 protection of your data if the EC2 instance goes down. Choose an EC2 instance
 type that is optimized for EBS attached volumes. For information on choosing the
@@ -33,13 +33,13 @@ supports public AMIs.
 
 <Procedure>
 
-## Installing Timescale from a pre-build cloud image
+## Installing TimescaleDB from a pre-build cloud image
 
 1.  Make sure you have an [Amazon Web Services account][aws-signup], and are
     signed in to [your EC2 dashboard][aws-dashboard].
 1.  Navigate to `Images → AMIs`.
 1.  In the search bar, change the search to `Public images` and type _Timescale_
-    search term to find all available Timescale images.
+    search term to find all available TimescaleDB images.
 1.  Select the image you want to use, and click `Launch instance from image`.
     <img class="main-content__illustration"
     src="https://s3.amazonaws.com/assets.timescale.com/docs/images/aws_launch_ami.png"
@@ -60,14 +60,14 @@ service for the configuration changes to take effect. To restart the service,
 run `sudo systemctl restart postgresql.service`.
 </Highlight>
 
-## Set up the Timescale extension
+## Set up the TimescaleDB extension
 
-When you have PostgreSQL and Timescale installed, connect to your instance and
-set up the Timescale extension.
+When you have PostgreSQL and TimescaleDB installed, connect to your instance and
+set up the TimescaleDB extension.
 
 <Procedure>
 
-### Setting up the Timescale extension
+### Setting up the TimescaleDB extension
 
 1.  On your instance, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -89,7 +89,7 @@ set up the Timescale extension.
     \c tsdb
     ```
 
-1.  Add the Timescale extension:
+1.  Add the TimescaleDB extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -97,7 +97,7 @@ set up the Timescale extension.
 
 </Procedure>
 
-You can check that the Timescale extension is installed by using the `\dx`
+You can check that the TimescaleDB extension is installed by using the `\dx`
 command at the command prompt. It looks like this:
 
 ```sql

--- a/self-hosted/install/installation-docker.md
+++ b/self-hosted/install/installation-docker.md
@@ -1,16 +1,16 @@
 ---
-title: Install Timescale from Docker container
-excerpt: Install self-hosted Timescale from a pre-built Docker container
+title: Install TimescaleDB from Docker container
+excerpt: Install self-hosted TimescaleDB from a pre-built Docker container
 products: [self_hosted]
 keywords: [installation, self-hosted, Docker]
 ---
 
 import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-# Install Timescale from a pre-built container
+# Install TimescaleDB from a pre-built container
 
-You can install a Timescale instance on any local system, from a pre-built
-container. This is the simplest method to install Timescale, and it means you
+You can install a TimescaleDB instance on any local system, from a pre-built
+container. This is the simplest method to install TimescaleDB, and it means you
 always have access to the latest version without worrying about local
 dependencies. You can access the Docker image directly from locally installed
 PostgreSQL client tools such as `psql`.
@@ -20,18 +20,18 @@ If you have already installed PostgreSQL using a method other than the pre-built
 container provided here, you could encounter errors following these
 instructions. It is safest to remove any existing PostgreSQL installations
 before you begin. If you want to keep your current PostgreSQL installation, do
-not install Timescale using this method.
+not install TimescaleDB using this method.
 [Install from source](/install/latest/self-hosted/installation-source/)
 instead.
 </Highlight>
 
 <Procedure>
 
-## Installing Timescale from a Docker container
+## Installing TimescaleDB from a Docker container
 
 1.  Install Docker, if you don't already have it. For packages and
     instructions, see the [Docker installation documentation][docker-install].
-1.  At the command prompt, run the Timescale Docker image:
+1.  At the command prompt, run the TimescaleDB Docker image:
 
     ```bash
     docker pull timescale/timescaledb-ha:pg14-latest
@@ -39,7 +39,7 @@ instead.
 
 <Highlight type="important">
 The [`timescaledb-ha`](https://hub.docker.com/r/timescale/timescaledb-ha) image
-offers the most complete Timescale experience. It
+offers the most complete TimescaleDB experience. It
 includes the
 [TimescaleDB Toolkit](https://github.com/timescale/timescaledb-toolkit),
 and support for PostGIS and Patroni. If you need the smallest possible image, use
@@ -65,9 +65,9 @@ information, see the [configuration][config] section.
 
 ## More Docker options
 
-The Timescale HA Docker image includes [Ubuntu][ubuntu] as its operating
-system. The lighter-weight Timescale (non-HA) image uses [Alpine][alpine]. The
-commands in this section use the Timescale HA image, but the steps are the
+The TimescaleDB HA Docker image includes [Ubuntu][ubuntu] as its operating
+system. The lighter-weight TimescaleDB (non-HA) image uses [Alpine][alpine]. The
+commands in this section use the TimescaleDB HA image, but the steps are the
 same for both.
 
 You can use the Docker image in different ways, depending on your use case.
@@ -80,7 +80,7 @@ docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password time
 ```
 
 The `-p` flag binds the container port to the host port. This means that
-anything that can access the host port can also access your Timescale container,
+anything that can access the host port can also access your TimescaleDB container,
 so it's important that you set a PostgreSQL password using the
 `POSTGRES_PASSWORD` environment variable. Without that variable, the Docker
 container disables password checks for all database users.
@@ -118,30 +118,30 @@ docker run -d --name timescaledb -p 5432:5432 \
 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14-latest
 ```
 
-When you install Timescale using a Docker container, the PostgreSQL settings
+When you install TimescaleDB using a Docker container, the PostgreSQL settings
 are inherited from the container. In most cases, you do not need to adjust them.
 However, if you need to change a setting you can add `-c setting=value` to your
 Docker `run` command. For more information, see the
 [Docker documentation][docker-postgres].
 
-The link provided in these instructions is for the latest version of Timescale
+The link provided in these instructions is for the latest version of TimescaleDB
 on PostgreSQL 14. To find other Docker tags you can use, see the
 [Dockerhub repository][dockerhub].
 
-## Set up the Timescale extension
+## Set up the TimescaleDB extension
 
-When you have PostgreSQL and Timescale installed, you can connect to it from
+When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't
 installed it yet, check out the [installing psql][install-psql] section.
 
 <Procedure>
 
-### Setting up the Timescale extension
+### Setting up the TimescaleDB extension
 
 <Highlight type="important">
-If you installed Timescale from the pre-built Docker container, then you
-probably already have the Timescale extension, and you can skip this procedure.
+If you installed TimescaleDB from the pre-built Docker container, then you
+probably already have the TimescaleDB extension, and you can skip this procedure.
 </Highlight>
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
@@ -174,7 +174,7 @@ probably already have the Timescale extension, and you can skip this procedure.
     \c example
     ```
 
-1.  Add the Timescale extension:
+1.  Add the TimescaleDB extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -188,7 +188,7 @@ probably already have the Timescale extension, and you can skip this procedure.
 
 </Procedure>
 
-You can check that the Timescale extension is installed by using the `\dx`
+You can check that the TimescaleDB extension is installed by using the `\dx`
 command at the `psql` prompt. It looks like this:
 
 ```sql

--- a/self-hosted/install/installation-kubernetes.md
+++ b/self-hosted/install/installation-kubernetes.md
@@ -1,19 +1,19 @@
 ---
-title: Install Timescale on Kubernetes
-excerpt: Install self-hosted Timescale on Kubernetes
+title: Install TimescaleDB on Kubernetes
+excerpt: Install self-hosted TimescaleDB on Kubernetes
 products: [self_hosted]
 keywords: [installation, self-hosted, Kubernetes]
 ---
 
-# Install Timescale on Kubernetes
+# Install TimescaleDB on Kubernetes
 
-You can install a Timescale instance on any Kubernetes deployment. Use the
-`timescaledb-single` Helm chart to deploy a highly available Timescale
+You can install a TimescaleDB instance on any Kubernetes deployment. Use the
+`timescaledb-single` Helm chart to deploy a highly available TimescaleDB
 database, and `timescaledb-multinode` to deploy a multi-node distributed
-Timescale database. For more information about the components that are
-deployed with these charts, see [Timescale on Kubernetes][timescaledb-k8s].
+TimescaleDB database. For more information about the components that are
+deployed with these charts, see [TimescaleDB on Kubernetes][timescaledb-k8s].
 
-Before you begin installing Timescale on a Kubernetes deployment, make sure
+Before you begin installing TimescaleDB on a Kubernetes deployment, make sure
 you have installed:
 
 *   [kubectl][kubectl-install]
@@ -25,23 +25,23 @@ than those specified in the default `values.yaml`. You can name this file
 `<MY_VALUES.yaml>`. For details about the parameters you can set, see the
 [Administrator Guide][admin-guide].
 
-## Install Timescale using a Helm chart
+## Install TimescaleDB using a Helm chart
 
-Install Timescale on Kubernetes using a Helm chart with the default
+Install TimescaleDB on Kubernetes using a Helm chart with the default
 `values.yaml` file. When you use the `values.yaml` file, the user credentials
 are randomly generated during installation. Therefore, the `helm upgrade`
 command does not rotate the credentials, because changing the database
 credentials would break the database. Instead, it continues to use the
 credentials generated during `helm install`.
 
-This section provides instructions to deploy Timescale using the
+This section provides instructions to deploy TimescaleDB using the
 `timescaledb-single` Helm chart.
 
 <Procedure>
 
-### Installing Timescale using a Helm chart
+### Installing TimescaleDB using a Helm chart
 
-1.  Add the Timescale Helm chart repository:
+1.  Add the TimescaleDB Helm chart repository:
 
     ```bash
     helm repo add timescale 'https://charts.timescale.com'
@@ -53,7 +53,7 @@ This section provides instructions to deploy Timescale using the
     helm repo update
     ```
 
-1.  Install the Timescale Helm chart, by replacing `<MY_NAME>` with a name of
+1.  Install the TimescaleDB Helm chart, by replacing `<MY_NAME>` with a name of
     your choice:
 
     ```bash
@@ -68,14 +68,14 @@ This section provides instructions to deploy Timescale using the
 
 </Procedure>
 
-## Connect to Timescale
+## Connect to TimescaleDB
 
-You can connect to Timescale from an external IP address, or from within the
+You can connect to TimescaleDB from an external IP address, or from within the
 cluster.
 
 <Procedure>
 
-### Connecting to Timescale using an external IP
+### Connecting to TimescaleDB using an external IP
 
 <Highlight type="note">
 If you configured the user credentials in the `my_values.yaml` file, you don't
@@ -118,9 +118,9 @@ the name that you provided during the installation.
 
 <Procedure>
 
-### Connecting to Timescale from inside the cluster
+### Connecting to TimescaleDB from inside the cluster
 
-1.  Get the Pod on which Timescale is installed:
+1.  Get the Pod on which TimescaleDB is installed:
 
    ```bash
    MASTERPOD="$(kubectl get pod -o name --namespace default -l release=test,role=master)"
@@ -136,8 +136,8 @@ the name that you provided during the installation.
 
 ## Create a database
 
- After installing and connecting to Timescale you can create a database,
- connect to the database, and also verify that the Timescale extension is
+ After installing and connecting to TimescaleDB you can create a database,
+ connect to the database, and also verify that the TimescaleDB extension is
  installed.
 
 <Procedure>
@@ -157,7 +157,7 @@ the name that you provided during the installation.
     \c tsdb
     ```
 
-1.  Verify that the Timescale extension is installed by using the `\dx`
+1.  Verify that the TimescaleDB extension is installed by using the `\dx`
     command at the command prompt. The output looks like this:
 
     ```sql
@@ -175,7 +175,7 @@ the name that you provided during the installation.
 
 ## Clean up
 
-You can use Helm to uninstall Timescale on the Kubernetes cluster and clean up
+You can use Helm to uninstall TimescaleDB on the Kubernetes cluster and clean up
 the Pods, persistent volume claim (PVC), S3 backups, and more.
 
 ### Cleaning up

--- a/self-hosted/install/installation-linux.md
+++ b/self-hosted/install/installation-linux.md
@@ -1,6 +1,6 @@
 ---
-title: Install Timescale on Linux
-excerpt: Install self-hosted Timescale on Linux
+title: Install TimescaleDB on Linux
+excerpt: Install self-hosted TimescaleDB on Linux
 products: [self_hosted]
 keywords: [installation, self-hosted, Debian, Ubuntu, RHEL, Fedora]
 ---
@@ -8,9 +8,9 @@ keywords: [installation, self-hosted, Debian, Ubuntu, RHEL, Fedora]
 import Linux from "versionContent/_partials/_psql-installation-linux.mdx";
 import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-# Install Timescale on Linux
+# Install TimescaleDB on Linux
 
-You can host Timescale yourself, on your Debian-based, Red Hat-based, or Arch
+You can host TimescaleDB yourself, on your Debian-based, Red Hat-based, or Arch
 Linux-based systems. These instructions use the `apt`, `yum`, and `pacman`
 package manager on these distributions:
 
@@ -25,18 +25,18 @@ If you have already installed PostgreSQL using a method other than the `apt`
 package manager maintained by Debian or Ubuntu archive, `yum`, or `pacman` package
 manager, you could encounter errors following these instructions. It is safest
 to remove any existing PostgreSQL installations before you begin. If you want to
-keep your current PostgreSQL installation, do not install Timescale using this
+keep your current PostgreSQL installation, do not install TimescaleDB using this
 method. [Install from source](/install/latest/self-hosted/installation-source/)
 instead.
 </Highlight>
 
-<Tabs label="Install Timescale">
+<Tabs label="Install TimescaleDB">
 
 <Tab title="Debian">
 
 <Procedure>
 
-## Installing self-hosted Timescale on Debian-based systems
+## Installing self-hosted TimescaleDB on Debian-based systems
 
 1.  At the command prompt, as root, add the PostgreSQL third party repository
     to get the latest PostgreSQL packages:
@@ -51,7 +51,7 @@ instead.
     /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
     ```
 
-1.  Add the Timescale third party repository:
+1.  Add the TimescaleDB third party repository:
 
     <Terminal>
 
@@ -73,14 +73,14 @@ instead.
 
     </Terminal>
 
-1.  Install Timescale GPG key
+1.  Install TimescaleDB GPG key
 
     ```bash
     wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
     ```
 
     <Highlight type="note">
-    For Ubuntu 21.10 and later use this command to install Timescale
+    For Ubuntu 21.10 and later use this command to install TimescaleDB
     GPG key
     `wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/timescaledb.gpg`
     </Highlight>
@@ -91,19 +91,19 @@ instead.
     apt update
     ```
 
-1.  Install Timescale:
+1.  Install TimescaleDB:
 
     ```bash
     apt install timescaledb-2-postgresql-14
     ```
 
     <Highlight type="note">
-    If you want to install a specific version of Timescale, instead of the
+    If you want to install a specific version of TimescaleDB, instead of the
     most recent, you can specify the version like this:
     `apt-get install timescaledb-2-postgresql-12='2.6.0*' timescaledb-2-loader-postgresql-12='2.6.0*'`
 
-    You can see the full list of Timescale releases by visiting the
-    [releases page][releases-page]. Note that older versions of Timescale
+    You can see the full list of TimescaleDB releases by visiting the
+    [releases page][releases-page]. Note that older versions of TimescaleDB
     don't always support all the OS versions listed above.
     </Highlight>
 
@@ -120,7 +120,7 @@ instead.
 
 <Procedure>
 
-## Installing self-hosted Timescale on Red Hat-based systems
+## Installing self-hosted TimescaleDB on Red Hat-based systems
 
 1.  At the command prompt, as root, add the PostgreSQL third party repository
     to get the latest PostgreSQL packages:
@@ -142,7 +142,7 @@ instead.
 
     </tab>
     </Terminal>
-1.  Create the Timescale repository:
+1.  Create the TimescaleDB repository:
     <Terminal>
 
     <tab label='Red Hat'>
@@ -189,7 +189,7 @@ instead.
     yum update
     ```
 
-1.  Install Timescale:
+1.  Install TimescaleDB:
 
     ```bash
     yum install timescaledb-2-postgresql-14
@@ -214,7 +214,7 @@ instead.
 
 1.  Configure your database by running the `timescaledb-tune` script, which is
     included with the `timescaledb-tools` package. Run the `timescaledb-tune`
-    script using the 
+    script using the
     `sudo timescaledb-tune --pg-config=/usr/pgsql-14/bin/pg_config` command.
     For more information, see the [configuration][config] section.
 
@@ -226,9 +226,9 @@ instead.
 
 <Procedure>
 
-## Installing self-hosted Timescale on ArchLinux-based systems
+## Installing self-hosted TimescaleDB on ArchLinux-based systems
 
-1.  Install Timescale and timescaledb-tune:
+1.  Install TimescaleDB and timescaledb-tune:
 
     ```bash
     sudo pacman -Syu timescaledb timescaledb-tune
@@ -240,7 +240,7 @@ instead.
     sudo -u postgres initdb --locale=en_US.UTF-8 --encoding=UTF8 -D /var/lib/postgres/data --data-checksums
     ```
 
-1.  Run timescaledb-tune to adjust your `postgresql.conf` file, to use Timescale
+1.  Run timescaledb-tune to adjust your `postgresql.conf` file, to use TimescaleDB
     as PostgreSQL extension:
 
     ```bash
@@ -260,24 +260,24 @@ instead.
 
 </Tabs>
 
-## Set up the Timescale extension
+## Set up the TimescaleDB extension
 
-When you have PostgreSQL and Timescale installed, you can connect to it from
+When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility.
 
 <Linux />
 
-<Tabs lable="Timescale extension">
+<Tabs lable="TimescaleDB extension">
 
 <Tab title="Debian">
 
 <Procedure>
 
-### Setting up the Timescale extension on Debian-based systems
+### Setting up the TimescaleDB extension on Debian-based systems
 
-Restart PostgreSQL and create the Timescale extension:
+Restart PostgreSQL and create the TimescaleDB extension:
 
-1.  Restart the service after enabling Timescale with `timescaledb-tune`:
+1.  Restart the service after enabling TimescaleDB with `timescaledb-tune`:
 
     ```bash
     systemctl restart postgresql
@@ -330,13 +330,13 @@ Restart PostgreSQL and create the Timescale extension:
     \c tsdb
     ```
 
-1.  Add the Timescale extension:
+1.  Add the TimescaleDB extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     ```
 
-1.  Check that the Timescale extension is installed by using the `\dx`
+1.  Check that the TimescaleDB extension is installed by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql
@@ -357,7 +357,7 @@ Restart PostgreSQL and create the Timescale extension:
 
 <Procedure>
 
-### Setting up the Timescale extension on Red Hat-based systems
+### Setting up the TimescaleDB extension on Red Hat-based systems
 
 1.  Enable and start the service:
 
@@ -409,13 +409,13 @@ Restart PostgreSQL and create the Timescale extension:
     \c tsdb
     ```
 
-1.  Add the Timescale extension:
+1.  Add the TimescaleDB extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     ```
 
-1.  Check that the Timescale extension is installed by using the `\dx`
+1.  Check that the TimescaleDB extension is installed by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql
@@ -436,7 +436,7 @@ Restart PostgreSQL and create the Timescale extension:
 
 <Procedure>
 
-### Setting up the Timescale extension on ArchLinux-based systems
+### Setting up the TimescaleDB extension on ArchLinux-based systems
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -466,7 +466,7 @@ Restart PostgreSQL and create the Timescale extension:
     \c tsdb
     ```
 
-1.  Add the Timescale extension:
+1.  Add the TimescaleDB extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -478,7 +478,7 @@ Restart PostgreSQL and create the Timescale extension:
     sudo -u postgres psql tsdb
     ```
 
-1.  Check that the Timescale extension is installed by using the `\dx`
+1.  Check that the TimescaleDB extension is installed by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql

--- a/self-hosted/install/installation-macos.md
+++ b/self-hosted/install/installation-macos.md
@@ -1,6 +1,6 @@
 ---
-title: Install Timescale on macOS
-excerpt: Install self-hosted Timescale on macOS
+title: Install TimescaleDB on macOS
+excerpt: Install self-hosted TimescaleDB on macOS
 products: [self_hosted]
 keywords: [installation, self-hosted, macOS]
 ---
@@ -9,9 +9,9 @@ import Homebrew from "versionContent/_partials/_psql-installation-homebrew.mdx";
 import MacPorts from "versionContent/_partials/_psql-installation-macports.mdx";
 import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-# Install self-hosted Timescale on macOS systems
+# Install self-hosted TimescaleDB on macOS systems
 
-You can host Timescale yourself on your Apple macOS system.
+You can host TimescaleDB yourself on your Apple macOS system.
 These instructions use a Homebrew or MacPorts installer on these versions:
 
 *   Apple macOS 10.15 Catalina
@@ -19,7 +19,7 @@ These instructions use a Homebrew or MacPorts installer on these versions:
 *   Apple macOS 12 Monterey
 
 <Highlight type="important">
-Before you begin installing Timescale, make sure you have installed PostgreSQL
+Before you begin installing TimescaleDB, make sure you have installed PostgreSQL
 version 12 or later.
 </Highlight>
 
@@ -27,18 +27,18 @@ version 12 or later.
 If you have already installed PostgreSQL using a method other than Homebrew, you
 could encounter errors following these instructions. It is safest to remove any
 existing PostgreSQL installations before you begin. If you want to keep your
-current PostgreSQL installation, do not install Timescale using this method.
+current PostgreSQL installation, do not install TimescaleDB using this method.
 [Install from source](/install/latest/self-hosted/installation-source/)
 instead.
 </Highlight>
 
-## Install self-hosted Timescale using Homebrew
+## Install self-hosted TimescaleDB using Homebrew
 
-You can use Homebrew to install Timescale on macOS-based systems.
+You can use Homebrew to install TimescaleDB on macOS-based systems.
 
 <Procedure>
 
-### Installing self-hosted Timescale using Homebrew
+### Installing self-hosted TimescaleDB using Homebrew
 
 1.  Install Homebrew, if you don't already have it:
 
@@ -48,13 +48,13 @@ You can use Homebrew to install Timescale on macOS-based systems.
 
     For more information about Homebrew, including installation instructions,
     see the [Homebrew documentation][homebrew].
-1.  At the command prompt, add the Timescale Homebrew tap:
+1.  At the command prompt, add the TimescaleDB Homebrew tap:
 
     ```bash
     brew tap timescale/tap
     ```
 
-1.  Install Timescale:
+1.  Install TimescaleDB:
 
     ```bash
     brew install timescaledb
@@ -82,23 +82,23 @@ You can use Homebrew to install Timescale on macOS-based systems.
 
 </Procedure>
 
-When you have PostgreSQL and Timescale installed, you can connect to it from
+When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility.
 
 <Homebrew />
 
-## Install self-hosted Timescale using MacPorts
+## Install self-hosted TimescaleDB using MacPorts
 
-You can use MacPorts to install Timescale on macOS-based systems.
+You can use MacPorts to install TimescaleDB on macOS-based systems.
 
 <Procedure>
 
-### Installing self-hosted Timescale using MacPorts
+### Installing self-hosted TimescaleDB using MacPorts
 
 1.  Install MacPorts by downloading and running the package installer.
     For more information about MacPorts, including installation instructions,
     see the [MacPorts documentation][macports].
-1.  Install Timescale:
+1.  Install TimescaleDB:
 
     ```bash
     sudo port install timescaledb
@@ -119,19 +119,19 @@ section.
 
 </Procedure>
 
-When you have PostgreSQL and Timescale installed, you can connect to it from
+When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility.
 
 <MacPorts />
 
-## Set up the Timescale extension
+## Set up the TimescaleDB extension
 
 Connect to PostgreSQL from your local system using the `psql` command-line
-utility and set up the Timescale extension.
+utility and set up the TimescaleDB extension.
 
 <Procedure>
 
-### Setting up the Timescale extension
+### Setting up the TimescaleDB extension
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -160,13 +160,13 @@ utility and set up the Timescale extension.
     \c tsdb
     ```
 
-1.  Add the Timescale extension:
+1.  Add the TimescaleDB extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
     ```
 
-1.  Check that the Timescale extension is installed by using the `\dx`
+1.  Check that the TimescaleDB extension is installed by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql

--- a/self-hosted/install/installation-source.md
+++ b/self-hosted/install/installation-source.md
@@ -1,15 +1,15 @@
 ---
-title: Install Timescale from source
-excerpt: Install self-hosted Timescale from source
+title: Install TimescaleDB from source
+excerpt: Install self-hosted TimescaleDB from source
 products: [self_hosted]
 keywords: [installation, self-hosted]
 ---
 
 import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-# Install self-hosted Timescale from source
+# Install self-hosted TimescaleDB from source
 
-You can host Timescale yourself, on any system, by downloading the source code
+You can host TimescaleDB yourself, on any system, by downloading the source code
 and compiling it. These instructions do not require the use of a package manager
 or installation tool.
 
@@ -24,7 +24,7 @@ You also need:
 *   CMake version 3.11 or later for your operating system. For more information
     about CMake installation, including downloads and instructions, see the [CMake documentation][cmake-download].
 *   C language compiler for your operating system, such as `gcc` or `clang`.
-*   Check the [compatibility matrix][compatibility-matrix] of Timescale versions
+*   Check the [compatibility matrix][compatibility-matrix] of TimescaleDB versions
     with PostgreSQL versions.
 
 <Highlight type="note">
@@ -35,9 +35,9 @@ Visual Studio components for CMake and Git when you run the installer.
 
 <Procedure>
 
-## Installing self-hosted Timescale from source
+## Installing self-hosted TimescaleDB from source
 
-1.  At the command prompt, clone the Timescale GitHub repository:
+1.  At the command prompt, clone the TimescaleDB GitHub repository:
 
     ```bash
     git clone https://github.com/timescale/timescaledb
@@ -110,7 +110,7 @@ Visual Studio components for CMake and Git when you run the installer.
 
     </Terminal>
 
-3.  Install Timescale:
+3.  Install TimescaleDB:
 
     <Terminal>
 
@@ -136,14 +136,14 @@ Visual Studio components for CMake and Git when you run the installer.
 
 ## Configure PostgreSQL after installing from source
 
-When you install Timescale from source, you need to do some additional
-PostgreSQL configuration to add the Timescale library.
+When you install TimescaleDB from source, you need to do some additional
+PostgreSQL configuration to add the TimescaleDB library.
 
 <Highlight type="important">
-If you have more than one version of PostgreSQL installed, Timescale can only
-be associated with one of them. The Timescale build scripts use `pg_config` to
+If you have more than one version of PostgreSQL installed, TimescaleDB can only
+be associated with one of them. The TimescaleDB build scripts use `pg_config` to
 find out where PostgreSQL stores its extension files, so you can use `pg_config`
-to find out which PostgreSQL installation Timescale is using.
+to find out which PostgreSQL installation TimescaleDB is using.
 </Highlight>
 
 <Procedure>
@@ -193,16 +193,16 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the Timescale extension
+## Set up the TimescaleDB extension
 
-When you have PostgreSQL and Timescale installed, you can connect to it from
+When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility. This is the same tool
 you might have used to connect to PostgreSQL before, but if you haven't
 installed it yet, check out our [installing psql][install-psql] section.
 
 <Procedure>
 
-### Setting up the Timescale extension
+### Setting up the TimescaleDB extension
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -234,7 +234,7 @@ installed it yet, check out our [installing psql][install-psql] section.
     \c example
     ```
 
-1.  Add the Timescale extension:
+1.  Add the TimescaleDB extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -248,7 +248,7 @@ installed it yet, check out our [installing psql][install-psql] section.
 
 </Procedure>
 
-You can check that the Timescale extension is installed by using the `\dx`
+You can check that the TimescaleDB extension is installed by using the `\dx`
 command at the `psql` prompt. It looks like this:
 
 ```sql

--- a/self-hosted/install/installation-windows.md
+++ b/self-hosted/install/installation-windows.md
@@ -1,6 +1,6 @@
 ---
-title: Install Timescale on Windows
-excerpt: Install self-hosted Timescale on Windows
+title: Install TimescaleDB on Windows
+excerpt: Install self-hosted TimescaleDB on Windows
 products: [self_hosted]
 keywords: [installation, self-hosted, Windows]
 ---
@@ -8,9 +8,9 @@ keywords: [installation, self-hosted, Windows]
 import Windows from "versionContent/_partials/_psql-installation-windows.mdx";
 import WhereTo from "versionContent/_partials/_where-to-next.mdx";
 
-# Install self-hosted Timescale on Windows systems
+# Install self-hosted TimescaleDB on Windows systems
 
-You can host Timescale yourself on your Microsoft Windows system.
+You can host TimescaleDB yourself on your Microsoft Windows system.
 These instructions use a `zip` installer on these versions:
 
 *   Microsoft Windows 10
@@ -28,7 +28,7 @@ The minimum supported PostgreSQL versions are:
 If you have already installed PostgreSQL using another method, you could
 encounter errors following these instructions. It is safest to remove any
 existing PostgreSQL installations before you begin. If you want to keep your
-current PostgreSQL installation, do not install Timescale using this method.
+current PostgreSQL installation, do not install TimescaleDB using this method.
 [Install from source](/install/latest/self-hosted/installation-source/) instead.
 </Highlight>
 
@@ -40,7 +40,7 @@ To install PostgreSQL version 15.1.1 or later, make sure you have:
 
 <Procedure>
 
-## Installing self-hosted Timescale on Windows-based systems
+## Installing self-hosted TimescaleDB on Windows-based systems
 
 1.  Download and install the Visual C++ Redistributable for Visual Studio from
     [www.microsoft.com][ms-download].
@@ -48,10 +48,10 @@ To install PostgreSQL version 15.1.1 or later, make sure you have:
     You might need to add the `pg_config` file location to your path. In the Windows
     Search tool, search for `system environment variables`. The path should be
     `C:\Program Files\PostgreSQL\<version>\bin`.
-2.  Download the Timescale installation `.zip` file from
+2.  Download the TimescaleDB installation `.zip` file from
     [Windows releases][windows-releases].
 3.  Locate the downloaded file on your local file system, and extract the files.
-4.  In the extracted Timescale directory, right-click the `setup.exe` file and
+4.  In the extracted TimescaleDB directory, right-click the `setup.exe` file and
     select `Run as Administrator` to start the installer.
 
 </Procedure>
@@ -61,16 +61,16 @@ that you can use it. The easiest way to do this is to run the `timescaledb-tune`
 script, which is included with the `timescaledb-tools` package. For more
 information, see the [configuration][config] section.
 
-## Set up the Timescale extension
+## Set up the TimescaleDB extension
 
-When you have PostgreSQL and Timescale installed, you can connect to it from
+When you have PostgreSQL and TimescaleDB installed, you can connect to it from
 your local system using the `psql` command-line utility.
 
 <Windows />
 
 <Procedure>
 
-### Setting up the Timescale extension
+### Setting up the TimescaleDB extension
 
 1.  On your local system, at the command prompt, connect to the PostgreSQL
     instance as the `postgres` superuser:
@@ -102,7 +102,7 @@ your local system using the `psql` command-line utility.
     \c example
     ```
 
-1.  Add the Timescale extension:
+1.  Add the TimescaleDB extension:
 
     ```sql
     CREATE EXTENSION IF NOT EXISTS timescaledb;
@@ -116,7 +116,7 @@ your local system using the `psql` command-line utility.
 
 </Procedure>
 
-You can check that the Timescale extension is installed by using the `\dx`
+You can check that the TimescaleDB extension is installed by using the `\dx`
 command at the `psql` prompt. It looks like this:
 
 ```sql
@@ -148,7 +148,7 @@ tsdb=>
 
 ## Windows releases
 
-Here are the latest Timescale releases for PostgreSQL 12, 13, 14, and 15. To see
+Here are the latest TimescaleDB releases for PostgreSQL 12, 13, 14, and 15. To see
 information on releases, check out the
 [GitHub releases page][gh-releases]. Also see the
 [release notes][release-notes].

--- a/self-hosted/install/self-hosted.md
+++ b/self-hosted/install/self-hosted.md
@@ -1,6 +1,6 @@
 ---
-title: Install self-hosted Timescale
-excerpt: Install a self-hosted, self-managed instance of Timescale
+title: Install self-hosted TimescaleDB
+excerpt: Install a self-hosted, self-managed instance of TimescaleDB
 products: [self_hosted]
 keywords: [installation, self-hosted]
 ---

--- a/self-hosted/multinode-timescaledb/about-multinode.md
+++ b/self-hosted/multinode-timescaledb/about-multinode.md
@@ -1,6 +1,6 @@
 ---
 title: About multi-node
-excerpt: Learn how multi-node Timescale works
+excerpt: Learn how multi-node TimescaleDB works
 products: [self_hosted]
 keywords: [multi-node]
 ---
@@ -8,7 +8,7 @@ keywords: [multi-node]
 # About multi-node
 
 If you have a larger petabyte-scale workload, you might need more than
-one Timescale instance. Timescale multi-node allows you to run and
+one TimescaleDB instance. TimescaleDB multi-node allows you to run and
 manage a cluster of databases, which can give you faster data ingest,
 and more responsive and efficient queries for large workloads.
 
@@ -24,7 +24,7 @@ according to your specific requirements.
 
 ## Multi-node architecture
 
-Multi-node Timescale allows you to tie several databases together
+Multi-node TimescaleDB allows you to tie several databases together
 into a logical distributed database in order to combine the
 processing power of many physical PostgreSQL instances.
 
@@ -41,7 +41,7 @@ For self-hosted installations, create a server that can act as an
 access node, then use that access node to create data nodes on other
 servers.
 
-When you have configured multi-node Timescale, the access node coordinates
+When you have configured multi-node TimescaleDB, the access node coordinates
 the placement and access of data chunks on the data nodes. In most
 cases, it is recommend that you use multidimensional partitioning to
 distribute data across chunks in both time and space dimensions. The
@@ -52,10 +52,10 @@ time interval across multiple data nodes (DN1, DN2, and DN3).
 
 A database user connects to the access node to issue commands and
 execute queries, similar to how one connects to a regular single
-node Timescale instance. In most cases, connecting directly to the
+node TimescaleDB instance. In most cases, connecting directly to the
 data nodes is not necessary.
 
-Because Timescale exists as an extension within a specific
+Because TimescaleDB exists as an extension within a specific
 database, it is possible to have both distributed and non-distributed
 databases on the same access node. It is also possible to
 have several distributed databases that use different sets of physical
@@ -92,7 +92,7 @@ generally run faster than queries that run on a single data node, so it is
 important to think about what kind of data you have, and the type of queries you
 want to run.
 
-Timescale multi-node currently supports capabilities that make it best suited
+TimescaleDB multi-node currently supports capabilities that make it best suited
 for large-volume time-series workloads that are partitioned on `time`, and a
 space dimension such as `location`. If you usually run wide queries that
 aggregate data across many locations and devices, choose this partitioning
@@ -137,7 +137,7 @@ like those on regular hypertables. This means that a distributed
 transaction that involves multiple data nodes is guaranteed to
 either succeed on all nodes or on none of them. This guarantee
 is provided by the [two-phase commit protocol][2pc], which
-is used to implement distributed transactions in Timescale.
+is used to implement distributed transactions in TimescaleDB.
 
 However, the read consistency of a distributed hypertable is different
 to a regular hypertable. Because a distributed transaction is a set of
@@ -160,4 +160,3 @@ hypertables.
 
 [2pc]: https://www.postgresql.org/docs/current/sql-prepare-transaction.html
 [hypertables]: /timescaledb/:currentVersion:/how-to-guides/hypertables/
-

--- a/self-hosted/multinode-timescaledb/index.md
+++ b/self-hosted/multinode-timescaledb/index.md
@@ -7,8 +7,8 @@ keywords: [multi-node, scaling]
 
 # Multi-node
 
-If you have a larger workload, you might need more than one Timescale
-instance. Timescale multi-node allows you to run and manage multiple instances,
+If you have a larger workload, you might need more than one TimescaleDB
+instance. TimescaleDB multi-node allows you to run and manage multiple instances,
 giving you faster data ingest, and more responsive and efficient queries.
 
 *   [Learn about multi-node][about-multi-node] to understand how it works

--- a/self-hosted/multinode-timescaledb/multinode-administration.md
+++ b/self-hosted/multinode-timescaledb/multinode-administration.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-node administration
-excerpt: Manage your multi-node Timescale cluster
+excerpt: Manage your multi-node TimescaleDB cluster
 products: [self_hosted]
 keywords: [multi-node, admin]
 tags: [manage]
@@ -8,7 +8,7 @@ tags: [manage]
 
 # Multi-node administration
 
-Multi-node Timescale allows you to administer your cluster directly
+Multi-node TimescaleDB allows you to administer your cluster directly
 from the access node. When your environment is set up, you do not
 need to log directly into the data nodes to administer your database.
 

--- a/self-hosted/multinode-timescaledb/multinode-config.md
+++ b/self-hosted/multinode-timescaledb/multinode-config.md
@@ -8,7 +8,7 @@ keywords: [configuration, settings, multi-node]
 # Multi-node configuration
 
 In addition to the
-[regular Timescale configuration][timescaledb-configuration], it is recommended
+[regular TimescaleDB configuration][timescaledb-configuration], it is recommended
 that you also configure additional settings specific to multi-node operation.
 
 ## Update settings

--- a/self-hosted/multinode-timescaledb/multinode-ha.md
+++ b/self-hosted/multinode-timescaledb/multinode-ha.md
@@ -1,13 +1,13 @@
 ---
 title: High availability with multi-node
-excerpt: How to configure multi-node Timescale for high availability
+excerpt: How to configure multi-node TimescaleDB for high availability
 products: [self_hosted]
 keywords: [multi-node, high availability]
 ---
 
 # High availability with multi-node
 
-A multi-node installation of Timescale can be made highly available
+A multi-node installation of TimescaleDB can be made highly available
 by setting up one or more standbys for each node in the cluster, or by
 natively replicating data at the chunk level.
 
@@ -16,7 +16,7 @@ in a similar way to [configuring single-node HA][single-ha], although the
 configuration needs to be applied to each node independently.
 
 To replicate data at the chunk level, you can use the built-in
-capabilities of multi-node Timescale to avoid having to
+capabilities of multi-node TimescaleDB to avoid having to
 replicate entire data nodes. The access node still relies on a
 streaming replication standby, but the data nodes need no additional
 configuration. Instead, the existing pool of data nodes share
@@ -41,7 +41,7 @@ HA][single-ha].
 ## Native replication
 
 Native replication is a set of capabilities and APIs that allow you to
-build a highly available multi-node Timescale installation. At the
+build a highly available multi-node TimescaleDB installation. At the
 core of native replication is the ability to write copies of a chunk
 to multiple data nodes in order to have alternative _chunk replicas_
 in case of a data node failure. If one data node fails, its chunks
@@ -51,7 +51,7 @@ lost chunk replicas can be re-replicated from other data nodes to
 reach the number of desired chunk replicas.
 
 <Highlight type="warning">
-Native replication in Timescale is under development and
+Native replication in TimescaleDB is under development and
 currently lacks functionality for a complete high-availability
 solution. Some functionality described in this section is still
 experimental. For production environments, we recommend setting up
@@ -65,7 +65,7 @@ PostgreSQL uses a system like Patroni for automatically handling
 fail-over, native replication requires an external entity to
 orchestrate fail-over, chunk re-replication, and data node
 management. This orchestration is _not_ provided by default in
-Timescale and therefore needs to be implemented separately. The
+TimescaleDB and therefore needs to be implemented separately. The
 sections below describe how to enable native replication and the steps
 involved to implement high availability in case of node failures.
 

--- a/self-hosted/multinode-timescaledb/multinode-setup.md
+++ b/self-hosted/multinode-timescaledb/multinode-setup.md
@@ -1,27 +1,27 @@
 ---
-title: Set up multi-node on self-hosted Timescale
+title: Set up multi-node on self-hosted TimescaleDB
 excerpt: How to set up a self-hosted multi-node instance
 products: [self_hosted]
 keywords: [multi-node, self-hosted]
 ---
 
-# Set up multi-node on self-hosted Timescale
+# Set up multi-node on self-hosted TimescaleDB
 
-To set up multi-node on a self-hosted Timescale instance, you need:
+To set up multi-node on a self-hosted TimescaleDB instance, you need:
 
 *   A PostgreSQL instance to act as an access node (AN)
 *   One or more PostgreSQL instances to act as data nodes (DN)
-*   Timescale [installed][install] and [set up][setup] on all nodes
+*   TimescaleDB [installed][install] and [set up][setup] on all nodes
 *   Access to a superuser role, such as `postgres`, on all nodes
 
-The access and data nodes must begin as individual Timescale instances.
-They should be hosts with a running PostgreSQL server and a loaded Timescale
-extension. For more information about installing self-hosted Timescale
+The access and data nodes must begin as individual TimescaleDB instances.
+They should be hosts with a running PostgreSQL server and a loaded TimescaleDB
+extension. For more information about installing self-hosted TimescaleDB
 instances, see the [installation instructions][install]. Additionally, you
 can configure [high availability with multi-node][multi-node-ha] to
 increase redundancy and resilience.
 
-The multi-node Timescale architecture consists of an access node (AN) which
+The multi-node TimescaleDB architecture consists of an access node (AN) which
 stores metadata for the distributed hypertable and performs query planning
 across the cluster, and a set of data nodes (DNs) which store subsets of the
 distributed hypertable dataset and execute queries locally. For more information
@@ -30,9 +30,9 @@ about the multi-node architecture, see [about multi-node][about-multi-node].
 If you intend to use continuous aggregates in your multi-node environment, check
 the additional considerations in the [continuous aggregates][caggs] section.
 
-## Set up multi-node on self-hosted Timescale
+## Set up multi-node on self-hosted TimescaleDB
 
-When you have installed Timescale on the access node and as many data nodes as
+When you have installed TimescaleDB on the access node and as many data nodes as
 you require, you can set up multi-node and create a distributed hypertable.
 
 <Highlight type="note">
@@ -44,7 +44,7 @@ and architecture, see the
 
 <Procedure>
 
-### Setting up multi-node on self-hosted Timescale
+### Setting up multi-node on self-hosted TimescaleDB
 
 1.  On the access node (AN), run this command and provide the hostname of the
     first data node (DN1) you want to add:

--- a/self-hosted/page-index/page-index.js
+++ b/self-hosted/page-index/page-index.js
@@ -1,22 +1,22 @@
 module.exports = [
   {
-    title: "Self-hosted Timescale",
+    title: "Self-hosted TimescaleDB",
     href: "self-hosted",
     filePath: "index.md",
     pageComponents: ["content-list"],
     excerpt:
-      "Install self-hosted Timescale, administer, and configure the database.",
+      "Install self-hosted TimescaleDB, administer, and configure the database.",
     children: [
       {
-        title: "Install Timescale",
+        title: "Install TimescaleDB",
         href: "install",
-        excerpt: "Install self-hosted Timescale",
+        excerpt: "Install self-hosted TimescaleDB",
         children: [
           {
             title: "Linux",
             href: "installation-linux",
             iconSrc: "https://assets.iobeam.com/images/docs/linux-icon.svg",
-            excerpt: "Install self-hosted Timescale on Linux",
+            excerpt: "Install self-hosted TimescaleDB on Linux",
           },
           {
             title: "Windows",
@@ -24,21 +24,21 @@ module.exports = [
             iconSrc:
               "https://assets.iobeam.com/images/docs/Windows_logo_-_2012.svg",
             excerpt:
-              "Install self-hosted Timescale on Microsoft Windows using a zipped .exe file",
+              "Install self-hosted TimescaleDB on Microsoft Windows using a zipped .exe file",
           },
           {
             title: "MacOS",
             href: "installation-macos",
             iconSrc:
               "https://assets.iobeam.com/images/docs/Apple_logo_black.svg",
-            excerpt: "Install self-hosted Timescale on MacOS using homebrew",
+            excerpt: "Install self-hosted TimescaleDB on MacOS using homebrew",
           },
           {
             title: "From source",
             href: "installation-source",
             iconSrc: "https://assets.iobeam.com/images/docs/source.png",
             excerpt:
-              "Install self-hosted Timescale on any operating system from source",
+              "Install self-hosted TimescaleDB on any operating system from source",
           },
           {
             title: "Pre-built containers",
@@ -46,14 +46,14 @@ module.exports = [
             iconSrc:
               "https://s3.amazonaws.com/assets.iobeam.com/images/docs/moby.png",
             excerpt:
-              "Install self-hosted Timescale with a pre-built Docker container",
+              "Install self-hosted TimescaleDB with a pre-built Docker container",
           },
           {
             title: "Kubernetes",
             href: "installation-kubernetes",
             iconSrc:
               "https://s3.amazonaws.com/assets.iobeam.com/images/docs/kubernetes-icon-color.svg",
-            excerpt: "Install self-hosted Timescale on Kubernetes",
+            excerpt: "Install self-hosted TimescaleDB on Kubernetes",
           },
           {
             title: "Pre-built cloud images",
@@ -61,7 +61,7 @@ module.exports = [
             iconSrc:
               "https://s3.amazonaws.com/assets.iobeam.com/images/docs/aws_logo.svg",
             excerpt:
-              "Install self-hosted Timescale on Amazon with an Ubuntu AMI",
+              "Install self-hosted TimescaleDB on Amazon with an Ubuntu AMI",
           },
         ],
       },
@@ -73,35 +73,35 @@ module.exports = [
             title: "About Configuration",
             href: "about-configuration",
             excerpt:
-              "Overview of configuration options and methods for PostgreSQL and self-hosted Timescale",
+              "Overview of configuration options and methods for PostgreSQL and self-hosted TimescaleDB",
           },
           {
             title: "Using timescaledb-tune",
             href: "timescaledb-tune",
-            excerpt: "Configure self-hosted Timescale using timescaledb-tune",
+            excerpt: "Configure self-hosted TimescaleDB using timescaledb-tune",
           },
           {
             title: "Manual PostgreSQL configuration",
             href: "postgres-config",
             excerpt:
-              "Configure self-hosted Timescale using the PostgreSQL configuration file",
+              "Configure self-hosted TimescaleDB using the PostgreSQL configuration file",
           },
           {
-            title: "Timescale configuration",
+            title: "TimescaleDB configuration",
             href: "timescaledb-config",
             excerpt:
-              "Configure self-hosted Timescale using Timescale configuration parameters",
+              "Configure self-hosted TimescaleDB using TimescaleDB configuration parameters",
           },
           {
             title: "Docker configuration",
             href: "docker-config",
             excerpt:
-              "Configure self-hosted Timescale when running within a Docker container",
+              "Configure self-hosted TimescaleDB when running within a Docker container",
           },
           {
             title: "Telemetry",
             href: "telemetry",
-            excerpt: "Configure telemetry gathered by self-hosted Timescale",
+            excerpt: "Configure telemetry gathered by self-hosted TimescaleDB",
           },
         ],
       },
@@ -136,9 +136,9 @@ module.exports = [
             excerpt: "Learn about multi-node environments",
           },
           {
-            title: "Multi-node setup on self-hosted Timescale",
+            title: "Multi-node setup on self-hosted TimescaleDB",
             href: "multinode-setup",
-            excerpt: "Set up multi-node on self-hosted Timescale",
+            excerpt: "Set up multi-node on self-hosted TimescaleDB",
           },
           {
             title: "Multi-node authentication",
@@ -179,7 +179,7 @@ module.exports = [
           {
             title: "About high availability",
             href: "about-ha",
-            excerpt: "High availability in self-hosted Timescale",
+            excerpt: "High availability in self-hosted TimescaleDB",
           },
           {
             title: "Configure replication",
@@ -189,34 +189,36 @@ module.exports = [
         ],
       },
       {
-        title: "Upgrade self-hosted Timescale",
+        title: "Upgrade self-hosted TimescaleDB",
         href: "upgrades",
         children: [
           {
             title: "About upgrades",
             href: "about-upgrades",
-            excerpt: "Learn about upgrading self-hosted Timescale",
+            excerpt: "Learn about upgrading self-hosted TimescaleDB",
           },
           {
             title: "Minor upgrades",
             href: "minor-upgrade",
-            excerpt: "Upgrade to a new minor version of self-hosted Timescale",
+            excerpt:
+              "Upgrade to a new minor version of self-hosted TimescaleDB",
           },
           {
             title: "Major upgrades",
             href: "major-upgrade",
-            excerpt: "Upgrade to a new major version of self-hosted Timescale",
+            excerpt:
+              "Upgrade to a new major version of self-hosted TimescaleDB",
           },
           {
-            title: "Downgrade self-hosted Timescale",
+            title: "Downgrade self-hosted TimescaleDB",
             href: "downgrade",
-            excerpt: "Downgrade a self-hosted Timescale version",
+            excerpt: "Downgrade a self-hosted TimescaleDB version",
           },
           {
             title: "Upgrade within Docker",
             href: "upgrade-docker",
             excerpt:
-              "Upgrade to a new minor version of self-hosted Timescale within a Docker container",
+              "Upgrade to a new minor version of self-hosted TimescaleDB within a Docker container",
           },
           {
             title: "Upgrade PostgreSQL",
@@ -226,19 +228,19 @@ module.exports = [
         ],
       },
       {
-        title: "Uninstall self-hosted Timescale",
+        title: "Uninstall self-hosted TimescaleDB",
         href: "uninstall",
-        excerpt: "Uninstalling self-hosted Timescale",
+        excerpt: "Uninstalling self-hosted TimescaleDB",
         children: [
           {
-            title: "Uninstall self-hosted Timescale on macOS",
+            title: "Uninstall self-hosted TimescaleDB on macOS",
             href: "uninstall-timescaledb",
-            excerpt: "Uninstall self-hosted Timescale on macOS",
+            excerpt: "Uninstall self-hosted TimescaleDB on macOS",
           },
         ],
       },
       {
-        title: "Troubleshooting self-hosted Timescale",
+        title: "Troubleshooting self-hosted TimescaleDB",
         href: "troubleshooting",
         type: "placeholder",
       },

--- a/self-hosted/replication-and-ha/about-ha.md
+++ b/self-hosted/replication-and-ha/about-ha.md
@@ -18,8 +18,8 @@ processes switch between these standby resources as quickly as possible.
 For some systems, recovering from backup alone can be a suitable availability
 strategy.
 
-For more information about backups in self-hosted Timescale, see the
-[backup and restore section][db-backup] in the Timescale documentation.
+For more information about backups in self-hosted TimescaleDB, see the
+[backup and restore section][db-backup] in the TimescaleDB documentation.
 
 ## Storage redundancy
 
@@ -37,15 +37,15 @@ running database that can take over immediately.
 ## Zonal redundancy
 
 While the public cloud is highly reliable, entire portions of the cloud can be
-unavailable at times. Timescale does not protect against Availability Zone
+unavailable at times. TimescaleDB does not protect against Availability Zone
 failures unless the user is using HA replicas. We do not currently offer
 multi-cloud solutions or protection from an AWS Regional failure.
 
 ## Replication
 
-Timescale supports replication using PostgreSQL's built-in
+TimescaleDB supports replication using PostgreSQL's built-in
 [streaming replication][postgres-streaming-replication-docs]. Using
-[logical replication][postgres-logrep-docs] with Timescale is not recommended,
+[logical replication][postgres-logrep-docs] with TimescaleDB is not recommended,
 as it requires schema synchronization between the primary and replica nodes and
 replicating partition root tables, which are
 [not currently supported][postgres-partition-limitations].

--- a/self-hosted/replication-and-ha/configure-replication.md
+++ b/self-hosted/replication-and-ha/configure-replication.md
@@ -11,12 +11,12 @@ This section outlines how to set up asynchronous streaming replication on one or
 more database replicas.
 
 Before you begin, make sure you have at least two separate instances of
-Timescale running. If you installed Timescale using a Docker container, use
+TimescaleDB running. If you installed TimescaleDB using a Docker container, use
 a [PostgreSQL entry point script][docker-postgres-scripts] to run the
 configuration. For sample Docker configuration and run scripts, see the
 [streaming replication Docker repository][timescale-streamrep-docker].
 
-To configure replication on self-hosted Timescale, you need to perform these
+To configure replication on self-hosted TimescaleDB, you need to perform these
 procedures:
 
 1.  [Configure the primary database][configure-primary-db]

--- a/self-hosted/tooling/about-timescaledb-parallel-copy.md
+++ b/self-hosted/tooling/about-timescaledb-parallel-copy.md
@@ -7,7 +7,7 @@ keywords: [timescaledb-parallel-copy, copy]
 
 # About timescaledb-parallel-copy
 
-To speed up bulk inserts of data, Timescale provides an open source [parallel
+To speed up bulk inserts of data, TimescaleDB provides an open source [parallel
 importer][github-tscopy] program called `timescaledb-parallel-copy`. The program
 parallelizes migration by using several workers to run multiple `COPY` functions
 concurrently.

--- a/self-hosted/tooling/about-timescaledb-tune.md
+++ b/self-hosted/tooling/about-timescaledb-tune.md
@@ -1,6 +1,6 @@
 ---
 title: About timescaledb-tune
-excerpt: Automatically tune your Timescale database to match your system resources and PostgreSQL version
+excerpt: Automatically tune your TimescaleDB database to match your system resources and PostgreSQL version
 products: [self_hosted]
 keywords: [configuration, timescaledb-tune]
 tags: [tune, settings]
@@ -8,14 +8,14 @@ tags: [tune, settings]
 
 # About timescaledb-tune
 
-Get better performance by tuning your Timescale database to match your system
+Get better performance by tuning your TimescaleDB database to match your system
 resources and PostgreSQL version.  `timescaledb-tune` is an open source command
 line tool that analyzes and adjusts your database settings.
 
 ## Install timescaledb-tune
 
-`timescaledb-tune` is packaged with binary releases of Timescale. If you
-installed Timescale from any binary release, including Docker, you already
+`timescaledb-tune` is packaged with binary releases of TimescaleDB. If you
+installed TimescaleDB from any binary release, including Docker, you already
 have access. For more install instructions, see the
 [GitHub repository][github-tstune].
 

--- a/self-hosted/tooling/index.md
+++ b/self-hosted/tooling/index.md
@@ -1,6 +1,6 @@
 ---
 title: Additional tooling
-excerpt: Get the most from Timescale with open source tools that help you perform common tasks
+excerpt: Get the most from TimescaleDB with open source tools that help you perform common tasks
 products: [self_hosted]
 ---
 
@@ -9,7 +9,7 @@ products: [self_hosted]
 Get the most from TimescaleDB with open source tools that help you perform
 common tasks.
 
-*   Automatically configure your Timescale instance with
+*   Automatically configure your TimescaleDB instance with
     [`timescaledb-tune`][tstune]
 *   Install and use [`timescaledb-parallel-copy`][tscopy] to insert data.
 

--- a/self-hosted/uninstall/index.md
+++ b/self-hosted/uninstall/index.md
@@ -1,16 +1,16 @@
 ---
-title: Uninstall Timescale
-excerpt: Uninstall Timescale on macOS
+title: Uninstall TimescaleDB
+excerpt: Uninstall TimescaleDB on macOS
 products: [self_hosted]
 keywords: [Uninstall]
 ---
 
-# Uninstall Timescale
+# Uninstall TimescaleDB
 
-You can install Timescale with Homebrew or MacPorts on macOS. If you want to
-uninstall Timescale because it does not meet your requirements, you can
+You can install TimescaleDB with Homebrew or MacPorts on macOS. If you want to
+uninstall TimescaleDB because it does not meet your requirements, you can
 uninstall it without having to uninstall PostgreSQL.
 
-*   [Learn how to uninstall][uninstall-timescaledb] Timescale in macOS
+*   [Learn how to uninstall][uninstall-timescaledb] TimescaleDB in macOS
 
 [uninstall-timescaledb]: /self-hosted/:currentVersion:/uninstall/

--- a/self-hosted/uninstall/uninstall-timescaledb.md
+++ b/self-hosted/uninstall/uninstall-timescaledb.md
@@ -1,24 +1,24 @@
 ---
-title: Uninstall Timescale
-excerpt: Uninstall Timescale
+title: Uninstall TimescaleDB
+excerpt: Uninstall TimescaleDB
 products: [self_hosted]
 keywords: [uninstall]
 ---
 
-# Uninstall Timescale
+# Uninstall TimescaleDB
 
 PostgreSQL is designed to be easily extensible. The extensions loaded into the
-database can function just like features that are built in. Timescale extends
+database can function just like features that are built in. TimescaleDB extends
 PostgreSQL for time-series data—giving PostgreSQL the high-performance,
 scalability, and analytical capabilities required by modern data-intensive
-applications. If you installed Timescale with Homebrew or MacPorts, you can
+applications. If you installed TimescaleDB with Homebrew or MacPorts, you can
 uninstall it without having to uninstall PostgreSQL.
 
 <Procedure>
 
-## Uninstalling Timescale using Homebrew
+## Uninstalling TimescaleDB using Homebrew
 
-1.  At the `psql` prompt, remove the Timescale extension:
+1.  At the `psql` prompt, remove the TimescaleDB extension:
 
     ```sql
     DROP EXTENSION timescaledb;
@@ -40,7 +40,7 @@ uninstall it without having to uninstall PostgreSQL.
     brew services restart postgresql
     ```
 
-1.  Check that the Timescale extension is uninstalled by using the `\dx`
+1.  Check that the TimescaleDB extension is uninstalled by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql
@@ -52,7 +52,7 @@ uninstall it without having to uninstall PostgreSQL.
     (1 row) 
     ```
 
-1.  Uninstall Timescale:
+1.  Uninstall TimescaleDB:
 
     ```bash
     brew uninstall timescaledb
@@ -68,9 +68,9 @@ uninstall it without having to uninstall PostgreSQL.
 
 <Procedure>
 
-## Uninstalling Timescale using MacPorts
+## Uninstalling TimescaleDB using MacPorts
 
-1.  At the `psql` prompt, remove the Timescale extension:
+1.  At the `psql` prompt, remove the TimescaleDB extension:
 
     ```sql
     DROP EXTENSION timescaledb;
@@ -92,7 +92,7 @@ uninstall it without having to uninstall PostgreSQL.
     port reload postgresql
     ```
 
-1.  Check that the Timescale extension is uninstalled by using the `\dx`
+1.  Check that the TimescaleDB extension is uninstalled by using the `\dx`
     command at the `psql` prompt. Output is similar to:
 
     ```sql
@@ -104,7 +104,7 @@ uninstall it without having to uninstall PostgreSQL.
     (1 row) 
     ```
 
-1.  Uninstall Timescale and the related dependencies:
+1.  Uninstall TimescaleDB and the related dependencies:
 
     ```bash
     port uninstall timescaledb --follow-dependencies

--- a/self-hosted/upgrades/about-upgrades.md
+++ b/self-hosted/upgrades/about-upgrades.md
@@ -9,15 +9,15 @@ import PlanUpgrade from 'versionContent/_partials/_plan_upgrade.mdx';
 
 # About upgrades
 
-A major upgrade is when you upgrade from one major version of Timescale, to
-the next major version. For example, when you upgrade from Timescale&nbsp;1
-to Timescale&nbsp;2.
+A major upgrade is when you upgrade from one major version of TimescaleDB, to
+the next major version. For example, when you upgrade from TimescaleDB&nbsp;1
+to TimescaleDB&nbsp;2.
 
 A minor upgrade is when you upgrade within your current major version of
-Timescale. For example, when you upgrade from Timescale&nbsp;2.5 to
-Timescale&nbsp;2.6.
+TimescaleDB. For example, when you upgrade from TimescaleDB&nbsp;2.5 to
+TimescaleDB&nbsp;2.6.
 
-If you originally installed Timescale using Docker, you can upgrade from
+If you originally installed TimescaleDB using Docker, you can upgrade from
 within the Docker container. For more information, and instructions, see the
 [Upgrading with Docker section][upgrade-docker].
 
@@ -27,7 +27,7 @@ within the Docker container. For more information, and instructions, see the
 
 ## Check your version
 
-You can check which version of Timescale you are running, at the psql command
+You can check which version of TimescaleDB you are running, at the psql command
 prompt. Use this to check which version you are running before you begin your
 upgrade, and again after your upgrade is complete:
 

--- a/self-hosted/upgrades/downgrade.md
+++ b/self-hosted/upgrades/downgrade.md
@@ -1,44 +1,44 @@
 ---
-title: Downgrade to a previous version of Timescale
-excerpt: Roll back to an older version of Timescale
+title: Downgrade to a previous version of TimescaleDB
+excerpt: Roll back to an older version of TimescaleDB
 products: [self_hosted]
 keywords: [upgrades]
 ---
 
-# Downgrade to a previous version of Timescale
+# Downgrade to a previous version of TimescaleDB
 
-If you upgrade to a new Timescale version and encounter problems, you can roll
+If you upgrade to a new TimescaleDB version and encounter problems, you can roll
 back to a previously installed version. This works in the same way as a minor
 upgrade.
 
 Downgrading is not supported for all versions. Generally, downgrades between
 patch versions and between consecutive minor versions are supported. For
-example, you can downgrade from Timescale 2.5.2 to 2.5.1, or from 2.5.0 to
+example, you can downgrade from TimescaleDB 2.5.2 to 2.5.1, or from 2.5.0 to
 2.4.2. To check whether you can downgrade from a specific version, see the
 [release notes][relnotes].
 
 ## Plan your downgrade
 
-You can downgrade your on-premise Timescale installation in-place. This means
+You can downgrade your on-premise TimescaleDB installation in-place. This means
 that you do not need to dump and restore your data. However, it is still
 important that you plan for your downgrade ahead of time.
 
 Before you downgrade:
 
-*   Read [the release notes][relnotes] for the Timescale version you are
+*   Read [the release notes][relnotes] for the TimescaleDB version you are
   downgrading to.
 *   Check which PostgreSQL version you are currently running. You might need to
   [upgrade to the latest PostgreSQL version][upgrade-pg]
-  before you begin your Timescale downgrade.
-*   [Perform a backup][backup] of your database. While Timescale
+  before you begin your TimescaleDB downgrade.
+*   [Perform a backup][backup] of your database. While TimescaleDB
   downgrades are performed in-place, downgrading is an intrusive operation.
   Always make sure you have a backup on hand, and that the backup is readable in
   the case of disaster.
 
-## Downgrade Timescale to a previous minor version
+## Downgrade TimescaleDB to a previous minor version
 
 This downgrade uses the PostgreSQL `ALTER EXTENSION` function to downgrade to
-the latest version of the Timescale extension. Timescale supports having
+the latest version of the TimescaleDB extension. TimescaleDB supports having
 different extension versions on different databases within the same PostgreSQL
 instance. This allows you to upgrade and downgrade extensions independently on
 different databases. Run the `ALTER EXTENSION` function on each database to
@@ -53,12 +53,12 @@ upgrading and downgrading.
 
 <Procedure>
 
-### Downgrading the Timescale extension
+### Downgrading the TimescaleDB extension
 
 1.  Connect to psql using the `-X` flag. This prevents any `.psqlrc` commands
-   from accidentally triggering the load of a previous Timescale version on
+   from accidentally triggering the load of a previous TimescaleDB version on
    session startup.
-1.  At the psql prompt, downgrade the Timescale extension. This must be the
+1.  At the psql prompt, downgrade the TimescaleDB extension. This must be the
    first command you execute in the current session:
 
     ```sql

--- a/self-hosted/upgrades/index.md
+++ b/self-hosted/upgrades/index.md
@@ -1,39 +1,38 @@
 ---
-title: Upgrade Timescale
-excerpt: Upgrade your self-hosted Timescale installation in-place
+title: Upgrade TimescaleDB
+excerpt: Upgrade your self-hosted TimescaleDB installation in-place
 products: [self_hosted]
 keywords: [upgrades]
 ---
 
-# Upgrade Timescale
+# Upgrade TimescaleDB
 
-You can upgrade your on-premise Timescale installation in-place.
+You can upgrade your on-premise TimescaleDB installation in-place.
 
-A major upgrade is when you upgrade from one major version of Timescale, to
-the next major version. For example, when you upgrade from Timescale&nbsp;1,
-to Timescale&nbsp;2.
+A major upgrade is when you upgrade from one major version of TimescaleDB, to
+the next major version. For example, when you upgrade from TimescaleDB&nbsp;1,
+to TimescaleDB&nbsp;2.
 
 A minor upgrade is when you upgrade within your current major version of
-Timescale. For example, when you upgrade from Timescale&nbsp;2.5, to
-Timescale&nbsp;2.6.
+TimescaleDB. For example, when you upgrade from TimescaleDB&nbsp;2.5, to
+TimescaleDB&nbsp;2.6.
 
-If you originally installed Timescale using Docker, you can upgrade from
+If you originally installed TimescaleDB using Docker, you can upgrade from
 within the Docker container. For more information, and instructions, see the
 [Upgrading with Docker section][upgrade-docker].
 
-You can also downgrade your Timescale installation to a previous version, if
+You can also downgrade your TimescaleDB installation to a previous version, if
 you need to.
 
 *   [Learn about upgrades][about-upgrades] to understand how it works
     before you begin your upgrade.
-*   Upgrade to the next [minor version][upgrade-minor] of Timescale.
-*   Upgrade to the next [major version][upgrade-major] of Timescale.
-*   [Downgrade][downgrade] to a previous version of Timescale.
-*   Upgrade Timescale using [Docker][upgrade-docker].
-*   Upgrade the version of [PostgreSQL][upgrade-pg] your Timescale
+*   Upgrade to the next [minor version][upgrade-minor] of TimescaleDB.
+*   Upgrade to the next [major version][upgrade-major] of TimescaleDB.
+*   [Downgrade][downgrade] to a previous version of TimescaleDB.
+*   Upgrade TimescaleDB using [Docker][upgrade-docker].
+*   Upgrade the version of [PostgreSQL][upgrade-pg] your TimescaleDB
     installation uses.
 *   [Troubleshoot][upgrade-tshoot] upgrading.
-
 
 [about-upgrades]: /self-hosted/:currentVersion:/upgrades/about-upgrades/
 [downgrade]: /self-hosted/:currentVersion:/upgrades/downgrade/

--- a/self-hosted/upgrades/major-upgrade.md
+++ b/self-hosted/upgrades/major-upgrade.md
@@ -1,20 +1,20 @@
 ---
-title: Major Timescale upgrades
-excerpt: Upgrade from one major of Timescale to the next major version
+title: Major TimescaleDB upgrades
+excerpt: Upgrade from one major of TimescaleDB to the next major version
 products: [self_hosted]
 keywords: [upgrades]
 ---
 
 import PlanUpgrade from 'versionContent/_partials/_plan_upgrade.mdx';
 
-# Major Timescale upgrades
+# Major TimescaleDB upgrades
 
-A major upgrade is when you upgrade from one major version of Timescale, to
-the next major version. For example, when you upgrade from Timescale&nbsp;1,
-to Timescale&nbsp;2.
+A major upgrade is when you upgrade from one major version of TimescaleDB, to
+the next major version. For example, when you upgrade from TimescaleDB&nbsp;1,
+to TimescaleDB&nbsp;2.
 
 For upgrading within your current major version, for example upgrading from
-Timescale&nbsp;2.5 to Timescale&nbsp;2.6, see the
+TimescaleDB&nbsp;2.5 to TimescaleDB&nbsp;2.6, see the
 [minor upgrades section][upgrade-minor].
 
 ## Plan your upgrade
@@ -22,19 +22,19 @@ Timescale&nbsp;2.5 to Timescale&nbsp;2.6, see the
 <PlanUpgrade />
 
 Additionally, before you begin this major upgrade, read the
-[changes in Timescale&nbsp;2 section][changes-in-ts2].
+[changes in TimescaleDB&nbsp;2 section][changes-in-ts2].
 This section provides a more detailed look at the major changes in
-Timescale&nbsp;2. It also includes information about how these major changes
-impact the way your applications and scripts interact with the Timescale API.
+TimescaleDB&nbsp;2. It also includes information about how these major changes
+impact the way your applications and scripts interact with the TimescaleDB API.
 
 ## Breaking changes
 
-When you upgrade from Timescale&nbsp;1, to Timescale&nbsp;2, scripts
+When you upgrade from TimescaleDB&nbsp;1, to TimescaleDB&nbsp;2, scripts
 automatically configure updated features to work as expected with the new
 version. However, not everything works in exactly the same way as previously.
 
 Before you begin this major upgrade, check the database log for errors related
-to failed retention policies that could have occurred in Timescale&nbsp;1. You
+to failed retention policies that could have occurred in TimescaleDB&nbsp;1. You
 can either remove the failing policies entirely, or update them to be compatible
 with your existing continuous aggregates.
 
@@ -45,12 +45,12 @@ notice is shown.
 For more information about changes to continuous aggregates and data retention
 policies, see the [release notes][relnotes-20].
 
-## Upgrade Timescale to the next major version
+## Upgrade TimescaleDB to the next major version
 
 To perform this major upgrade:
 
-1.  Export your Timescale&nbsp;1 policy settings
-1.  Upgrade the Timescale extension
+1.  Export your TimescaleDB&nbsp;1 policy settings
+1.  Upgrade the TimescaleDB extension
 1.  Verify updated policy settings and jobs
 
 When you perform the upgrade, new policies are automatically configured based on
@@ -59,7 +59,7 @@ policy settings before performing the upgrade, so that you can verify them after
 the upgrade is complete.
 
 This upgrade uses the PostgreSQL `ALTER EXTENSION` function to upgrade to the
-latest version of the Timescale extension. Timescale supports having
+latest version of the TimescaleDB extension. TimescaleDB supports having
 different extension versions on different databases within the same PostgreSQL
 instance. This allows you to upgrade extensions independently on different
 databases. Run the `ALTER EXTENSION` function on each database to upgrade them
@@ -67,7 +67,7 @@ individually.
 
 <Procedure>
 
-### Exporting Timescale&nbsp;1 policy settings
+### Exporting TimescaleDB&nbsp;1 policy settings
 
 1.  At the psql prompt, use this command to save the current settings for your
    policy statistics to a `.csv` file:
@@ -105,12 +105,12 @@ individually.
 
 <Procedure>
 
-### Upgrading the Timescale extension
+### Upgrading the TimescaleDB extension
 
 1.  Connect to psql using the `-X` flag. This prevents any `.psqlrc` commands
-   from accidentally triggering the load of a previous Timescale version on
+   from accidentally triggering the load of a previous TimescaleDB version on
    session startup.
-1.  At the psql prompt, upgrade the Timescale extension. This must be the first
+1.  At the psql prompt, upgrade the TimescaleDB extension. This must be the first
    command you execute in the current session:
 
     ```sql

--- a/self-hosted/upgrades/minor-upgrade.md
+++ b/self-hosted/upgrades/minor-upgrade.md
@@ -1,30 +1,30 @@
 ---
-title: Minor Timescale upgrades
-excerpt: Upgrade within the same major version of Timescale
+title: Minor TimescaleDB upgrades
+excerpt: Upgrade within the same major version of TimescaleDB
 products: [self_hosted]
 keywords: [upgrades]
 ---
 
 import PlanUpgrade from 'versionContent/_partials/_plan_upgrade.mdx';
 
-# Minor Timescale upgrades
+# Minor TimescaleDB upgrades
 
 A minor upgrade is when you upgrade within your current major version of
-Timescale. For example, when you upgrade from Timescale&nbsp;2.5, to
-Timescale&nbsp;2.6.
+TimescaleDB. For example, when you upgrade from TimescaleDB&nbsp;2.5, to
+TimescaleDB&nbsp;2.6.
 
 For upgrading to a new major version, for example upgrading from
-Timescale&nbsp;1 to Timescale&nbsp;2, see the
+TimescaleDB&nbsp;1 to TimescaleDB&nbsp;2, see the
 [major upgrades section][upgrade-major].
 
 ## Plan your upgrade
 
 <PlanUpgrade />
 
-## Upgrade Timescale to the next minor version
+## Upgrade TimescaleDB to the next minor version
 
 This upgrade uses the PostgreSQL `ALTER EXTENSION` function to upgrade to the
-latest version of the Timescale extension. Timescale supports having
+latest version of the TimescaleDB extension. TimescaleDB supports having
 different extension versions on different databases within the same PostgreSQL
 instance. This allows you to upgrade extensions independently on different
 databases. Run the `ALTER EXTENSION` function on each database to upgrade them
@@ -32,12 +32,12 @@ individually.
 
 <Procedure>
 
-### Upgrading the Timescale extension
+### Upgrading the TimescaleDB extension
 
 1.  Connect to psql using the `-X` flag. This prevents any `.psqlrc` commands
-   from accidentally triggering the load of a previous Timescale version on
+   from accidentally triggering the load of a previous TimescaleDB version on
    session startup.
-1.  At the psql prompt, upgrade the Timescale extension. This must be the first
+1.  At the psql prompt, upgrade the TimescaleDB extension. This must be the first
    command you execute in the current session:
 
     ```sql

--- a/self-hosted/upgrades/upgrade-docker.md
+++ b/self-hosted/upgrades/upgrade-docker.md
@@ -1,15 +1,15 @@
 ---
 title: Upgrades within a Docker container
-excerpt: Upgrade Timescale within a Docker container
+excerpt: Upgrade TimescaleDB within a Docker container
 products: [self_hosted]
 keywords: [upgrades, Docker]
 ---
 
 # Upgrades within a Docker container
 
-If you originally installed Timescale using Docker, you can upgrade from
+If you originally installed TimescaleDB using Docker, you can upgrade from
 within the Docker container. This allows you to upgrade to the latest
-Timescale version, while retaining your data.
+TimescaleDB version, while retaining your data.
 
 <Highlight type="note">
 In this section, the examples use a Docker instance called `timescaledb`. If you
@@ -64,20 +64,20 @@ mounts, or bind mounts.
 
 </Procedure>
 
-## Upgrade Timescale within Docker
+## Upgrade TimescaleDB within Docker
 
-To upgrade Timescale within Docker, you need to download the upgraded image,
+To upgrade TimescaleDB within Docker, you need to download the upgraded image,
 stop the old container, and launch the new container pointing to your existing
 data.
 
 <Procedure>
 
-### Upgrading Timescale within Docker
+### Upgrading TimescaleDB within Docker
 
-1.  Pull the latest Timescale image. This command pulls the image for
+1.  Pull the latest TimescaleDB image. This command pulls the image for
     PostgreSQL&nbsp;14. If you're using another PostgreSQL version, look for the
     relevant tag in the
-    [Timescale HA Docker Hub repository](https://hub.docker.com/r/timescale/timescaledb-ha/tags).
+    [TimescaleDB HA Docker Hub repository](https://hub.docker.com/r/timescale/timescaledb-ha/tags).
 
     ```bash
     docker pull timescale/timescaledb-ha:pg14-latest
@@ -130,8 +130,8 @@ data.
     ALTER EXTENSION timescaledb UPDATE;
     ```
 
-1.  Update the [Timescale Toolkit][toolkit] extension. Toolkit is packaged
-    with Timescale's HA Docker image, and includes additional hyperfunctions
+1.  Update the [TimescaleDB Toolkit][toolkit] extension. Toolkit is packaged
+    with TimescaleDB's HA Docker image, and includes additional hyperfunctions
     to help you with queries and data analysis:
 
     ```sql

--- a/self-hosted/upgrades/upgrade-pg.md
+++ b/self-hosted/upgrades/upgrade-pg.md
@@ -1,40 +1,40 @@
 ---
 title: Upgrade PostgreSQL
-excerpt: Upgrade the PostgreSQL installation associated with Timescale
+excerpt: Upgrade the PostgreSQL installation associated with TimescaleDB
 products: [self_hosted]
 keywords: [upgrades, PostgreSQL, versions, compatibility]
 ---
 
 # Upgrade PostgreSQL
 
-Because Timescale is a PostgreSQL extension, you need to ensure you keep your
-underlying PotsgreSQL installation up to date. When you upgrade your Timescale
+Because TimescaleDB is a PostgreSQL extension, you need to ensure you keep your
+underlying PotsgreSQL installation up to date. When you upgrade your TimescaleDB
 extension to a new version, always take the time to check if you need to also
 upgrade your PostgreSQL version. If you are running an older version of
-PostgreSQL, you need to upgrade it first, before you upgrade your Timescale
+PostgreSQL, you need to upgrade it first, before you upgrade your TimescaleDB
 extension.
 
-Timescale supports these PostgreSQL releases. If you are not running a
+TimescaleDB supports these PostgreSQL releases. If you are not running a
 compatible PostgreSQL version, make sure you upgrade PostgreSQL before you
-upgrade Timescale:
+upgrade TimescaleDB:
 
 ||PostgreSQL&nbsp;15|PostgreSQL&nbsp;14|PostgreSQL&nbsp;13|PostgreSQL&nbsp;12|PostgreSQL&nbsp;11|PostgreSQL&nbsp;10|PostgreSQL&nbsp;9.6|
 |-|-|-|-|-|-|-|-|
-|Timescale&nbsp;2.10 and higher|&#9989;|&#9989;|&#9989;|&#9989;|&#10060;|&#10060;|&#10060;|
-|Timescale&nbsp;2.5 to 2.9|&#10060;|&#9989;|&#9989;|&#9989;|&#10060;|&#10060;|&#10060;|
-|Timescale&nbsp;2.4|&#10060;|&#10060;|&#9989;|&#9989;|&#10060;|&#10060;|&#10060;|
-|Timescale&nbsp;2.1 to 2.3|&#10060;|&#10060;|&#9989;|&#9989;|&#9989;|&#10060;|&#10060;|
-|Timescale&nbsp;2.0|&#10060;|&#10060;|&#10060;|&#9989;|&#9989;|&#10060;|&#10060;
-|Timescale&nbsp;1.7|&#10060;|&#10060;|&#10060;|&#9989;|&#9989;|&#9989;|&#9989;|
+|TimescaleDB&nbsp;2.10 and higher|&#9989;|&#9989;|&#9989;|&#9989;|&#10060;|&#10060;|&#10060;|
+|TimescaleDB&nbsp;2.5 to 2.9|&#10060;|&#9989;|&#9989;|&#9989;|&#10060;|&#10060;|&#10060;|
+|TimescaleDB&nbsp;2.4|&#10060;|&#10060;|&#9989;|&#9989;|&#10060;|&#10060;|&#10060;|
+|TimescaleDB&nbsp;2.1 to 2.3|&#10060;|&#10060;|&#9989;|&#9989;|&#9989;|&#10060;|&#10060;|
+|TimescaleDB&nbsp;2.0|&#10060;|&#10060;|&#10060;|&#9989;|&#9989;|&#10060;|&#10060;
+|TimescaleDB&nbsp;1.7|&#10060;|&#10060;|&#10060;|&#9989;|&#9989;|&#9989;|&#9989;|
 
-You need to upgrade PostgreSQL and Timescale in two separate steps. This is so
+You need to upgrade PostgreSQL and TimescaleDB in two separate steps. This is so
 that you can make sure each upgrade completes properly. For example, if you are
-running PostgreSQL&nbsp;10 and Timescale&nbsp;1.7.5, and you want to upgrade
-to PostgreSQL&nbsp;13 and Timescale&nbsp;2.2, upgrade in this order:
+running PostgreSQL&nbsp;10 and TimescaleDB&nbsp;1.7.5, and you want to upgrade
+to PostgreSQL&nbsp;13 and TimescaleDB&nbsp;2.2, upgrade in this order:
 
 1.  Upgrade PostgreSQL&nbsp;10 to PostgreSQL&nbsp;12
-1.  Upgrade Timescale&nbsp;1.7.5 to Timescale&nbsp;2.2 on PostgreSQL&nbsp;12
-1.  Upgrade PostgreSQL&nbsp;12 to PostgreSQL&nbsp;13 with Timescale&nbsp;2.2
+1.  Upgrade TimescaleDB&nbsp;1.7.5 to TimescaleDB&nbsp;2.2 on PostgreSQL&nbsp;12
+1.  Upgrade PostgreSQL&nbsp;12 to PostgreSQL&nbsp;13 with TimescaleDB&nbsp;2.2
    installed
 
 ## Plan your upgrade
@@ -48,7 +48,7 @@ Before you upgrade:
 *   Read [the release notes][pg-relnotes] for the PostgreSQL version you are
   upgrading to.
 *   [Perform a backup][backup] of your database. While PostgreSQL and
-  Timescale upgrades are performed in-place, upgrading is an intrusive
+  TimescaleDB upgrades are performed in-place, upgrading is an intrusive
   operation. Always make sure you have a backup on hand, and that the backup is
   readable in the case of disaster.
 


### PR DESCRIPTION
# Description

Fix to be consistent with brand guidelines: self-hosted TimescaleDB should always be referred to as such

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
