### PR TITLE
Fix argument order for time_bucket_gapfill

### DIFF
--- a/api/_hyperfunctions/time_bucket_gapfill/time_bucket_gapfill.md
+++ b/api/_hyperfunctions/time_bucket_gapfill/time_bucket_gapfill.md
@@ -21,9 +21,9 @@ api_details:
         time_bucket_gapfill(
           bucket_width INTERVAL | INTEGER,
           time TIMESTAMPTZ | INTEGER,
+          [, timezone TEXT]
           [, start TIMESTAMPTZ | INTEGER]
           [, finish TIMESTAMPTZ | INTEGER]
-          [, timezone TEXT]
         ) RETURNS TIMESTAMPTZ
   parameters:
     required:
@@ -37,6 +37,13 @@ api_details:
         type: TIMESTAMPTZ | INTEGER
         description: The timestamp on which to base the bucket
     optional:
+      - name: timezone
+        type: TEXT
+        description: >
+          The timezone to use for bucketing. For example, `Europe/Berlin`.
+          Available in TimescaleDB 2.9 or later. Does not work for integer-based time.
+          If you have an untyped `start` or `finish` argument and a `timezone` argument, you might run into a problem where you are not passing your arguments for the parameter that you expect.
+          To solve this, either name your arguments or explicitly type cast them.
       - name: start
         type: TIMESTAMPTZ | INTEGER
         description: >
@@ -53,13 +60,6 @@ api_details:
           Use `INTEGER` only if your time column is integer-based.
           We recommend using a `WHERE` clause rather than specifying `start`, which is a legacy option.
           The `WHERE` is more performant, because the query planner can filter out chunks by constraint exclusion.
-      - name: timezone
-        type: TEXT
-        description: >
-          The timezone to use for bucketing. For example, `Europe/Berlin`.
-          Available in TimescaleDB 2.9 or later. Does not work for integer-based time.
-          If you have an untyped `start` or `finish` argument and a `timezone` argument, you might run into a problem where you are not passing your arguments for the parameter that you expect.
-          To solve this, either name your arguments or explicitly type cast them.
     returns:
       - column: time_bucket_gapfill
         type: TIMESTAMPTZ


### PR DESCRIPTION
# Description

`timezone` is the third argument to `time_bucket_gapfill`, not the last. 

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
