### PR TITLE
Add caggs to set_chunk_time_interval

### DIFF
--- a/api/drop_chunks.md
+++ b/api/drop_chunks.md
@@ -28,19 +28,19 @@ specified one.
 Chunks can only be dropped based on their time intervals. They cannot be dropped
 based on a space partition.
 
-### Required arguments
+## Required arguments
 
 |Name|Type|Description|
-|---|---|---|
-| `relation` | REGCLASS | Hypertable or continuous aggregate from which to drop chunks. |
-| `older_than` | INTERVAL | Specification of cut-off point where any full chunks older than this timestamp should be removed. |
+|-|-|-|
+|`relation`|REGCLASS|Hypertable or continuous aggregate from which to drop chunks.|
+|`older_than`|INTERVAL|Specification of cut-off point where any full chunks older than this timestamp should be removed.|
 
-### Optional arguments
+## Optional arguments
 
 |Name|Type|Description|
-|---|---|---|
-| `newer_than` | INTERVAL | Specification of cut-off point where any full chunks newer than this timestamp should be removed. |
-| `verbose` | BOOLEAN | Setting to true displays messages about the progress of the reorder command. Defaults to false.|
+|-|-|-|
+|`newer_than`|INTERVAL|Specification of cut-off point where any full chunks newer than this timestamp should be removed.|
+|`verbose`|BOOLEAN|Setting to true displays messages about the progress of the reorder command. Defaults to false.|
 
 The `older_than` and `newer_than` parameters can be specified in two ways:
 
@@ -60,13 +60,15 @@ you are removing things _in the past_. If you want to remove data
 in the future, for example to delete erroneous entries, use a timestamp.
 </Highlight>
 
-When both arguments are used, the function returns the intersection of the resulting two ranges. For example,
-specifying `newer_than => 4 months` and `older_than => 3 months` drops all full chunks that are between 3 and
-4 months old. Similarly, specifying `newer_than => '2017-01-01'` and `older_than => '2017-02-01'` drops
-all full chunks between '2017-01-01' and '2017-02-01'. Specifying parameters that do not result in an overlapping
+When both arguments are used, the function returns the intersection of the
+resulting two ranges. For example, specifying `newer_than => 4 months` and
+`older_than => 3 months` drops all full chunks that are between 3 and 4 months
+old. Similarly, specifying `newer_than => '2017-01-01'` and
+`older_than => '2017-02-01'` drops all full chunks between '2017-01-01' and
+'2017-02-01'. Specifying parameters that do not result in an overlapping
 intersection between two ranges results in an error.
 
-### Sample usage
+## Sample usage
 
 Drop all chunks from hypertable `conditions` older than 3 months:
 

--- a/api/set_chunk_time_interval.md
+++ b/api/set_chunk_time_interval.md
@@ -15,14 +15,15 @@ Sets the `chunk_time_interval` on a hypertable. The new interval is used
 when new chunks are created, and time intervals on existing chunks are
 not changed.
 
-### Required arguments
+## Required arguments
 
 |Name|Type|Description|
 |-|-|-|
-|`hypertable`|REGCLASS| Hypertable to update interval for|
+|`hypertable`|REGCLASS| Hypertable or continuous aggregate to update interval for|
 |`chunk_time_interval`|See note|Event time that each new chunk covers|
 
-The valid types for the `chunk_time_interval` depend on the type used for the hypertable `time` column:
+The valid types for the `chunk_time_interval` depend on the type used for the
+hypertable `time` column:
 
 |`time` column type|`chunk_time_interval` type|Time unit|
 |-|-|-|
@@ -38,7 +39,7 @@ The valid types for the `chunk_time_interval` depend on the type used for the hy
 
 For more information, see the [`create_hypertable` section][create-hypertable].
 
-### Optional arguments
+## Optional arguments
 
 |TEXT|Description|
 |-|-|-|
@@ -47,7 +48,7 @@ For more information, see the [`create_hypertable` section][create-hypertable].
 You need to use `dimension_name` argument only if your hypertable has multiple
 time dimensions.
 
