### PR TITLE
Take request a lang note out of admonition

### DIFF
--- a/quick-start/index.md
+++ b/quick-start/index.md
@@ -5,18 +5,16 @@ excerpt: Get started with TimescaleDB and your favorite language
 
 # Language quick starts
 
-Here is a collection of quick starts for various programming languages.
-
-<Highlight type="warning">
-If you didn't find a quick start with your favorite language,
-feel free to [request one](https://forms.gle/tBc3qBMKRosdHrGG9).
-</Highlight>
+Here is a collection of quick starts for various programming languages:
 
 *   [Node][node-quickstart]
 *   [Python][python-quickstart]
 *   [Ruby on Rails][ruby-quickstart]
 *   [Golang][go-quickstart]
 *   [Java][java-quickstart]
+
+If you didn't find a quick start with your favorite language,
+feel free to [request one](https://forms.gle/tBc3qBMKRosdHrGG9).
 
 [go-quickstart]: /quick-start/:currentVersion:/golang
 [java-quickstart]: /quick-start/:currentVersion:/java


### PR DESCRIPTION
# Description

For some reason, the 'request a code quick start in your language' info was in a warning box. This moves it out of the admonition, and below the list.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
