### PR TITLE
Add experimental schema partial

### DIFF
--- a/_partials/_experimental-schema-upgrade.md
+++ b/_partials/_experimental-schema-upgrade.md
@@ -1,0 +1,5 @@
+<Highlight type="important">
+When you upgrade the `timescaledb` extension, the experimental schema is removed
+by default. To use experimental features after an upgrade, you need to add the
+experimental schema again.
+</Highlight>

--- a/api/api-tag-overview.md
+++ b/api/api-tag-overview.md
@@ -4,10 +4,13 @@ excerpt: Understand the tags used in the Timescale documentation API references
 tags: [licenses, toolkit, experimental]
 ---
 
+import ExperimentalUpgrade from "versionContent/_partials/_experimental-schema-upgrade.mdx";
+
 # API Reference tag overview
 
-The Timescale API Reference uses tags to categorize functions. The tags are `Community`,
-`Experimental`, `Toolkit`, and `Experimental (Toolkit)`. This section explains each tag.
+The Timescale API Reference uses tags to categorize functions. The tags are
+`Community`, `Experimental`, `Toolkit`, and `Experimental (Toolkit)`. This
+section explains each tag.
 
 ## Community <Tag type="community">Community</Tag>
 
@@ -17,12 +20,17 @@ visit our [TimescaleDB License comparison sheet][tsl-comparison].
 
 ## Experimental (TimescaleDB Experimental Schema) <Tag type="experimental">Experimental</Tag>
 
-This tag indicates that the function is included in the TimescaleDB experimental schema.
-Do not use experimental functions in production. Experimental features could include bugs,
-and are likely to change in future versions. The experimental schema is used by Timescale
-to develop new features more quickly. If experimental functions are successful,
-they can move out of the experimental schema and go into production use. For more
-information about the experimental schema, [read the Timescale blog post][experimental-blog].
+This tag indicates that the function is included in the TimescaleDB experimental
+schema. Do not use experimental functions in production. Experimental features
+could include bugs, and are likely to change in future versions. The
+experimental schema is used by Timescale to develop new features more quickly.
+If experimental functions are successful, they can move out of the experimental
+schema and go into production use.
+
+<ExperimentalUpgrade />
+
+For more information about the experimental
+schema, [read the Timescale blog post][experimental-blog].
 
 ## Toolkit <Tag type="toolkit">Toolkit</Tag>
 
@@ -32,14 +40,17 @@ For installation instructions, [see the installation guide][toolkit-install].
 
 ## Experimental (TimescaleDB Toolkit) <Tag type="experimental-toolkit">Experimental</Tag>
 
-This tag is used with the Toolkit tag. It indicates a Toolkit function that is under
-active development. Do not use experimental toolkit functions in production.
-Experimental toolkit functions could include bugs, and are likely to change in future versions.
+This tag is used with the Toolkit tag. It indicates a Toolkit function that is
+under active development. Do not use experimental toolkit functions in
+production. Experimental toolkit functions could include bugs, and are likely to
+change in future versions.
+
 These functions might not correctly handle unusual use cases or errors, and they
 could have poor performance. Updates to the TimescaleDB extension drop database
-objects that depend on experimental features like this function. If you use experimental
-toolkit functions on Timescale Cloud, this function is automatically dropped when the
-Toolkit extension is updated. For more information, [see the TimescaleDB Toolkit docs][toolkit-docs].
+objects that depend on experimental features like this function. If you use
+experimental toolkit functions on Timescale Cloud, this function is
+automatically dropped when the Toolkit extension is updated. For more
+information, [see the TimescaleDB Toolkit docs][toolkit-docs].
 
 [tsl-comparison]: /about/:currentVersion:/timescaledb-editions/
 [toolkit-install]: /self-hosted/:currentVersion:/tooling/install-toolkit/

--- a/self-hosted/tooling/install-toolkit.md
+++ b/self-hosted/tooling/install-toolkit.md
@@ -58,8 +58,9 @@ For more information on running TimescaleDB using Docker, see the section on
 
 ### Install Toolkit on CentOS 7 and other Red Hat-based systems
 
-These instructions use the `yum` package manager. They have been tested on CentOS 7
-and may also work on other Red Hat-based systems, such as Red Hat Enterprise Linux and Fedora.
+These instructions use the `yum` package manager. They have been tested on
+CentOS 7 and may also work on other Red Hat-based systems, such as Red Hat
+Enterprise Linux and Fedora.
 
 <Procedure>
 

--- a/self-hosted/tooling/install-toolkit.md
+++ b/self-hosted/tooling/install-toolkit.md
@@ -1,7 +1,7 @@
 ---
 title: Install and update TimescaleDB Toolkit
 excerpt: How to install TimescaleDB Toolkit to access more hyperfunctions and function pipelines
-products: [ mst, self_hosted]
+products: [mst, self_hosted]
 keywords: [Toolkit, installation, hyperfunctions, function pipelines]
 ---
 

--- a/self-hosted/upgrades/about-upgrades.md
+++ b/self-hosted/upgrades/about-upgrades.md
@@ -7,6 +7,8 @@ keywords: [upgrades]
 
 import PlanUpgrade from 'versionContent/_partials/_plan_upgrade.mdx';
 
+import ExperimentalUpgrade from "versionContent/_partials/_experimental-schema-upgrade.mdx";
+
 # About upgrades
 
 A major upgrade is when you upgrade from one major version of TimescaleDB, to
@@ -20,6 +22,8 @@ TimescaleDB&nbsp;2.6.
 If you originally installed TimescaleDB using Docker, you can upgrade from
 within the Docker container. For more information, and instructions, see the
 [Upgrading with Docker section][upgrade-docker].
+
+<ExperimentalUpgrade />
 
 ## Plan your upgrade
 

--- a/use-timescale/hyperfunctions/about-hyperfunctions.md
+++ b/use-timescale/hyperfunctions/about-hyperfunctions.md
@@ -7,6 +7,8 @@ keywords: [hyperfunctions, Toolkit, analytics]
 
 import Experimental from 'versionContent/_partials/_experimental.mdx';
 
+import ExperimentalUpgrade from "versionContent/_partials/_experimental-schema-upgrade.mdx";
+
 # About Timescale hyperfunctions
 
 Timescale hyperfunctions are a specialized set of functions that allow you to
@@ -31,11 +33,14 @@ marked 'experimental' are still under development.
 
 <Experimental />
 
+<ExperimentalUpgrade />
+
 <HyperfunctionTable
     includeExperimental
 />
 
-For more information about each of the API calls listed in this table, see our [hyperfunction API documentation][api-hyperfunctions].
+For more information about each of the API calls listed in this table, see the
+[hyperfunction API documentation][api-hyperfunctions].
 
 ## Function pipelines
 


### PR DESCRIPTION
# Description

Adds a partial about what happens to the experimental schema on upgrade, and adds it to both the self-hosted upgrading section, and the API tag overview (which seems to be the only location in the docs where we actively describe what the experimental schema is).

# Links

Fixes https://github.com/timescale/docs/issues/2107

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
