### PR TITLE
Document min_n/max_n stabilization in Toolkit 1.16

### DIFF
--- a/api/_hyperfunctions/max_n/examples.md
+++ b/api/_hyperfunctions/max_n/examples.md
@@ -22,11 +22,11 @@ You can query for the 10 largest transactions each day:
 WITH t as (
     SELECT
         time_bucket('1 day'::interval, ts) as day,
-        toolkit_experimental.max_n(price * volume, 10) AS daily_max
+        max_n(price * volume, 10) AS daily_max
     FROM stock_sales
     GROUP BY time_bucket('1 day'::interval, ts)
 )
 SELECT
-    day, toolkit_experimental.as_array(daily_max)
+    day, as_array(daily_max)
 FROM t;
 ```

--- a/api/_hyperfunctions/max_n/into_array.md
+++ b/api/_hyperfunctions/max_n/into_array.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, maximum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: accessor
@@ -43,8 +43,8 @@ api_details:
       command:
         language: sql
         code: |
-          SELECT toolkit_experimental.into_array(
-              toolkit_experimental.max_n(sub.val, 5))
+          SELECT into_array(
+              max_n(sub.val, 5))
           FROM (
             SELECT (i * 13) % 10007 AS val 
             FROM generate_series(1,10000) as i

--- a/api/_hyperfunctions/max_n/into_values.md
+++ b/api/_hyperfunctions/max_n/into_values.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, maximum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: accessor
@@ -42,8 +42,8 @@ api_details:
       command:
         language: sql
         code: |
-          SELECT toolkit_experimental.into_values(
-              toolkit_experimental.max_n(sub.val, 5))
+          SELECT into_values(
+              max_n(sub.val, 5))
           FROM (
             SELECT (i * 13) % 10007 AS val 
             FROM generate_series(1,10000) as i

--- a/api/_hyperfunctions/max_n/max_n.md
+++ b/api/_hyperfunctions/max_n/max_n.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, maximum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: aggregate

--- a/api/_hyperfunctions/max_n/rollup.md
+++ b/api/_hyperfunctions/max_n/rollup.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, maximum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: rollup

--- a/api/_hyperfunctions/max_n_by/examples.md
+++ b/api/_hyperfunctions/max_n_by/examples.md
@@ -23,8 +23,8 @@ SELECT
     (data).symbol, 
     value AS transaction 
 FROM
-    toolkit_experimental.into_values((
-        SELECT toolkit_experimental.max_n_by(price * volume, stock_sales, 10)
+    into_values((
+        SELECT max_n_by(price * volume, stock_sales, 10)
         FROM stock_sales
     ), 
     NULL::stock_sales);

--- a/api/_hyperfunctions/max_n_by/into_values.md
+++ b/api/_hyperfunctions/max_n_by/into_values.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, maximum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: accessor
@@ -55,8 +55,8 @@ api_details:
       command:
         language: sql
         code: |
-          SELECT toolkit_experimental.into_values(
-              toolkit_experimental.max_n_by(sub.mod, sub.div, 5),
+          SELECT into_values(
+              max_n_by(sub.mod, sub.div, 5),
               NULL::INT)
           FROM (
             SELECT (i * 13) % 10007 AS mod, (i * 13) / 10007 AS div

--- a/api/_hyperfunctions/max_n_by/max_n_by.md
+++ b/api/_hyperfunctions/max_n_by/max_n_by.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, maximum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: aggregate

--- a/api/_hyperfunctions/max_n_by/rollup.md
+++ b/api/_hyperfunctions/max_n_by/rollup.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, maximum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: rollup

--- a/api/_hyperfunctions/min_n/examples.md
+++ b/api/_hyperfunctions/min_n/examples.md
@@ -20,11 +20,11 @@ You can query for the 10 smallest transactions each day:
 WITH t as (
     SELECT
         time_bucket('1 day'::interval, ts) as day,
-        toolkit_experimental.min_n(price * volume, 10) AS daily_min
+        min_n(price * volume, 10) AS daily_min
     FROM stock_sales
     GROUP BY time_bucket('1 day'::interval, ts)
 )
 SELECT
-    day, toolkit_experimental.as_array(daily_max)
+    day, as_array(daily_max)
 FROM t;
 ```

--- a/api/_hyperfunctions/min_n/into_array.md
+++ b/api/_hyperfunctions/min_n/into_array.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, minimum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: accessor
@@ -43,8 +43,8 @@ api_details:
       command:
         language: sql
         code: |
-          SELECT toolkit_experimental.into_array(
-              toolkit_experimental.min_n(sub.val, 5))
+          SELECT into_array(
+              min_n(sub.val, 5))
           FROM (
             SELECT (i * 13) % 10007 AS val 
             FROM generate_series(1,10000) as i

--- a/api/_hyperfunctions/min_n/into_values.md
+++ b/api/_hyperfunctions/min_n/into_values.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, minimum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: accessor

--- a/api/_hyperfunctions/min_n/min_n.md
+++ b/api/_hyperfunctions/min_n/min_n.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, minimum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: aggregate

--- a/api/_hyperfunctions/min_n/rollup.md
+++ b/api/_hyperfunctions/min_n/rollup.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, minimum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: rollup

--- a/api/_hyperfunctions/min_n_by/examples.md
+++ b/api/_hyperfunctions/min_n_by/examples.md
@@ -23,8 +23,8 @@ SELECT
     (data).symbol, 
     value AS transaction 
 FROM
-    toolkit_experimental.into_values((
-        SELECT toolkit_experimental.min_n_by(price * volume, stock_sales, 10)
+    into_values((
+        SELECT min_n_by(price * volume, stock_sales, 10)
         FROM stock_sales
     ), 
     NULL::stock_sales);

--- a/api/_hyperfunctions/min_n_by/into_values.md
+++ b/api/_hyperfunctions/min_n_by/into_values.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, minimum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: accessor
@@ -54,8 +54,8 @@ api_details:
       command:
         language: sql
         code: |
-          SELECT toolkit_experimental.into_values(
-              toolkit_experimental.min_n_by(sub.mod, sub.div, 5),
+          SELECT into_values(
+              min_n_by(sub.mod, sub.div, 5),
               NULL::INT)
           FROM (
             SELECT (i * 13) % 10007 AS mod, (i * 13) / 10007 AS div

--- a/api/_hyperfunctions/min_n_by/min_n_by.md
+++ b/api/_hyperfunctions/min_n_by/min_n_by.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, minimum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: aggregate

--- a/api/_hyperfunctions/min_n_by/rollup.md
+++ b/api/_hyperfunctions/min_n_by/rollup.md
@@ -6,10 +6,10 @@ tags: [hyperfunctions, toolkit, minimum]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.12.0
+    stable: 1.16.0
 hyperfunction:
   family: minimum and maximum
   type: rollup


### PR DESCRIPTION
# Description

min_n/max_n/min_n_by/max_n_by were stabilized in Toolkit 1.16.

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
