### PR TITLE
update pgdump restore and hypershift links

### DIFF
--- a/api/timescaledb_post_restore.md
+++ b/api/timescaledb_post_restore.md
@@ -11,14 +11,17 @@ api:
 
 # timescaledb_post_restore()
 
-Perform the proper operations after restoring the database has completed.
-Specifically this resets the `timescaledb.restoring` GUC and restarts any
-background workers. See [backup/restore docs][backup-restore] for more information.
+Perform the required operations after you have finished restoring the database
+using `pg_restore`. Specifically, this resets the `timescaledb.restoring` GUC
+and restarts any background workers. For more information, see the
+[backup and restore section][backup-restore].
 
-### Sample usage  
+## Sample usage
+
+Prepare the database for normal use after a restore:
 
 ```sql
 SELECT timescaledb_post_restore();
 ```
 
-[backup-restore]: /self-hosted/:currentVersion:/backup-and-restore/pg-dump-and-restore/
+[backup-restore]: /use-timescale/:currentVersion:/migration/pg-dump-and-restore/

--- a/api/timescaledb_pre_restore.md
+++ b/api/timescaledb_pre_restore.md
@@ -11,29 +11,28 @@ api:
 
 # timescaledb_pre_restore()
 
-Perform the proper operations to allow restoring of the database via `pg_restore` to commence.
-Specifically this sets the `timescaledb.restoring` GUC to `on` and stops any
-background workers which may have been performing tasks until the [`timescaledb_post_restore`][timescaledb_post_restore]
-function is run following the restore. See [backup/restore docs][backup-restore] for more information.
+Perform the required operations so that you can restore the database using
+`pg_restore`. Specifically, this sets the `timescaledb.restoring` GUC to `on`
+and stops any background workers which could have been performing tasks. The
+background workers are stopped until the
+[`timescaledb_post_restore`][timescaledb_post_restore]
+function is run, after the restore operation is complete.
 
-<Highlight type="warning">
- Using this function when doing an upgrade could cause issues in TimescaleDB
- versions before 1.7.1.
+For more information, see the [backup and restore section][backup-restore].
 
+<Highlight type="important">
+After using `timescaledb_pre_restore()`, you need to run
+[`timescaledb_post_restore`](/api/latest/administration/timescaledb_post_restore/)
+before you can use the database normally.
 </Highlight>
 
-<Highlight type="warning">
- After running `SELECT timescaledb_pre_restore()` you must run the
-  [`timescaledb_post_restore`](/api/latest/administration/timescaledb_post_restore/) function before using
-  the database normally.
+## Sample usage
 
-</Highlight>
-
-### Sample usage  
+Prepare to restore the database:
 
 ```sql
 SELECT timescaledb_pre_restore();
 ```
 
-[backup-restore]: /self-hosted/:currentVersion:/backup-and-restore/pg-dump-and-restore/
+[backup-restore]: /use-timescale/:currentVersion:/migration/pg-dump-and-restore/
 [timescaledb_post_restore]: /api/:currentVersion:/administration/timescaledb_post_restore/

--- a/self-hosted/backup-and-restore/index.md
+++ b/self-hosted/backup-and-restore/index.md
@@ -21,6 +21,6 @@ backup your self-hosted TimescaleDB database:
 
 <ConsiderCloud />
 
-[logical-backups]: /self-hosted/:currentVersion:/backup-and-restore/pg-dump-and-restore/
+[logical-backups]: /use-timescale/:currentVersion:/migration/pg-dump-and-restore/
 [ongoing-physical-backups]: /self-hosted/:currentVersion:/backup-and-restore/docker-and-wale/
 [physical-backups]: /self-hosted/:currentVersion:/backup-and-restore/physical/

--- a/use-timescale/migration/OLD_hypershift-content/OLD_about-hypershift.md
+++ b/use-timescale/migration/OLD_hypershift-content/OLD_about-hypershift.md
@@ -56,8 +56,7 @@ describes the various options.
 
 You can also provide configuration to hypershift using a YAML configuration
 file. For more information about constructing a hypershift configuration file,
