### PR TITLE
Remove early access admon from Data Tiering pages

### DIFF
--- a/use-timescale/data-tiering/about-data-tiering.md
+++ b/use-timescale/data-tiering/about-data-tiering.md
@@ -12,8 +12,6 @@ import ExperimentalPrivateBeta from 'versionContent/_partials/_early_access.mdx'
 
 Save on storage costs by tiering data to a low-cost object-storage layer.
 
-<ExperimentalPrivateBeta />
-
 Timescale includes traditional disk storage, and a low-cost object-storage
 layer built on Amazon S3. You can move your hypertable data across the different
 storage tiers to get the best price performance. You can use primary storage for
@@ -85,9 +83,9 @@ For more about how data tiering works, see the
     native data types, but not for non-native types, such as `JSON`, `JSONB`,
     and `GIS`.
 
-*   **Latency.** S3 has higher access latency than EBS however, S3 has 
-    comparatively greater throughput for large scans. This can affect the 
-    execution time of queries in latency-sensitive environments, especially 
+*   **Latency.** S3 has higher access latency than EBS however, S3 has
+    comparatively greater throughput for large scans. This can affect the
+    execution time of queries in latency-sensitive environments, especially
     lighter queries.
 
 ## Learn more

--- a/use-timescale/data-tiering/index.md
+++ b/use-timescale/data-tiering/index.md
@@ -12,8 +12,6 @@ import ExperimentalPrivateBeta from 'versionContent/_partials/_early_access.mdx'
 
 Save on storage costs by tiering data to a low-cost object-storage layer.
 
-<ExperimentalPrivateBeta />
-
 *   Learn [how data tiering works][about-data-tiering] before you start using it.
 *   [Tier data to object storage][tier-data]
 *   [Untier data][untier-data]

--- a/use-timescale/data-tiering/tier-data-object-storage.md
+++ b/use-timescale/data-tiering/tier-data-object-storage.md
@@ -15,8 +15,6 @@ Tier data from primary storage to object storage to save on storage costs. You
 can continue to query a hypertable as normal after migration. All queries,
 including `JOIN`s, work as usual.
 
-<ExperimentalPrivateBeta />
-
 ## Manually tier a chunk
 
 Move a single chunk to tiered S3 storage by calling the `tier_chunk` function

--- a/use-timescale/data-tiering/untier-data.md
+++ b/use-timescale/data-tiering/untier-data.md
@@ -16,12 +16,10 @@ be changed. To update data in a tiered chunk, you need to move it back to EBS
 (elastic block storage). This is called untiering the data. You can untier data
 in a chunk using the `untier_chunk` stored procedure.
 
-<ExperimentalPrivateBeta />
-
 ## Untier data in a chunk
 
-Untiering chunks is a synchronous process that occurs when the `untier_chunk` procedure is called. 
-When you untier a chunk, the data is moved from S3 storage to EBS storage.  
+Untiering chunks is a synchronous process that occurs when the `untier_chunk` procedure is called.
+When you untier a chunk, the data is moved from S3 storage to EBS storage.
 Chunks are renamed when the data is untiered.
 
 <Procedure>


### PR DESCRIPTION
# Description

Data tiering is no longer early access

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
