### PR TITLE
Make unix_now function immutable, not stable

### DIFF
--- a/api/set_integer_now_func.md
+++ b/api/set_integer_now_func.md
@@ -22,15 +22,15 @@ chunk.
 ### Required arguments
 
 |Name|Type|Description|
-|---|---|---|
-| `main_table` | REGCLASS | Hypertable to set the integer now function for .|
-| `integer_now_func` | REGPROC | A function that returns the current time value in the same units as the time column. |
+|-|-|-|
+|`main_table`|REGCLASS|Hypertable to set the integer now function for|
+|`integer_now_func`|REGPROC|A function that returns the current time value in the same units as the time column|
 
 ### Optional arguments
 
 |Name|Type|Description|
-|---|---|---|
-| `replace_if_exists` | BOOLEAN | Whether to override the function if one is already set. Defaults to false.|
+|-|-|-|
+|`replace_if_exists`|BOOLEAN|Whether to override the function if one is already set. Defaults to false.|
 
 ### Sample usage
 
@@ -38,7 +38,7 @@ To set the integer now function for a hypertable with a time column in unix
 time (number of seconds since the unix epoch, UTC).
 
 ```
-CREATE OR REPLACE FUNCTION unix_now() returns BIGINT LANGUAGE SQL STABLE as $$ SELECT extract(epoch from now())::BIGINT $$;
+CREATE OR REPLACE FUNCTION unix_now() returns BIGINT LANGUAGE SQL IMMUTABLE as $$ SELECT extract(epoch from now())::BIGINT $$;
 
 SELECT set_integer_now_func('test_table_bigint', 'unix_now');
 ```

--- a/api/set_integer_now_func.md
+++ b/api/set_integer_now_func.md
@@ -37,7 +37,7 @@ chunk.
 To set the integer now function for a hypertable with a time column in unix
 time (number of seconds since the unix epoch, UTC).
 
-```
+```sql
 CREATE OR REPLACE FUNCTION unix_now() returns BIGINT LANGUAGE SQL IMMUTABLE as $$ SELECT extract(epoch from now())::BIGINT $$;
 
 SELECT set_integer_now_func('test_table_bigint', 'unix_now');

--- a/api/set_integer_now_func.md
+++ b/api/set_integer_now_func.md
@@ -19,20 +19,20 @@ In particular, many policies only apply to chunks of a certain age and a
 function that returns the current time is necessary to determine the age of a
 chunk.
 
-### Required arguments
+## Required arguments
 
 |Name|Type|Description|
 |-|-|-|
 |`main_table`|REGCLASS|Hypertable to set the integer now function for|
 |`integer_now_func`|REGPROC|A function that returns the current time value in the same units as the time column|
 
-### Optional arguments
+## Optional arguments
 
 |Name|Type|Description|
 |-|-|-|
 |`replace_if_exists`|BOOLEAN|Whether to override the function if one is already set. Defaults to false.|
 
-### Sample usage
+## Sample usage
 
 To set the integer now function for a hypertable with a time column in unix
 time (number of seconds since the unix epoch, UTC).

--- a/api/set_integer_now_func.md
+++ b/api/set_integer_now_func.md
@@ -37,6 +37,12 @@ chunk.
 To set the integer now function for a hypertable with a time column in unix
 time (number of seconds since the unix epoch, UTC).
 
+<Highlight type="important">
+The `unix_now` function is not immutable by default, and this example could lead
+to incorrect query results if you are using it with prepared statements or plan
+caching.
+</Highlight>
+
 ```sql
 CREATE OR REPLACE FUNCTION unix_now() returns BIGINT LANGUAGE SQL IMMUTABLE as $$ SELECT extract(epoch from now())::BIGINT $$;
 


### PR DESCRIPTION
# Description

Update the example to use unix_now function as immutable instead of stable

# Links

Fixes https://github.com/timescale/docs/issues/2158

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
