### PR TITLE
ci: disable deploy action on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy docs to dev
 
-on: pull_request
+on:
+  - pull_request
+  - workflow_dispatch
 
 env:
   PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   trigger:
-    if: github.repository == 'timescale/docs'
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       pull-requests: write
     name: Docs dev deploy


### PR DESCRIPTION
Deploy on forks fails because it doesn't have access to the required secret.
However, it still attempts to run.
This PR restricts the deploy action to branches of the base repository.

# Description

[Short summary of why you created this PR]

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
