### PR TITLE
Adds back Cloud regions

### DIFF
--- a/use-timescale/page-index/page-index.js
+++ b/use-timescale/page-index/page-index.js
@@ -28,6 +28,11 @@ module.exports = [
             excerpt: "Timescale Cloud services overview",
           },
           {
+            title: "Clouds and regions",
+            href: "regions",
+            excerpt: "Timescale Cloud AWS regions",
+          },
+          {
             title: "Service explorer",
             href: "service-explorer",
             excerpt: "Timescale Cloud services explorer",

--- a/use-timescale/regions.md
+++ b/use-timescale/regions.md
@@ -1,0 +1,25 @@
+---
+title: Timescale Cloud regions
+excerpt: Available AWS regions for your Timescale Cloud services
+product: cloud
+---
+
+# Timescale Cloud available regions
+
+Timescale Cloud is available in these clouds and regions:
+
+Amazon Web Services:
+
+|Region|Zone|Location|
+|-|-|-|
+|`ap-southeast-2`|Australia|Sydney|
+|`eu-central-1`|Europe|Frankfurt|
+|`eu-west-1`|Europe|Ireland|
+|`us-east-1`|United States|North Virginia|
+|`us-west-2`|United States|Oregon|
+
+If you need a different cloud or region, you might want to use Managed Service
+for TimescaleDB instead. For a list of available clouds and regions, see
+[the Managed Service for TimescaleDB section][mst-regions].
+
+[mst-regions]: /mst/:currentVersion:/cloud-regions/


### PR DESCRIPTION
# Description

In the reorg, the Cloud regions section inadvertently got deleted (it was on the Cloud index page, which has gone away). This adds back the content as a page under the Use Timescale section, formats it the same as the existing MST page, and adds a link to the MST page.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