-see the
-[hypershift configuration section][hypershift-config].
+see the hypershift configuration section.
 
 You can provide the source and target database URIs using either command line
 flags, or the configuration file. If the information is provided in both,
@@ -119,5 +118,3 @@ docker run -v $(pwd)/config.yaml:/config.yaml -ti timescale/hypershift:0.6 clone
 -s='host=localhost dbname=postgres port=5432 user=postgres password=source_password' \
 -t='host=localhost dbname=postgres port=5433 user=postgres password=target_password'
 ```
-
-[hypershift-config]: /use-timescale/:currentVersion:/migration/hypershift-config/

--- a/use-timescale/migration/OLD_hypershift-content/OLD_hypershift-config.md
+++ b/use-timescale/migration/OLD_hypershift-content/OLD_hypershift-config.md
@@ -58,7 +58,7 @@ database, the name of the database, the port the database can be accessed on,
 and username and password details to log in to the database. If you do not want
 to provide this information in the configuration file, you can provide these
 details on the command line instead. For more information, see the
-[hypershift command line options][hypershift-cli].
+hypershift command line options.
 
 Connection strings are in the format:
 
@@ -354,4 +354,3 @@ verbose: <boolean> # Default = false
 </Collapsible>
 
 [chunk-time]: /use-timescale/:currentVersion:/hypertables/about-hypertables#best-practices-for-time-partitioning
-[hypershift-cli]: /use-timescale/:currentVersion:/migration/about-hypershift#the-hypershift-command-line-tool

--- a/use-timescale/migration/OLD_hypershift-content/OLD_index.md
+++ b/use-timescale/migration/OLD_hypershift-content/OLD_index.md
@@ -13,9 +13,9 @@ using Timescale Hypershift. You can also use hypershift to migrate your data
 from Managed Service for TimescaleDB, from a self-hosted Timescale instance, or
 from another PostgreSQL database, including Amazon RDS.
 
-*   [Understand how hypershift works][about-hypershift] before you begin using it.
-*   [Migrate your data with hypershift][migrate-hypershift].
-*   [Configure hypershift][configure-hypershift].
+*   Understand how hypershift works before you begin using it.
+*   Migrate your data with hypershift.
+*   Configure hypershift.
 
 If you want to import data from another format, such as a `.csv` file, into a
 new Timescale service, see the [data ingest section][data-ingest].
@@ -29,6 +29,3 @@ the [Managed Service for TimescaleDB migration section][mst-migration].
 [data-ingest]: /use-timescale/:currentVersion:/ingest-data/
 [self-hosted-migration]: /self-hosted/:currentVersion:/migration/
 [mst-migration]: /mst/:currentVersion:/migrate-to-mst/
-[about-hypershift]: /use-timescale/:currentVersion:/migration/about-hypershift/
-[migrate-hypershift]: /use-timescale/:currentVersion:/migration/migrate-hypershift/
-[configure-hypershift]: /use-timescale/:currentVersion:/migration/hypershift-config/

--- a/use-timescale/migration/OLD_hypershift-content/OLD_migrate-hypershift.md
+++ b/use-timescale/migration/OLD_hypershift-content/OLD_migrate-hypershift.md
@@ -101,7 +101,7 @@ configuration file, see the
 
 1.  Open the `hypershift.yml` configuration file, and adjust parameters
     accordingly. For more information about creating a Hypershift configuration
-    file, see the [Hypershift configuration section][hypershift-config].
+    file, see the Hypershift configuration section.
 
 1.  At the command prompt, run the Hypershift container. Include the source and
     destination database passwords, and the path to your `hypershift.yml`
@@ -122,4 +122,3 @@ configuration file, see the
 
 [cloud-install]: /getting-started/latest/
 [docker-install]: https://docs.docker.com/get-docker/
-[hypershift-config]: /use-timescale/:currentVersion:/migration/hypershift-config/


### PR DESCRIPTION
# Description

* updated a couple of links that broke when we moved the pgdump/pgrestore content
* removed a few links from the old hypershift content
* light editing of a couple of very old api docs

# Links

Fixes https://github.com/timescale/docs/issues/2560

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
