### PR TITLE
Remove tutorials containing dead links

### DIFF
--- a/tutorials/OLD_nyc-taxi-cab.md
+++ b/tutorials/OLD_nyc-taxi-cab.md
@@ -87,7 +87,11 @@ This download contains two files:
 
 You can download the files from the below link:
 
-<Tag type="download">[nyc_data.tar.gz](https://timescaledata.blob.core.windows.net/datasets/nyc_data.tar.gz)</Tag>
+<!--- This link no longer works, deleted. LKB 2023-05-10
+
+<Tag type="download">[nyc_data.tar.gz]()</Tag>
+
+-->
 
 #### Get connected to TimescaleDB
 

--- a/tutorials/OLD_sample-datasets.md
+++ b/tutorials/OLD_sample-datasets.md
@@ -17,9 +17,13 @@ you are importing them to has already been [set up with the TimescaleDB extensio
 **Device ops**: these datasets include metrics such as CPU, memory, and network,
 that are collected from mobile devices. Click on the name to download.
 
-*   <Tag type="download" >[devices_small](https://assets.timescale.com/docs/downloads/devices_small.tar.gz)</Tag> 1,000 devices recorded over 1,000 time intervals - 39&nbsp;MB
-*   <Tag type="download" >[devices_med](https://timescaledata.blob.core.windows.net/datasets/devices_med.tar.gz)</Tag> 5,000 devices recorded over 2,000 time intervals - 390&nbsp;MB
-*   <Tag type="download" >[devices_big](https://timescaledata.blob.core.windows.net/datasets/devices_big.tar.gz)</Tag> 3,000 devices recorded over 10,000 time intervals - 1.2&nbsp;GB
+<!--- These links no longer work, deleted. LKB 2023-05-10
+
+*   <Tag type="download" >[devices_small]()</Tag> 1,000 devices recorded over 1,000 time intervals - 39&nbsp;MB
+*   <Tag type="download" >[devices_med]()</Tag> 5,000 devices recorded over 2,000 time intervals - 390&nbsp;MB
+*   <Tag type="download" >[devices_big]()</Tag> 3,000 devices recorded over 10,000 time intervals - 1.2&nbsp;GB
+
+-->
 
 For more details and example usage, see
 [device ops datasets](#device-ops-datasets).
@@ -27,12 +31,16 @@ For more details and example usage, see
 **Weather**: these datasets include metrics like temperature and humidity data
 from a variety of locations. Click on the name to download.
 
-*   <Tag type="download" >[weather_small](https://assets.timescale.com/docs/downloads/weather_small.tar.gz)</Tag>
+<!--- These links no longer work, deleted. LKB 2023-05-10
+
+*   <Tag type="download" >[weather_small]()</Tag>
     1,000 locations over 1,000 two-minute intervals - 8.1&nbsp;MB
-*   <Tag type="download" >[weather_med](https://timescaledata.blob.core.windows.net/datasets/weather_med.tar.gz)</Tag>
+*   <Tag type="download" >[weather_med]()</Tag>
     1,000 locations over 15,000 two-minute intervals - 115&nbsp;MB
-*   <Tag type="download" >[weather_big](https://assets.timescale.com/docs/downloads/weather_big.tar.gz)</Tag>
+*   <Tag type="download" >[weather_big]()</Tag>
     2,000 locations over 20,000 two-minute intervals - 305&nbsp;MB
+
+-->
 
 For more details and example usage, see [weather datasets](#weather-datasets).
 

--- a/tutorials/OLD_telegraf-output-plugin.md
+++ b/tutorials/OLD_telegraf-output-plugin.md
@@ -40,9 +40,13 @@ the different plugins must be part of that binary. Timescale have an unofficial
 build of Telegraf version 1.13.0 with the plugin added, that you can download
 from:
 
-*   Linux amd64: <Tag type="download">[deb](https://telegrafreleases.blob.core.windows.net/linux/telegraf_1.13.0~with~pg-1_amd64.deb)</Tag> <Tag type="download">[rpm](https://telegrafreleases.blob.core.windows.net/linux/telegraf-1.13.0~with~pg-1.x86_64.rpm)</Tag> <Tag type="download">[binary](https://telegrafreleases.blob.core.windows.net/linux/telegraf)</Tag>
-*   Windows amd64: <Tag type="download">[binary/exe](https://telegrafreleases.blob.core.windows.net/windows/telegraf.exe)</Tag>
-*   MacOS amd64: <Tag type="download">[binary](https://telegrafreleases.blob.core.windows.net/macos/telegraf)</Tag>
+<!--- These links no longer work, deleted. LKB 2023-05-10
+
+*   Linux amd64: <Tag type="download">[deb]()</Tag> <Tag type="download">[rpm]()</Tag> <Tag type="download">[binary]()</Tag>
+*   Windows amd64: <Tag type="download">[binary/exe]()</Tag>
+*   MacOS amd64: <Tag type="download">[binary]()</Tag>
+
+-->
 
 Timescale also provide you with builds for:
 
@@ -225,7 +229,7 @@ core with `SELECT cpu, avg(usage_user) FROM cpu GROUP BY cpu`. The output should
 look like this:
 
 ```sql
-    cpu    |       avg        
+    cpu    |       avg
 -----------+------------------
  cpu-total | 8.46385703620795
  cpu0      | 12.4343351351033
@@ -263,20 +267,20 @@ After a while you can check on the `cpu` table in the database, like this:
 psql> \dS cpu
 \dS cpu;
 Table "public.cpu"
-      Column      |           Type           
+      Column      |           Type
 ------------------+--------------------------
  time             | timestamp with time zone
- cpu              | text                     
- host             | text                     
- usage_steal      | double precision         
- usage_iowait     | double precision         
- usage_guest      | double precision         
- usage_idle       | double precision         
- usage_softirq    | double precision         
- usage_system     | double precision         
- usage_user       | double precision         
- usage_irq        | double precision         
- location         | text                     
+ cpu              | text
+ host             | text
+ usage_steal      | double precision
+ usage_iowait     | double precision
+ usage_guest      | double precision
+ usage_idle       | double precision
+ usage_softirq    | double precision
+ usage_system     | double precision
+ usage_user       | double precision
+ usage_irq        | double precision
+ location         | text
  ```
 
  You can see the `location` column is added and it contains `New York` for all
@@ -317,18 +321,18 @@ database:
 psql> \dS cpu
 \dS cpu
 Table "public.cpu"
-      Column      |           Type           
+      Column      |           Type
 ------------------+--------------------------
  time             | timestamp with time zone
- tag_id           | integer                  
- usage_irq        | double precision         
- usage_softirq    | double precision         
- usage_system     | double precision         
- usage_iowait     | double precision         
- usage_guest      | double precision         
- usage_user       | double precision         
- usage_idle       | double precision         
- usage_steal      | double precision         
+ tag_id           | integer
+ usage_irq        | double precision
+ usage_softirq    | double precision
+ usage_system     | double precision
+ usage_iowait     | double precision
+ usage_guest      | double precision
+ usage_user       | double precision
+ usage_idle       | double precision
+ usage_steal      | double precision
 ```
 
 Now the `cpu`, `host` and `location` columns are not there, instead there's a `tag_id` column. The tag sets are stored in a separate table called `cpu_tag`:
@@ -367,7 +371,7 @@ telegraf --config telegraf.conf
 
 ```sql
  psql> SELECT * FROM cpu_tag;
- tag_id |                                       tags                                        
+ tag_id |                                       tags
 --------+-----------------------------------------------------------------------------------
       1 | {"cpu": "cpu-total", "host": "local", "location": "New York"}
       2 | {"cpu": "cpu0", "host": "local", "location": "New York"}

--- a/tutorials/analyze-nft-data/index.md
+++ b/tutorials/analyze-nft-data/index.md
@@ -71,7 +71,7 @@ You can see all NFTs in the Time Travel Tigers collection live on [OpenSea][eon-
 [nft-form]: https://docs.google.com/forms/d/e/1FAIpQLSdZMzES-vK8K_pJl1n7HWWe5-v6D9A03QV6rys18woGTZr0Yw/viewform?usp=sf_link
 [nft-schema]: /tutorials/:currentVersion:/analyze-nft-data/nft-schema-ingestion
 [nft-wiki]: https://en.wikipedia.org/wiki/Non-fungible_token
-[opensea-key]: https://docs.opensea.io/reference/request-an-api-key
+[opensea-key]: https://docs.opensea.io/reference/api-keys
 [opensea]: https://opensea.io/
 [starter-kit]: https://github.com/timescale/nft-starter-kit
 [superset]: https://superset.apache.org

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -11,6 +11,9 @@ started with *TimescaleDB*.
 
 Most of these tutorials require a working [installation of TimescaleDB][install-timescale].
 
+<!--- Removing these, as they are no longer current, and we'll need to rewrite
+this index entirely anyway. LKB 2023-05-10
+
 ### Common scenarios for using TimescaleDB
 
 *   **[Introduction to TimescaleDB][nyc-taxi]**: The tried and true tutorial for learning TimescaleDB.
@@ -48,6 +51,8 @@ on PostgreSQL or TimescaleDB.
 *   **[psql installation][psql]**: `psql` is a terminal-based front-end for PostgreSQL.
 Learn how to install `psql` on Mac, Ubuntu, Debian, Windows,
 and pick up some valuable `psql` tips and tricks along the way.
+
+-->
 
 [Crypto]: /tutorials/:currentVersion:/analyze-cryptocurrency-data
 [Forecasting]: /tutorials/:currentVersion:/time-series-forecast

--- a/tutorials/page-index/page-index.js
+++ b/tutorials/page-index/page-index.js
@@ -157,11 +157,6 @@ module.exports = [
         excerpt: "Monitor a Django application with Prometheus",
       },
       {
-        title: "Collect metrics with Telegraf",
-        href: "telegraf-output-plugin",
-        excerpt: "Collect metrics with Telegraf",
-      },
-      {
         title: "Grafana",
         href: "grafana",
         excerpt: "Getting Started with Grafana and TimescaleDB",
@@ -283,11 +278,6 @@ module.exports = [
               "Create a continuous deployment between GitHub and AWS Lambda",
           },
         ],
-      },
-      {
-        title: "Sample datasets",
-        href: "sample-datasets",
-        excerpt: "Sample datasets for Tableau and TimescaleDB",
       },
     ],
   },


### PR DESCRIPTION
# Description

This removes the tutorials that contain links to the content that is no longer accessible. Content is still in the repo, just renamed and removed from the nav (in case we decide to resurrect them). It also (as a drive-by) updates the link to the OpenSea API key, which appears to have been moved in the OpenSea docs.

With any luck, this will mean the link checker stops failing now 🤞 

# Links

- Fixes: https://github.com/timescale/docs/issues/2352
- Partial: https://github.com/timescale/docs/pull/2353

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
