### PR TITLE
Remove MST sign up links

### DIFF
--- a/_partials/_cloud-mst-comparison.md
+++ b/_partials/_cloud-mst-comparison.md
@@ -6,6 +6,8 @@ If your workload lives in AWS, use
 [Timescale Cloud](/getting-started/latest/),
 built and exclusively operated by Timescale, designed to offer maximum
 cost-effectiveness and performance for time-series data. If you need Azure or
-GCP, try
-[Managed Service for TimescaleDB](/mst/latest/) instead.
+GCP, contact
+[Timescale support](https://www.timescale.com/support/) about
+[Managed Service for TimescaleDB](/mst/latest/)
+instead.
 </Highlight>

--- a/_partials/_mst-intro.md
+++ b/_partials/_mst-intro.md
@@ -1,5 +1,3 @@
-To serve Timescale deployments in Azure, GCP, and certain regions in AWS,
-we've partnered with the vendor Aiven to offer Managed Service for Timescale.
-This is a managed database platform through which you'll be able to deploy
-Timescale instances with ease, automating operational tasks like scaling,
-resizing, configuring high availability, and much more.
+Managed Service for TimescaleDB is a managed database-as-a-service product for
+accessing hosted TimescaleDB in Azure or Google Cloud Platform. Managed Service
+for TimescaleDB is offered in partnership with Timescale and Aiven.

--- a/mst/about-mst.md
+++ b/mst/about-mst.md
@@ -17,9 +17,6 @@ import CloudMSTComparison from "versionContent/_partials/_cloud-mst-comparison.m
 Your Managed Service for TimescaleDB account has three main components:
 projects, services, and databases.
 
-Before you begin, make sure you have
-[signed up to Managed Service for TimescaleDB][sign-up] and created your account.
-
 ## Projects
 
 When you sign up for Managed Service for TimescaleDB, an empty project is
@@ -281,7 +278,6 @@ SET statement_timeout = <milliseconds>
 ```
 
 [mst-install]: /mst/:currentVersion:/installation-mst/
-[sign-up]: https://www.timescale.com/cloud-signup
 [timescale-support]: https://www.timescale.com/support
 [aiven-sla]: https://aiven.io/sla
 [pg-keepalive]: http://www.postgresql.org/docs/9.5/static/libpq-connect.html#LIBPQ-KEEPALIVES

--- a/mst/installation-mst.md
+++ b/mst/installation-mst.md
@@ -17,30 +17,6 @@ import CloudMSTComparison from "versionContent/_partials/_cloud-mst-comparison.m
 
 <CloudMSTComparison />
 
-<Procedure>
-
-## Sign in to Managed Service for TimescaleDB
-
-1.  Sign up for a [Managed Service for TimescaleDB account][sign-up] with your
-    name and email address. You do not need to provide payment details to
-    get started. A confirmation email is sent to the email address you provide.
-1.  Verify your email by clicking on the link in the email you received. Don't
-    forget to check your spam folder in case the email ends up there.
-1.  Sign in to your [Managed Service for TimescaleDB portal][mst-login] with the
-    password you set:
-
-    <img class="main-content__illustration"
-    src="https://s3.amazonaws.com/assets.timescale.com/docs/images/mst-portal-noservices.png"
-    alt="Managed Service for TimescaleDB Portal"/>
-
-<Highlight type="important">
-Your Managed Service for TimescaleDB trial includes up to US$300 credit for you
-to use. This is enough to complete all our tutorials and run a few test projects
-of your own.
-</Highlight>
-
-</Procedure>
-
 ## Create your first service
 
 A service in Managed Service for TimescaleDB is a cloud instance on your chosen
@@ -68,12 +44,6 @@ cloud provider, which you can install your database on.
     takes a few minutes to provision.
 
     <img class="main-content__illustration" src="https://s3.amazonaws.com/assets.timescale.com/docs/images/mst-new-service.png" alt="Create a new service in the Managed Service for TimescaleDB portal"/>
-
-<Highlight type="important">
-Your Managed Service for TimescaleDB trial includes up to US$300 credit for you
-to use. This is enough to complete all our tutorials and run a few test projects
-of your own.
-</Highlight>
 
 </Procedure>
 
@@ -153,5 +123,4 @@ if you want to have a chat.
 [install-psql]: /use-timescale/:currentVersion:/connecting/psql/
 [mst-docs]: /mst/:currentVersion:/
 [mst-login]: https://portal.managed.timescale.com
-[sign-up]: https://www.timescale.com/timescale-signup
 [tutorials]: /tutorials/:currentVersion:/


### PR DESCRIPTION
# Description

Removes the remaining MST sign up links. Also re-words the MST intro and MST/Cloud comparison partials to use the new Project Timberlake wording.

# Links

- Built off: https://github.com/timescale/docs/pull/2356
- Fixes: https://github.com/timescale/docs-private/issues/122

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
