### PR TITLE
Adds Hypershift to GSG

### DIFF
--- a/_partials/_hypershift-alternatively.md
+++ b/_partials/_hypershift-alternatively.md
@@ -1,0 +1,6 @@
+<Highlight type="note">
+Alternatively, if you have data in an existing database, you can migrate it
+directly into your new Timescale database using hypershift. For more information
+about hypershift, including instructions for how to migrate your data, see the
+[hypershift documentation](https://docs.timescale.com/use-timescale/latest/migration/).
+</Highlight>

--- a/getting-started/add-data.md
+++ b/getting-started/add-data.md
@@ -6,11 +6,15 @@ keywords: [ingest]
 tags: [add, data, time-series]
 ---
 
+import HypershiftAlt from "versionContent/_partials/_hypershift-alternatively.mdx";
+
 # Add time-series data
 
 To explore Timescale's features, you need some sample data. This tutorial
 provides real-time stock trade data, also known as tick data, from
 [Twelve Data][twelve-data].
+
+<HypershiftAlt />
 
 ## About the dataset
 
@@ -54,6 +58,8 @@ second during trading hours.
 
 To ingest data into the tables that you created, you need to download the
 dataset and copy the data to your database.
+
+<HypershiftAlt />
 
 <Procedure>
 
@@ -106,8 +112,8 @@ docker cp tutorial_sample_company.csv timescaledb:/tutorial_sample_company.csv
 
 ## Next steps
 
-Now that you have data in your Timescale Cloud instance, learn how to [query the
-data][query-data].
+Now that you have data in your Timescale Cloud instance, learn how to
+[query the data][query-data].
 
 [twelve-data]: https://twelvedata.com/
 [query-data]: /getting-started/:currentVersion:/query-data/


### PR DESCRIPTION
# Description

Adds a partial to xref to hypershift docs in the GSG add data section. When the GSG is rewritten (very soon!), hypershift will take a starring role.

# Links

**_Merge https://github.com/timescale/docs/pull/2230 first!_**

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
