### PR TITLE
Document date utility stabilization in Toolkit 1.16

### DIFF
--- a/api/days_in_month.md
+++ b/api/days_in_month.md
@@ -6,15 +6,15 @@ keywords: [hyperfunctions, Toolkit, normalization]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.6.0
+    stable: 1.16.0
 hyperfunction:
   type: one-step operation
 ---
 
-# days_in_month() <Tag type="toolkit" content="Toolkit" /><Tag type="experimental" content="Experimental" />
+# days_in_month() <Tag type="toolkit" content="Toolkit" />
 
 Given a timestamptz, returns how many days are in that month.
 
@@ -29,7 +29,7 @@ Given a timestamptz, returns how many days are in that month.
 Calculate how many days in the month of January 1, 2022:
 
 ```sql
-SELECT toolkit_experimental.days_in_month('2021-01-01 00:00:00+03'::timestamptz)
+SELECT days_in_month('2021-01-01 00:00:00+03'::timestamptz)
 ```
 
 The output looks like this:

--- a/api/month_normalize.md
+++ b/api/month_normalize.md
@@ -6,15 +6,15 @@ keywords: [hyperfunctions, Toolkit, normalization]
 api:
   license: community
   type: function
-  experimental: true
   toolkit: true
   version:
     experimental: 1.10.1
+    stable: 1.16.0
 hyperfunction:
   type: one-step operation
 ---
 
-# month_normalize() <Tag type="toolkit" content="Toolkit" /><Tag type="experimental-toolkit" content="Experimental" />
+# month_normalize() <Tag type="toolkit" content="Toolkit" />
 
 Normalize the provided metric based on reference date and days.
 
@@ -32,7 +32,7 @@ Get the normalized value for a metric of 1000, and a reference date of January
 1, 2021:
 
 ```sql
-SELECT toolkit_experimental.month_normalize(1000,'2021-01-01 00:00:00+03'::timestamptz)
+SELECT month_normalize(1000,'2021-01-01 00:00:00+03'::timestamptz)
 ```
 
 The output looks like this:

--- a/api/to_epoch.md
+++ b/api/to_epoch.md
@@ -1,0 +1,41 @@
+---
+api_name: to_epoch()
+excerpt: Converts a date to a Unix epoch time
+topics: [hyperfunctions]
+keywords: [hyperfunctions, Toolkit, normalization]
+api:
+  license: community
+  type: function
+  toolkit: true
+  version:
+    experimental: 1.6.0
+    stable: 1.16.0
+hyperfunction:
+  type: one-step operation
+---
+
+# to_epoch() <Tag type="toolkit" content="Toolkit" />
+
+Given a timestamptz, returns the number of seconds since January 1, 1970 (the Unix epoch).
+
+### Required arguments
+
+|Name|Type|Description|
+|-|-|-|
+|`date`|`TIMESTAMPTZ`|Timestamp to use to calculate epoch|
+
+### Sample usage
+
+Convert a date to a Unix epoch time:
+
+```sql
+SELECT to_epoch('2021-01-01 00:00:00+03'::timestamptz);
+```
+
+The output looks like this:
+
+```sql
+  to_epoch
+------------
+ 1609448400
+```


### PR DESCRIPTION
# Description

We stabilized the three date utility functions in Toolkit 1.16. We forgot to document `to_epoch` when it was added, so this PR also documents that function.

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
