### PR TITLE
Adds MST install to MST section

### DIFF
--- a/mst/installation-mst.md
+++ b/mst/installation-mst.md
@@ -1,0 +1,156 @@
+---
+title: Install Managed Service for TimescaleDB
+nav-title: Managed Service for TimescaleDB
+excerpt: Start a TimescaleDB instance on Managed Service for TimescaleDB
+product: mst
+section: install
+order: 2
+keywords: [installation]
+---
+
+import MSTIntro from "versionContent/_partials/_mst-intro.mdx";
+import CloudMSTComparison from "versionContent/_partials/_cloud-mst-comparison.mdx";
+
+# Install Managed Service for TimescaleDB
+
+<MSTIntro />
+
+<CloudMSTComparison />
+
+<Procedure>
+
+## Installing Managed Service for TimescaleDB
+
+1.  Sign up for a [Managed Service for TimescaleDB account][sign-up] with your
+    name and email address. You do not need to provide payment details to
+    get started. A confirmation email is sent to the email address you provide.
+1.  Verify your email by clicking on the link in the email you received. Don't
+    forget to check your spam folder in case the email ends up there.
+1.  Sign in to the [Managed Service for TimescaleDB portal][mst-portal] with the
+    password you set:
+    <img class="main-content__illustration"
+    src="https://s3.amazonaws.com/assets.timescale.com/docs/images/mst-portal-noservices.png"
+    alt="Managed Service for TimescaleDB Portal"/>
+
+<Highlight type="important">
+Your Managed Service for TimescaleDB trial includes up to US$300 credit for you
+to use. This is enough to complete all our tutorials and run a few test projects
+of your own.
+</Highlight>
+
+</Procedure>
+
+## Create your first service
+
+A service in Managed Service for TimescaleDB is a cloud instance on your chosen
+cloud provider, which you can install your database on.
+
+<Procedure>
+
+### Creating your first service
+
+1.  Sign in to the [Managed Service for TimescaleDB portal][mst-portal].
+1.  Click `Create a new service`, and complete these details:
+    *   In the `Select Your Service` field, click `TimescaleDB`.
+    *   In the `Select Your Cloud Service Provider` field, click your
+        preferred provider.
+    *   In the `Select Your Cloud Service Region` field, click your preferred
+        server location. This is often the server that's physically closest
+        to you.
+    *   In the `Select Your Service Plan` field, click your preferred plan,
+        based on the hardware configuration you require. If you are in your
+        trial period, and just want to try the service out, or develop a proof
+        of concept, we recommend the `Dev` plan, because it is the most
+        cost-effective during your trial period.
+1.  In the information bar on the right of the screen, review the settings you
+    have selected for your service, and click `Create Service`. The service
+    takes a few minutes to provision.
+
+    <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/mst-new-service.png" alt="Create a new service in the Managed Service for TimescaleDB portal"/>
+
+<Highlight type="important">
+Your Managed Service for TimescaleDB trial includes up to US$300 credit for you
+to use. This is enough to complete all our tutorials and run a few test projects
+of your own.
+</Highlight>
+
+</Procedure>
+
+## Connect to your service from the command prompt
+
+When you have a service up and running, you can connect to it from your local
+system using the `psql` command-line utility. This is the same tool you might
+have used to connect to PostgreSQL before, but if you haven't installed it yet,
+check out our [installing psql][install-psql] section.
+
+<Procedure>
+
+### Connecting to your service from the command prompt
+
+1.  Sign in to the [Managed Service for TimescaleDB portal][mst-portal].
+1.  In the `Services` tab, find the service you want to connect to, and check
+    it is marked as `Running`.
+1.  Click the name of the service you want to connect to see the connection
+    information. Take a note of the `host`, `port`, and `password`.
+1.  On your local system, at the command prompt, connect to the service, using
+    your own service details:
+
+    ```bash
+    psql -x "postgres://tsdbadmin:<PASSWORD>@<HOSTNAME>:<PORT>/defaultdb?sslmode=require"
+    ```
+
+    If your connection is successful, you'll see a message like this, followed
+    by the `psql` prompt:
+
+    ```bash
+    psql (13.3, server 13.4)
+    SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
+    Type "help" for help.
+    defaultdb=>
+    ```
+
+</Procedure>
+
+## Check that you have the TimescaleDB extension
+
+TimescaleDB is provided as an extension to your PostgreSQL database, and it is
+enabled by default when you create a new service on Managed Service for
+TimescaleDB. You can check that the TimescaleDB extension is installed by using
+the `\dx` command at the `psql` prompt. It looks like this:
+
+```sql
+defaultdb=> \dx
+
+List of installed extensions
+-[ RECORD 1 ]------------------------------------------------------------------
+Name        | plpgsql
+Version     | 1.0
+Schema      | pg_catalog
+Description | PL/pgSQL procedural language
+-[ RECORD 2 ]------------------------------------------------------------------
+Name        | timescaledb
+Version     | 2.5.1
+Schema      | public
+Description | Enables scalable inserts and complex queries for time-series data
+
+defaultdb=>
+```
+
+## Where to next
+
+Now that you have your first service up and running, you can check out the
+[Managed Service for TimescaleDB][mst-docs] section in our documentation, and
+find out what you can do with it.
+
+If you want to work through some tutorials to help you get up and running with
+TimescaleDB and time-series data, check out our [tutorials][tutorials] section.
+
+You can always [contact us][contact] if you need help working something out, or
+if you want to have a chat.
+
+[contact]: https://www.timescale.com/contact
+[install-psql]: /timescaledb/:currentVersion:/how-to-guides/connecting/psql/
+[mst-docs]: /mst/:currentVersion:/
+[mst-portal]: https://portal.managed.timescale.com
+[sign-up]: https://www.timescale.com/timescale-signup
+[tutorials]: /timescaledb/:currentVersion:/tutorials/

--- a/mst/page-index/page-index.js
+++ b/mst/page-index/page-index.js
@@ -11,6 +11,10 @@ module.exports = [
         href: "about-mst",
       },
       {
+        title: "Install Managed Service for TimescaleDB",
+        href: "installation-mst",
+      },
+      {
         title: "Clouds and regions",
         href: "cloud-regions",
       },
@@ -46,14 +50,14 @@ module.exports = [
         title: "Integrations",
         href: "integrations",
         excerpt: " MST integrates with the other tools you are already using, and makes it easy to add more integrations",
-        children:  [
+        children: [
           {
-           title: "Visualizing data with Google Data Studio",
-           href: "google-data-studio-mst",
+            title: "Visualizing data with Google Data Studio",
+            href: "google-data-studio-mst",
           },
           {
             title:
-          "Visualizing data with Grafana",
+              "Visualizing data with Grafana",
             href: "grafana-mst",
           },
           {
@@ -63,7 +67,7 @@ module.exports = [
           {
             title: "Sending metrics to Datadog",
             href: "metrics-datadog",
-          }, 
+          },
           {
             title: "Monitoring with Prometheus endpoint",
             href: "prometheus-mst",


### PR DESCRIPTION
# Description

The MST install docs got deleted in the reorg (because the entire Install directory got deleted). This adds the page for MST install to the top of the MST section.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
