### PR TITLE
Adds a more obvious warning on the older relnotes section

### DIFF
--- a/about/release-notes/past-releases.md
+++ b/about/release-notes/past-releases.md
@@ -6,9 +6,11 @@ keywords: [upgrades, updates, releases]
 
 # Release notes for past releases
 
-This page contains release notes for older versions. For the current release
-notes, see the
-[current release section][current-relnotes].
+<Highlight type="warning">
+This is an historical document, which contains release notes for older versions
+of TimescaleDB. For details on the most recent release, see the
+[current release notes](/about/latest/release-notes/).
+</Highlight>
 
 ## What's new in TimescaleDB 2.9:
 
@@ -1947,4 +1949,3 @@ For more information on this release, read the [blog announcement](https://blog.
 [github-issue]: <https://github.com/timescale/timescaledb/issues/new/choose>
 [github-repo]: <https://github.com/timescale/timescaledb>
 [community]: https://www.timescale.com/community/
-[current-relnotes]: /about/:currentVersion:/release-notes/


### PR DESCRIPTION
# Description

Makes the note about being an historical document a little more obvious on the past releases section (styled in the same way as the what's new in TSDB 2.0 section).

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
