### PR TITLE
Add back qstudio page

### DIFF
--- a/use-timescale/page-index/page-index.js
+++ b/use-timescale/page-index/page-index.js
@@ -792,6 +792,11 @@ module.exports = [
                   excerpt: "Install pgAdmin to connect to Timescale",
                 },
                 {
+                  title: "Connect using qStudio",
+                  href: "qstudio",
+                  excerpt: "Install qstudio to connect to Timescale",
+                },
+                {
                   title: "Troubleshooting Timescale connections",
                   href: "troubleshooting",
                   type: "placeholder",


### PR DESCRIPTION
# Description

Looks like we lost qstudio from the nav when we did the reorg on Use Timescale. This should solve the problem.

# Links

Fixes https://github.com/timescale/docs/issues/2605

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
