### PR TITLE
Fix(typo) in use-time-buckets.md

### DIFF
--- a/use-timescale/time-buckets/use-time-buckets.md
+++ b/use-timescale/time-buckets/use-time-buckets.md
@@ -46,7 +46,7 @@ By default, the `time_bucket` column shows the start time of the bucket. If you
 prefer to show the end time, you can shift the displayed time using a
 mathematical operation on `time`.
 
-For example, you cna calculate the minimum and maximum CPU usage for 5-minute
+For example, you can calculate the minimum and maximum CPU usage for 5-minute
 intervals, and show the end of time of the interval. The example table is named
 `metrics`. It has a time column named `time` and a CPU usage column named `cpu`:
 


### PR DESCRIPTION
# Description

Fixes typo 'cna' inside `use-timescale/time-buckets/use-time-buckets.md`

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