-### Sample usage
+## Sample usage
 
 For a TIMESTAMP column, set `chunk_time_interval` to 24 hours:
 

--- a/api/set_chunk_time_interval.md
+++ b/api/set_chunk_time_interval.md
@@ -19,7 +19,7 @@ not changed.
 
 |Name|Type|Description|
 |-|-|-|
-|`hypertable`|REGCLASS| Hypertable or continuous aggregate to update interval for|
+|`hypertable`|REGCLASS|Hypertable or continuous aggregate to update interval for|
 |`chunk_time_interval`|See note|Event time that each new chunk covers|
 
 The valid types for the `chunk_time_interval` depend on the type used for the

--- a/api/show_chunks.md
+++ b/api/show_chunks.md
@@ -16,37 +16,40 @@ Get list of chunks associated with a hypertable.
 Function accepts the following required and optional arguments. These arguments
 have the same semantics as the `drop_chunks` [function][drop_chunks].
 
-### Required arguments
+## Required arguments
 
 |Name|Type|Description|
-|---|---|---|
-| `relation` | REGCLASS | Hypertable or continuous aggregate from which to select chunks. |
+|-|-|-|
+|`relation`|REGCLASS|Hypertable or continuous aggregate from which to select chunks.|
 
-### Optional arguments
+## Optional arguments
 
 |Name|Type|Description|
-|---|---|---|
-| `older_than` | ANY | Specification of cut-off point where any full chunks older than this timestamp should be shown. |
-| `newer_than` | ANY | Specification of cut-off point where any full chunks newer than this timestamp should be shown. |
+|-|-|-|
+|`older_than`|ANY|Specification of cut-off point where any full chunks older than this timestamp should be shown.|
+|`newer_than`|ANY|Specification of cut-off point where any full chunks newer than this timestamp should be shown.|
 
 The `older_than` and `newer_than` parameters can be specified in two ways:
 
 *   **interval type:** The cut-off point is computed as `now() -
-    older_than` and similarly `now() - newer_than`.  An error is returned if an INTERVAL is supplied
-    and the time column is not one of a TIMESTAMP, TIMESTAMPTZ, or
-    DATE.
+    older_than` and similarly `now() - newer_than`. An error is returned if an
+    INTERVAL is supplied and the time column is not one of a TIMESTAMP,
+    TIMESTAMPTZ, or DATE.
 
-*   **timestamp, date, or integer type:** The cut-off point is
-    explicitly given as a TIMESTAMP / TIMESTAMPTZ / DATE or as a
-    SMALLINT / INT / BIGINT. The choice of timestamp or integer must follow the type of the hypertable's time column.
+*   **timestamp, date, or integer type:** The cut-off point is explicitly given
+    as a TIMESTAMP / TIMESTAMPTZ / DATE or as a SMALLINT / INT / BIGINT. The
+    choice of timestamp or integer must follow the type of the hypertable's time
+    column.
 
-When both arguments are used, the function returns the intersection of the resulting two ranges. For example,
-specifying `newer_than => 4 months` and `older_than => 3 months` shows all full chunks that are between 3 and
-4 months old. Similarly, specifying `newer_than => '2017-01-01'` and `older_than => '2017-02-01'` shows
-all full chunks between '2017-01-01' and '2017-02-01'. Specifying parameters that do not result in an overlapping
+When both arguments are used, the function returns the intersection of the
+resulting two ranges. For example, specifying `newer_than => 4 months` and
+`older_than => 3 months` shows all full chunks that are between 3 and 4 months
+old. Similarly, specifying `newer_than => '2017-01-01'` and
+`older_than => '2017-02-01'` shows all full chunks between '2017-01-01' and
+'2017-02-01'. Specifying parameters that do not result in an overlapping
 intersection between two ranges results in an error.
 
-### Sample usage
+## Sample usage
 
 Get list of all chunks associated with a table:
 


### PR DESCRIPTION
# Description

Adds caggs to the description for the required argument for set_chunk_time_interval, plus a bunch of light editing to a few related pages that I stumbled across.

# Links

Fixes https://github.com/timescale/docs/issues/2530

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
