### PR TITLE
Untiering is now a synchronous operation

### DIFF
--- a/use-timescale/data-tiering/untier-data.md
+++ b/use-timescale/data-tiering/untier-data.md
@@ -23,13 +23,9 @@ in a chunk using the `untier_chunk` stored procedure.
 
 ## Untier data in a chunk
 
-Untiering chunks is an asynchronous process. When you untier a chunk, the data
-is moved from S3 storage to EBS storage. This process occurs in the background.
-The chunk remains available for queries during the migration to EBS.
-
-<Highlight type="note">
-Chunks are sometimes renamed when you untier your data.
-</Highlight>
+Untiering chunks is a synchronous process and will occur when the `untier_chunk` procedure is called. 
+When you untier a chunk, the data is moved from S3 storage to EBS storage.  
+Chunks will be  renamed when you untier your data.
 
 <Procedure>
 

--- a/use-timescale/data-tiering/untier-data.md
+++ b/use-timescale/data-tiering/untier-data.md
@@ -23,9 +23,9 @@ in a chunk using the `untier_chunk` stored procedure.
 
 ## Untier data in a chunk
 
-Untiering chunks is a synchronous process and will occur when the `untier_chunk` procedure is called. 
+Untiering chunks is a synchronous process that occurs when the `untier_chunk` procedure is called. 
 When you untier a chunk, the data is moved from S3 storage to EBS storage.  
-Chunks will be  renamed when you untier your data.
+Chunks are renamed when the data is untiered.
 
 <Procedure>
 


### PR DESCRIPTION
# Description

Untiering is now synchronous when `untier_chunk` is called. Updating the docs to remove reference to untiering being asyncronous. 

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
