### PR TITLE
Move space partitioning to dist hypertables.

### DIFF
--- a/use-timescale/distributed-hypertables/about-distributed-hypertables.md
+++ b/use-timescale/distributed-hypertables/about-distributed-hypertables.md
@@ -37,10 +37,7 @@ Distributed hypertables are always partitioned by time, just like standard
 hypertables. But unlike standard hypertables, distributed hypertables should also
 be partitioned by space. This allows you to balance inserts and queries between
 data nodes, similar to traditional sharding. Without space partitioning, all
-data in the same time range would write to the same chunk on a single node. For
-more information about space partitioning, see the
-[space partitioning][space-partitioning] and
-[multi-node][multi-node] sections.
+data in the same time range would write to the same chunk on a single node.
 
 By default, Timescale creates as many space partitions as there are data
 nodes. You can change this number, but having too many space partitions degrades
@@ -50,6 +47,22 @@ balancing when mapping items to partitions.
 Data is assigned to space partitions by hashing. Each hash bucket in the space
 dimension corresponds to a data node. One data node may hold many buckets, but
 each bucket may belong to only one node for each time interval.
+
+When space partitioning is on, 2 dimensions are used to divide data into chunks:
+the time dimension and the space dimension. You can specify the number of
+partitions along the space dimension. Data is assigned to a partition by hashing
+its value on that dimension.
+
+For example, say you use `device_id` as a space partitioning column. For each
+row, the value of the `device_id` column is hashed. Then the row is inserted
+into the correct partition for that hash value.
+
+<img class="main-content__illustration"
+src="https://s3.amazonaws.com/assets.timescale.com/docs/images/hypertable-time-space-partition.png"
+alt="A hypertable visualized as a rectangular plane carved into smaller rectangles, which are chunks. One dimension of the rectangular plane is time and the other is space. Data enters the hypertable and flows to a chunk based on its time and space values." />
+
+For more information about space partitioning, see the
+[multi-node][multi-node] section.
 
 ### Repartitioning distributed hypertables
 

--- a/use-timescale/distributed-hypertables/about-distributed-hypertables.md
+++ b/use-timescale/distributed-hypertables/about-distributed-hypertables.md
@@ -34,10 +34,10 @@ can.
 ## Space partitioning
 
 Distributed hypertables are always partitioned by time, just like standard
-hypertables. But unlike standard hypertables, distributed hypertables should also
-be partitioned by space. This allows you to balance inserts and queries between
-data nodes, similar to traditional sharding. Without space partitioning, all
-data in the same time range would write to the same chunk on a single node.
+hypertables. But unlike standard hypertables, distributed hypertables should
+also be partitioned by space. This allows you to balance inserts and queries
+between data nodes, similar to traditional sharding. Without space partitioning,
+all data in the same time range would write to the same chunk on a single node.
 
 By default, Timescale creates as many space partitions as there are data
 nodes. You can change this number, but having too many space partitions degrades

--- a/use-timescale/distributed-hypertables/about-distributed-hypertables.md
+++ b/use-timescale/distributed-hypertables/about-distributed-hypertables.md
@@ -74,7 +74,7 @@ space dimension is open, and there is no way to adjust this. To create a
 hypertable with a closed space dimension, create the hypertable with only the
 time dimension first. Then use the `add_dimension` command to explicitly add an
 open device. If you set the range to `1`, each device has its own chunks. This
-can help you work around some limitations of normal space dimensions, and is
+can help you work around some limitations of regular space dimensions, and is
 especially useful if you want to make some chunks readily available for
 exclusion.
 

--- a/use-timescale/distributed-hypertables/about-distributed-hypertables.md
+++ b/use-timescale/distributed-hypertables/about-distributed-hypertables.md
@@ -78,13 +78,6 @@ can help you work around some limitations of normal space dimensions, and is
 especially useful if you want to make some chunks readily available for
 exclusion.
 
