### PR TITLE
Add link to create_index and WITH docs to indexing

### DIFF
--- a/use-timescale/schema-management/indexing.md
+++ b/use-timescale/schema-management/indexing.md
@@ -77,7 +77,7 @@ time-series data uses `UNIQUE` indexes more rarely than relational data.
 
 If you do not want to create an index in a single transaction, you can use the
 [`CREATE_INDEX`][create-index]
-function. This uses a separate function top create an index on each chunk,
+function. This uses a separate function to create an index on each chunk,
 instead of a single transaction for the entire hypertable. This means that you
 can perform other actions on the table while the index is being created, rather
 than having to wait until index creation is complete.

--- a/use-timescale/schema-management/indexing.md
+++ b/use-timescale/schema-management/indexing.md
@@ -27,7 +27,8 @@ to a hypertable.
 Some indexes are created by default when you perform certain actions on your
 database.
 
-When you create a hypertable with the `create_hypertable` command, a time index
+When you create a hypertable with the
+[`create_hypertable`][create_hypertable] command, a time index
 is created on your data. If you want to manually create a time index, you can
 use this command:
 
@@ -74,5 +75,18 @@ a unique index must include at least the `(time, location)` columns, in addition
 to any other columns you want to use. Generally,
 time-series data uses `UNIQUE` indexes more rarely than relational data.
 
+If you do not want to create an index in a single transaction, you can use the [`CREATE_INDEX`][create-index]
+function. This uses a separate function top create an index on each chunk,
+instead of a single transaction for the entire hypertable. This means that you
+can perform other actions on the table while the index is being created, rather
+than having to wait until index creation is complete.
+
+<Highlight type="note">
+You can also use the
+[PostgreSQL `WITH` clause](https://www.postgresql.org/docs/current/queries-with.html)
+to perform indexing transactions on an individual chunk.
+</Highlight>
+
 [create_hypertable]: /api/:currentVersion:/hypertable/create_hypertable/
 [about-index]: /use-timescale/:currentVersion:/schema-management/about-indexing/
+[create-index]: https://docs.timescale.com/api/latest/hypertable/create_index/

--- a/use-timescale/schema-management/indexing.md
+++ b/use-timescale/schema-management/indexing.md
@@ -75,7 +75,8 @@ a unique index must include at least the `(time, location)` columns, in addition
 to any other columns you want to use. Generally,
 time-series data uses `UNIQUE` indexes more rarely than relational data.
 
-If you do not want to create an index in a single transaction, you can use the [`CREATE_INDEX`][create-index]
+If you do not want to create an index in a single transaction, you can use the
+[`CREATE_INDEX`][create-index]
 function. This uses a separate function top create an index on each chunk,
 instead of a single transaction for the entire hypertable. This means that you
 can perform other actions on the table while the index is being created, rather


### PR DESCRIPTION
# Description

Added a note to the Indexing best practices about creating indexes in a transaction for each chunk rather than a single transaction. This section links to the create_index API doc, and the WITH PG docs.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
