### PR TITLE
use latest instead of currentversion in url

### DIFF
--- a/api/_hyperfunctions/gp_lttb.md
+++ b/api/_hyperfunctions/gp_lttb.md
@@ -46,7 +46,7 @@ api_details:
         description: >
           An object representing a series of values occurring at set intervals from a starting time.
           It can be unpacked with `unnest`.
-          For more information, see the documentation on [timevectors](/use-timescale/:currentVersion:/hyperfunctions/function-pipelines/#timevectors).
+          For more information, see the documentation on [timevectors](/use-timescale/latest/hyperfunctions/function-pipelines/#timevectors).
   examples:
     - description: >
         This example uses a table with raw data generated as a sine wave, and removes a day from the middle of the data.
@@ -68,7 +68,7 @@ api_details:
               FROM metrics))
       return:
         code: |
-          time                   |             value 
+          time                   |             value
           -----------------------+-------------------
           2020-01-01 01:00:00+00 | 5.652630961100257
           2020-01-02 12:00:00+00 |                 0


### PR DESCRIPTION
# Description

Apparently we need to use `latest` in URLs in the hyperfunction API docs, not `:currentVersion:`.

# Links

Fixes https://github.com/timescale/docs/issues/2241

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