-### Best practices for space partitioning
-
-Space partitioning is only useful if you have multiple physical disks, each
-corresponding to a separate tablespace. Each disk can then store some of the
-space partitions. If you partition by space without this setup, you increase
-query planning complexity without increasing I/O performance.
-
 ### Repartitioning distributed hypertables
 
 You can expand distributed hypertables by adding additional data nodes. If you

--- a/use-timescale/distributed-hypertables/about-distributed-hypertables.md
+++ b/use-timescale/distributed-hypertables/about-distributed-hypertables.md
@@ -31,7 +31,7 @@ on the data nodes. When you insert data or run a query, the access node
 communicates with the relevant data nodes and pushes down any processing if it
 can.
 
-## Space partitions for distributed hypertables
+## Space partitioning
 
 Distributed hypertables are always partitioned by time, just like standard
 hypertables. But unlike standard hypertables, distributed hypertables should also
@@ -61,8 +61,29 @@ into the correct partition for that hash value.
 src="https://s3.amazonaws.com/assets.timescale.com/docs/images/hypertable-time-space-partition.png"
 alt="A hypertable visualized as a rectangular plane carved into smaller rectangles, which are chunks. One dimension of the rectangular plane is time and the other is space. Data enters the hypertable and flows to a chunk based on its time and space values." />
 
-For more information about space partitioning, see the
-[multi-node][multi-node] section.
+### Closed and open dimensions for space partitioning
+
+Space partitioning dimensions can be open or closed. A closed dimension has a
+fixed number of partitions, and usually uses some hashing to match values to
+partitions. An open dimension does not have a fixed number of partitions, and
+usually has each chunk cover a certain range. In most cases the time dimension
+is open and the space dimension is closed.
+
+If you use the `create_hypertable` command to create your hypertable, then the
+space dimension is open, and there is no way to adjust this. To create a
+hypertable with a closed space dimension, create the hypertable with only the
+time dimension first. Then use the `add_dimension` command to explicitly add an
+open device. If you set the range to `1`, each device has its own chunks. This
+can help you work around some limitations of normal space dimensions, and is
+especially useful if you want to make some chunks readily available for
+exclusion.
+
+### Best practices for space partitioning
+
+Space partitioning is only useful if you have multiple physical disks, each
+corresponding to a separate tablespace. Each disk can then store some of the
+space partitions. If you partition by space without this setup, you increase
+query planning complexity without increasing I/O performance.
 
 ### Repartitioning distributed hypertables
 

--- a/use-timescale/hypertables/about-hypertables.md
+++ b/use-timescale/hypertables/about-hypertables.md
@@ -78,41 +78,8 @@ to view and set your chunk time intervals, see the section on
 Space partitioning is optional. It is not usually recommended for regular
 hypertables, except in very particular circumstances. It is recommended for
 distributed hypertables, to balance inserts between nodes. For more information,
-see the sections on
-[best practices for space partitioning][best-practices-space] and
-[distributed hypertables][about-distributed-hypertables].
-
-### Closed and open dimensions for space partitioning
-
-Space partitioning dimensions can be open or closed. A closed dimension has a
-fixed number of partitions, and usually uses some hashing to match values to
-partitions. An open dimension does not have a fixed number of partitions, and
-usually has each chunk cover a certain range. In most cases the time dimension
-is open and the space dimension is closed.
-
-If you use the `create_hypertable` command to create your hypertable, then the
-space dimension is open, and there is no way to adjust this. To create a
-hypertable with a closed space dimension, create the hypertable with only the
-time dimension first. Then use the `add_dimension` command to explicitly add an
-open device. If you set the range to `1`, each device has its own chunks. This
-can help you work around some limitations of normal space dimensions, and is
-especially useful if you want to make some chunks readily available for
-exclusion.
-
-### Best practices for space partitioning
-
-Space partitioning is not usually recommended for non-distributed hypertables.
-It's only useful if you have multiple physical disks, each corresponding to a
-separate tablespace. Each disk can then store some of the space partitions. If
-you partition by space without this setup, you increase query planning
-complexity without increasing I/O performance.
-
-<Highlight type="note">
-A more recommended way to increase input/output performance is to use RAID
-(redundant array of inexpensive disks). RAID virtualizes multiple physical disks
-into a single logical disk. You can then use this single logical disk to store
-your hypertable, without any space partitioning.
-</Highlight>
+see the
+[distributed hypertables][about-distributed-hypertables] section.
 
 ## Hypertable indexes
 

