### PR TITLE
add create service info to services section

### DIFF
--- a/_partials/_cloud-installation.md
+++ b/_partials/_cloud-installation.md
@@ -5,7 +5,7 @@
 1.  Sign up for a [Timescale account][sign-up] with your
     name and email address. You do not need to provide payment details to
     get started. A confirmation email is sent to the email address you provide.
-1.  Verify your email by clicking on the link in the email you received. Don't
+1.  Verify your email by clicking the link in the email you received. Don't
     forget to check your spam folder in case the email ends up there.
 1.  Sign in to the [Timescale portal][tsc-portal] with the
     password you set:

--- a/_partials/_cloud-installation.md
+++ b/_partials/_cloud-installation.md
@@ -5,9 +5,9 @@
 1.  Sign up for a [Timescale account][sign-up] with your
     name and email address. You do not need to provide payment details to
     get started. A confirmation email is sent to the email address you provide.
-2.  Verify your email by clicking on the link in the email you received. Don't
+1.  Verify your email by clicking on the link in the email you received. Don't
     forget to check your spam folder in case the email ends up there.
-3.  Sign in to the [Timescale portal][tsc-portal] with the
+1.  Sign in to the [Timescale portal][tsc-portal] with the
     password you set:
     <img
       class="main-content__illustration"

--- a/_troubleshooting/cloud-singledb.md
+++ b/_troubleshooting/cloud-singledb.md
@@ -1,0 +1,32 @@
+---
+title: Cannot add column to a compressed hypertable
+section: troubleshooting
+products: [cloud, mst, self_hosted]
+topics: [services]
+errors:
+  - language: text
+    message: |-
+      ERROR:  tsdb_admin: database <DB_NAME> is not an allowed database name
+      HINT:  Contact your administrator to configure the "tsdb_admin.allowed_databases"
+
+apis:
+
+keywords: [services]
+tags: [services]
+---
+
+<!---
+* Use this format for writing troubleshooting sections:
+ - Cause: What causes the problem?
+ - Consequence: What does the user see when they hit this problem?
+ - Fix/Workaround: What can the user do to fix or work around the problem?
+   Provide a "Resolving" Procedure if required.
+ - Result: When the user applies the fix, what is the result when the same
+   action is applied?
+* Copy this comment at the top of every troubleshooting page
+-->
+
+Each Timescale service can have a single database. The database must be
+named `tsdb`. If you try to create an additional database you receive this error.
+
+If you need another database, you need to create a new service.

--- a/use-timescale/page-index/page-index.js
+++ b/use-timescale/page-index/page-index.js
@@ -38,6 +38,11 @@ module.exports = [
             excerpt:
               "Timescale services operations, Service management tab",
           },
+          {
+            title: "Troubleshooting Timescale services",
+            href: "troubleshooting",
+            type: "placeholder",
+          },
         ],
       },
       {

--- a/use-timescale/services/create-a-service.md
+++ b/use-timescale/services/create-a-service.md
@@ -10,26 +10,29 @@ cloud_ui:
 ---
 
 import WhereTonext from "versionContent/_partials/_where-to-next.mdx";
+import Install from "versionContent/_partials/_cloud-installation.mdx";
+import CreateService from "versionContent/_partials/_cloud-create-service.mdx";
+import Connect from "versionContent/_partials/_cloud-connect.mdx";
+import CloudTrial from "versionContent/_partials/_cloudtrial.mdx";
+import CloudIntro from "versionContent/_partials/_cloud-intro.mdx";
 
 # Create a Timescale service
 
-Timescale is a hosted, cloud-native Timescale service that allows you to
-quickly spin up new Timescale instances. You can
-[try Timescale for free][sign-up], no credit card required.
+<CloudIntro />
 
-For installation instructions, and help getting your first service up and
-running, see the [Timescale installation section][cloud-install].
+<CloudTrial />
 
-Each Timescale service can have a single database. The database must be
-named `tsdb`. If you try to create an additional database you receive an error
-like this:
+## Create your Timescale account
 
-```sql
-ERROR:  tsdb_admin: database <DB_NAME> is not an allowed database name
-HINT:  Contact your administrator to configure the "tsdb_admin.allowed_databases"
-```
+<Install />
 
-If you need another database, you need to create a new service.
+## Create your first service
+
+<CreateService demoData={false} />
+
+## Connect to your service
+
+<Connect />
 
 ## Where to next
 


### PR DESCRIPTION
# Description

The services section used to point to the GSG for initial service creation instructions. Because the GSG is being reworked (in #2372), this adds that info to the services section directly.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
