### PR TITLE
[update] Backup and Restore

### DIFF
--- a/self-hosted/page-index/page-index.js
+++ b/self-hosted/page-index/page-index.js
@@ -102,11 +102,6 @@ module.exports = [
         href: "backup-and-restore",
         children: [
           {
-            title: "Using pg_dump/pg_restore",
-            href: "pg-dump-and-restore",
-            excerpt: "Backing up and restoring with the pg_dump and pg_restore",
-          },
-          {
             title: "Docker & WAL-E",
             href: "docker-and-wale",
             excerpt: "Backing up and restoring with Docker and WAL-E",


### PR DESCRIPTION
# Description

Removed the pg-dump and restore it from the Index file. Did not remove it from the https://docs.timescale.com/self-hosted/latest/backup-and-restore/ because the Logical back has the link to the page under Use timescale.

# Links

Fixes https://github.com/timescale/docs-private/issues/181
# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