--- a/use-timescale/hypertables/about-hypertables.md
+++ b/use-timescale/hypertables/about-hypertables.md
@@ -78,17 +78,17 @@ to view and set your chunk time intervals, see the section on
 Space partitioning is optional. It is not usually recommended for regular
 hypertables.
 
-A more recommended way to increase input/output performance on single
-hypertables is to use RAID (redundant array of inexpensive disks).
-RAID virtualizes multiple physical disks into a single logical disk.
-You can then use this single logical disk to store your hypertable,
-without any space partitioning.
+A good alternative way to increase input/output performance on single
+hypertables is to use RAID (redundant array of inexpensive disks). RAID
+virtualizes multiple physical disks into a single logical disk. You can then use
+this single logical disk to store your hypertable, without any space
+partitioning.
 
 Space partitioning is useful if you have multiple physical disks, each
-corresponding to a separate tablespace. Each disk can then store some of
-the space partitions. If you partition by space without this setup, you
-increase query planning complexity without increasing I/O performance.
-For more information, see the
+corresponding to a separate tablespace. Each disk can then store some of the
+space partitions. If you partition by space without this setup, you increase
+query planning complexity without increasing I/O performance. For more
+information, see the
 [distributed hypertables][about-distributed-hypertables] section.
 
 ## Hypertable indexes

--- a/use-timescale/hypertables/about-hypertables.md
+++ b/use-timescale/hypertables/about-hypertables.md
@@ -82,19 +82,6 @@ see the sections on
 [best practices for space partitioning][best-practices-space] and
 [distributed hypertables][about-distributed-hypertables].
 
-When space partitioning is on, 2 dimensions are used to divide data into chunks:
-the time dimension and the space dimension. You can specify the number of
-partitions along the space dimension. Data is assigned to a partition by hashing
-its value on that dimension.
-
-For example, say you use `device_id` as a space partitioning column. For each
-row, the value of the `device_id` column is hashed. Then the row is inserted
-into the correct partition for that hash value.
-
-<img class="main-content__illustration"
-src="https://s3.amazonaws.com/assets.timescale.com/docs/images/hypertable-time-space-partition.png"
-alt="A hypertable visualized as a rectangular plane carved into smaller rectangles, which are chunks. One dimension of the rectangular plane is time and the other is space. Data enters the hypertable and flows to a chunk based on its time and space values." />
-
 ### Closed and open dimensions for space partitioning
 
 Space partitioning dimensions can be open or closed. A closed dimension has a

--- a/use-timescale/hypertables/about-hypertables.md
+++ b/use-timescale/hypertables/about-hypertables.md
@@ -76,9 +76,19 @@ to view and set your chunk time intervals, see the section on
 ### Space partitioning
 
 Space partitioning is optional. It is not usually recommended for regular
-hypertables, except in very particular circumstances. It is recommended for
-distributed hypertables, to balance inserts between nodes. For more information,
-see the
+hypertables.
+
+A more recommended way to increase input/output performance on single
+hypertables is to use RAID (redundant array of inexpensive disks).
+RAID virtualizes multiple physical disks into a single logical disk.
+You can then use this single logical disk to store your hypertable,
+without any space partitioning.
+
+Space partitioning is useful if you have multiple physical disks, each
+corresponding to a separate tablespace. Each disk can then store some of
+the space partitions. If you partition by space without this setup, you
+increase query planning complexity without increasing I/O performance.
+For more information, see the
 [distributed hypertables][about-distributed-hypertables] section.
 
 ## Hypertable indexes


### PR DESCRIPTION
# Description

The space partitioning section didn't make much sense in the About hypertables page. This PR moves it to About distributed hypertables instead.

# Links

Fixes https://github.com/timescale/docs/issues/2103

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
