### PR TITLE
feat: add frontmatter for curricular content

### DIFF
--- a/getting-started/add-data.md
+++ b/getting-started/add-data.md
@@ -4,6 +4,8 @@ excerpt: Add time-series data to your Timescale instance
 products: [cloud, mst, self_hosted]
 keywords: [ingest]
 tags: [add, data, time-series]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 import HypershiftAlt from "versionContent/_partials/_hypershift-alternatively.mdx";

--- a/getting-started/compress-data.md
+++ b/getting-started/compress-data.md
@@ -3,6 +3,8 @@ title: Compression
 excerpt: Use Timescale's native compression to save on storage
 products: [cloud, mst, self_hosted]
 keywords: [compression]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 # Compression

--- a/getting-started/create-cagg/create-cagg-basics.md
+++ b/getting-started/create-cagg/create-cagg-basics.md
@@ -3,6 +3,8 @@ title: Creating continuous aggregates
 excerpt: Create a continuous aggregate from your data
 products: [cloud, mst, self_hosted]
 keywords: [continuous aggregates, create]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 # Creating continuous aggregates

--- a/getting-started/create-cagg/create-cagg-policy.md
+++ b/getting-started/create-cagg/create-cagg-policy.md
@@ -3,6 +3,8 @@ title: Using and setting up continuous aggregate policies
 excerpt: Set a policy to refresh your continuous aggregates automatically
 products: [cloud, mst, self_hosted]
 keywords: [continuous aggregates, policies]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 # Using and setting up continuous aggregate policies

--- a/getting-started/create-cagg/index.md
+++ b/getting-started/create-cagg/index.md
@@ -3,6 +3,8 @@ title: Create a continuous aggregate
 excerpt: Learn how to speed up queries with continuous aggregates
 products: [cloud, mst, self_hosted]
 keywords: [continuous aggregates, create]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 # Create a continuous aggregate

--- a/getting-started/create-hypertable.md
+++ b/getting-started/create-hypertable.md
@@ -3,6 +3,8 @@ title: Create a hypertable
 excerpt: Create a hypertable to store your time-series data
 products: [cloud, mst, self_hosted]
 keywords: [hypertables, create]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 import HypertableIntro from "versionContent/_partials/_hypertables-intro.mdx";

--- a/getting-started/data-retention.md
+++ b/getting-started/data-retention.md
@@ -3,6 +3,8 @@ title: Create a data retention policy
 excerpt: Automatically drop historical data with a data retention policy
 products: [cloud, mst, self_hosted]
 keywords: [data retention, policies, create]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 # Create a data retention policy

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -2,6 +2,8 @@
 title: Get started with Timescale
 excerpt: Get started with your first Timescale instance
 products: [cloud]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 import Install from "versionContent/_partials/_cloud-installation.mdx";

--- a/getting-started/next-steps.md
+++ b/getting-started/next-steps.md
@@ -3,6 +3,8 @@ title: Next steps
 excerpt: Continue exploring Timescale
 products: [cloud, mst, self_hosted]
 keywords: [data migration, ingest, visualize, connect]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 # Next steps

--- a/getting-started/query-data.md
+++ b/getting-started/query-data.md
@@ -3,6 +3,8 @@ title: Query your data
 excerpt: Query your Timescale data with the full power of SQL
 products: [cloud, mst, self_hosted]
 keywords: [queries]
+layout_components: [next_prev_large]
+content_group: Getting started
 ---
 
 # Query your data

--- a/tutorials/analyze-bitcoin-blockchain/analyze-blockchain.md
+++ b/tutorials/analyze-bitcoin-blockchain/analyze-blockchain.md
@@ -3,6 +3,8 @@ title: Analyze the blockchain with hyperfunctions
 excerpt: Use SQL functions and hyperfunctions to analyze Bitcoin transactions
 products: [cloud, mst, self_hosted]
 keywords: [crypto, blockchain, Bitcoin, finance, analytics]
+layout_components: [next_prev_large]
+content_group: Analyze the Bitcoin blockchain
 ---
 
 # Analyze the blockchain with hyperfunctions

--- a/tutorials/analyze-bitcoin-blockchain/index.md
+++ b/tutorials/analyze-bitcoin-blockchain/index.md
@@ -3,6 +3,8 @@ title: Analyze the Bitcoin blockchain
 excerpt: Learn how to store and analyze your Bitcoin blockchain data to uncover trends
 products: [cloud, mst, self_hosted]
 keywords: [crypto, blockchain, Bitcoin, finance, analytics]
+layout_components: [next_prev_large]
+content_group: Analyze the Bitcoin blockchain
 ---
 
 # Analyze the Bitcoin blockchain

--- a/tutorials/analyze-bitcoin-blockchain/ingest-query-btc-transactions.md
+++ b/tutorials/analyze-bitcoin-blockchain/ingest-query-btc-transactions.md
@@ -3,6 +3,8 @@ title: Insert and query Bitcoin transactions
 excerpt: Ingest and store Bitcoin blockchain data in your database
 products: [cloud, mst, self_hosted]
 keywords: [crypto, blockchain, Bitcoin, finance, analytics]
+layout_components: [next_prev_large]
+content_group: Analyze the Bitcoin blockchain
 ---
 
 # Insert and query Bitcoin transactions

