### PR TITLE
Add pre-req info about datatypes

### DIFF
--- a/use-timescale/ingest-data/import-csv.md
+++ b/use-timescale/ingest-data/import-csv.md
@@ -11,10 +11,24 @@ tags: [import, csv]
 If you have data stored in an external `.csv` file, you can import it into
 Timescale.
 
+<Highlight type="note">
+You can use the Timescale
+[parallel copy](https://github.com/timescale/timescaledb-parallel-copy)
+tool to speed up data copying. The tool parallelizes migration by using several
+workers to run multiple `COPY` operations concurrently. It also offers options
+to improve the copying experience. If you prefer not to use
+`timescaledb-parallel-copy`, you can also use regular PostgreSQL `COPY`. This
+section provides instructions for both methods.
+</Highlight>
+
 ## Prerequisites
 
-Before you start, make sure you have signed up for your
-[free Timescale account][install].
+Before you start, make sure you have:
+
+*   Signed up for your [free Timescale account][install].
+*   Checked that your source data uses a schema that matches the database you
+    want to import it into.
+*   Ensure the `time` column in your source data uses the `TIMESTAMPTZ` data type.
 
 ## Import data
 
@@ -23,15 +37,6 @@ Import data from a `csv`.
 <Procedure>
 
 ### Importing data
-
-<Highlight type="note">
-Timescale provides an open source
-[parallel importer](https://github.com/timescale/Timescale-parallel-copy) program,
-`Timescale-parallel-copy`, to speed up data copying. The program parallelizes
-migration by using several workers to run multiple `COPY`s concurrently. It also
-offers options to improve the copying experience. If you prefer not to download
-`timescaledb-parallel-copy`, you can also use regular PostgreSQL `COPY`.
-</Highlight>
 
 1.  Connect to your database and create a new empty table. Use a schema that
     matches the data in your `.csv` file. In this example, the `.csv` file

--- a/use-timescale/ingest-data/import-csv.md
+++ b/use-timescale/ingest-data/import-csv.md
@@ -28,7 +28,7 @@ Before you start, make sure you have:
 *   Signed up for your [free Timescale account][install].
 *   Checked that your source data uses a schema that matches the database you
     want to import it into.
-*   Ensure the `time` column in your source data uses the `TIMESTAMPTZ` data type.
+*   Ensured that the `time` column in the source data uses the `TIMESTAMPTZ` data type.
 
 ## Import data
 


### PR DESCRIPTION
# Description

Also moves the admon about parallel copy up to the top of the page, and fixes the broken URL. I considered adding info about sqllite, then decided against it and added generic info about the datatypes to pre-reqs instead.

# Links

Fixes https://github.com/timescale/docs/issues/2073

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
