### PR TITLE
fix: link formatting in Highlight component

### DIFF
--- a/use-timescale/account-management.md
+++ b/use-timescale/account-management.md
@@ -17,7 +17,7 @@ can also update to a new credit card here.
 <Highlight type="important">
 If you prefer to pay by invoice, or if you are unable to provide a credit card
 for billing, you can switch your project to corporate billing instead. To switch
-from credit card to corporate billing, [contact us][contact] and ask to be
+from credit card to corporate billing, [contact us](https://www.timescale.com/contact/) and ask to be
 changed to corporate billing.
 </Highlight>
 


### PR DESCRIPTION
# Description

The Highlight component in the account management docs page had a markdown link inside of it, causing it to render incorrectly.

<details><summary>Screenshot</summary>
<img width="902" alt="Screenshot 2023-06-14 at 11 57 44 AM" src="https://github.com/timescale/docs/assets/74229895/2a9b2eeb-7441-4969-9c75-986d67b5b4b2">
</details>

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