--- a/tutorials/analyze-nft-data/analyzing-nft-transactions.md
+++ b/tutorials/analyze-nft-data/analyzing-nft-transactions.md
@@ -4,6 +4,8 @@ excerpt: Analyze NFT transactions from the OpenSea marketplace
 products: [cloud, mst, self_hosted]
 keywords: [crypto, blockchain, finance, analytics]
 tags: [nft]
+layout_components: [next_prev_large]
+content_group: Analyze NFT data
 ---
 
 # Analyzing NFT transactions

--- a/tutorials/analyze-nft-data/index.md
+++ b/tutorials/analyze-nft-data/index.md
@@ -4,6 +4,8 @@ excerpt: Learn how to collect, store, and analyze NFT sales data from the larges
 products: [cloud, mst, self_hosted]
 keywords: [crypto, blockchain, finance, analytics]
 tags: [nft]
+layout_components: [next_prev_large]
+content_group: Analyze NFT data
 ---
 
 # Analyze non-fungible token (NFT) sales data

--- a/tutorials/analyze-nft-data/nft-schema-ingestion.md
+++ b/tutorials/analyze-nft-data/nft-schema-ingestion.md
@@ -4,6 +4,8 @@ excerpt: Design a schema to ingest and store NFT transaction data
 products: [cloud, mst, self_hosted]
 keywords: [crypto, blockchain, finance, analytics]
 tags: [nft]
+layout_components: [next_prev_large]
+content_group: Analyze NFT data
 ---
 
 # NFT schema design and ingestion

--- a/tutorials/financial-tick-data/financial-tick-dataset.md
+++ b/tutorials/financial-tick-data/financial-tick-dataset.md
@@ -4,6 +4,8 @@ excerpt: Set up a dataset so you can query financial tick data to analyze price 
 products: [cloud, mst, self_hosted]
 keywords: [tutorials, finance, learn]
 tags: [tutorials, beginner]
+layout_components: [next_prev_large]
+content_group: Analyze financial tick data
 ---
 
 import Install from "versionContent/_partials/_cloud-installation.mdx";

--- a/tutorials/financial-tick-data/financial-tick-query.md
+++ b/tutorials/financial-tick-data/financial-tick-query.md
@@ -4,6 +4,8 @@ excerpt: Create candlestick views and query financial tick data to analyze price
 products: [cloud, mst, self_hosted]
 keywords: [tutorials, finance, learn]
 tags: [tutorials, beginner]
+layout_components: [next_prev_large]
+content_group: Analyze financial tick data
 ---
 
 # Query the data

--- a/tutorials/financial-tick-data/index.md
+++ b/tutorials/financial-tick-data/index.md
@@ -4,6 +4,8 @@ excerpt: Learn how to store financial tick data and create candlestick views to 
 products: [cloud, mst, self_hosted]
 keywords: [tutorials, finance, learn]
 tags: [tutorials, beginner]
+layout_components: [next_prev_large]
+content_group: Analyze financial tick data
 ---
 
 # Analyze financial tick data with TimescaleDB

--- a/tutorials/nyc-taxi-cab/advanced-nyc.md
+++ b/tutorials/nyc-taxi-cab/advanced-nyc.md
@@ -4,6 +4,8 @@ excerpt: Extra things to try with time-series data
 products: [cloud, mst, self_hosted]
 keywords: [tutorials, advanced, query]
 tags: [tutorials, beginner]
+layout_components: [next_prev_large]
+content_group: Analyze NYC taxi cab data
 ---
 
 # Advanced steps

--- a/tutorials/nyc-taxi-cab/dataset-nyc.md
+++ b/tutorials/nyc-taxi-cab/dataset-nyc.md
@@ -4,6 +4,8 @@ excerpt: Set up a dataset so you can query time-series data
 products: [cloud, mst, self_hosted]
 keywords: [tutorials, create, dataset]
 tags: [tutorials, beginner]
+layout_components: [next_prev_large]
+content_group: Analyze NYC taxi cab data
 ---
 
 import Install from "versionContent/_partials/_cloud-installation.mdx";

--- a/tutorials/nyc-taxi-cab/index.md
+++ b/tutorials/nyc-taxi-cab/index.md
@@ -4,6 +4,8 @@ excerpt: Learn how to query time-series data
 products: [cloud, mst, self_hosted]
 keywords: [tutorials, query, learn]
 tags: [tutorials, beginner]
+layout_components: [next_prev_large]
+content_group: Analyze NYC taxi cab data
 ---
 
 # Analyze NYC taxi cab data

--- a/tutorials/nyc-taxi-cab/query-nyc.md
+++ b/tutorials/nyc-taxi-cab/query-nyc.md
@@ -4,6 +4,8 @@ excerpt: Query time-series data
 products: [cloud, mst, self_hosted]
 keywords: [tutorials, query]
 tags: [tutorials, beginner]
+layout_components: [next_prev_large]
+content_group: Analyze NYC taxi cab data
 ---
 
 # Query the data


### PR DESCRIPTION
Add frontmatter to group curricular content by tutorial, and to choose whether to use the highlighted next and previous buttons for those pages.

Related to https://github.com/timescale/web-documentation/pull/617
Related to https://github.com/timescale/docs-private/issues/100