### PR TITLE
Reword first para of Hypertables overview content

### DIFF
--- a/_partials/_hypertables-intro.md
+++ b/_partials/_hypertables-intro.md
@@ -1,7 +1,7 @@
-Hypertables are PostgreSQL tables with special features that make it easy to
-work with time-series data. You interact with them just as you would with
-regular PostgreSQL tables. But behind the scenes, hypertables automatically
-partition your data into chunks by time.
+Hypertables are PostgreSQL tables that automatically partition your data by
+time. You interact with hypertables in the same way as regular PostgreSQL
+tables, but with extra features that makes managing your time-series data much
+easier.
 
 In Timescale, hypertables exist alongside regular PostgreSQL tables. Use
 hypertables to store time-series data. This gives you improved insert and query


### PR DESCRIPTION
# Description

Rewords the first para of the Hypertables Overview partial, to emphasise that hypertables are PG tables that partition data by time. 

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/timescaledb/latest/contribute-to-docs/)

# Review checklists
Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

- [ ] Is the content technically accurate?
- [ ] Is the content complete?
- [ ] Is the content presented in a logical order?
- [ ] Does the content use appropriate names for features and products?
- [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

- [ ] Is the content free from typos?
- [ ] Does the content use plain English?
- [ ] Does the content contain clear sections for concepts, tasks, and references?
- [ ] Have any images been uploaded to the correct location, and are resolvable?
- [ ] If the page index was updated, are redirects required
      and have they been implemented?
- [ ] Have you checked the built version of this content?
