### PR TITLE
Move deprecation notice for WAL-E and Docker

### DIFF
--- a/self-hosted/backup-and-restore/docker-and-wale.md
+++ b/self-hosted/backup-and-restore/docker-and-wale.md
@@ -22,8 +22,6 @@ ready to implement this in your production deployment, you can adapt the
 instructions here to do archiving against cloud providers such as AWS S3, and
 run it in an orchestration framework such as Kubernetes.
 
-<Deprecation />
-
 <ConsiderCloud />
 
 ## Run the TimescaleDB container in Docker
@@ -36,6 +34,8 @@ write-ahead log (`POSTGRES_INITDB_WALDIR`) and data directory (`PGDATA`) so that
 you can share them with the WAL-E sidecar. Both must reside in a Docker volume,
 by default a volume is created for `/var/lib/postgresql/data`. When you have
 started TimescaleDB, you can log in and create tables and data.
+
+<Deprecation />
 
 <Procedure>
 


### PR DESCRIPTION
# Description

Moved the deprecation notice in the Docker and WAL-E section to make it clear that the deprecation is referring to the Docker container, not the process itself. 

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
