### PR TITLE
[update] remove references to space partition

### DIFF
--- a/api/add_data_node.md
+++ b/api/add_data_node.md
@@ -102,13 +102,14 @@ TimescaleDB extension on the data node unless it is already installed.
 ### Sample usage
 
 If you have an existing hypertable `conditions` and want to use `time`
-as the time partitioning column. You also want to distribute the chunks
-of the hypertable on two data nodes `dn1.example.com` and `dn2.example.com`:
+as the time partitioning column and `location` as the space partitioning
+column. You also want to distribute the chunks of the hypertable on two
+data nodes `dn1.example.com` and `dn2.example.com`:
 
 ```sql
 SELECT add_data_node('dn1', host => 'dn1.example.com');
 SELECT add_data_node('dn2', host => 'dn2.example.com');
-SELECT create_distributed_hypertable('conditions', 'time');
+SELECT create_distributed_hypertable('conditions', 'time', 'location');
 ```
 
 If you want to create a distributed database with the two data nodes
@@ -117,7 +118,7 @@ local to this instance, you can write:
 ```sql
 SELECT add_data_node('dn1', host => 'localhost', database => 'dn1');
 SELECT add_data_node('dn2', host => 'localhost', database => 'dn2');
-SELECT create_distributed_hypertable('conditions', 'time');
+SELECT create_distributed_hypertable('conditions', 'time', 'location');
 ```
 
 Note that this does not offer any performance advantages over using a

--- a/api/add_data_node.md
+++ b/api/add_data_node.md
@@ -101,8 +101,8 @@ TimescaleDB extension on the data node unless it is already installed.
 
 ### Sample usage
 
-Let's assume that you have an existing hypertable `conditions` and want to use
-`time` as the time partitioning column. You also want to distribute the chunks
+If you have an existing hypertable `conditions` and want to use `time`
+as the time partitioning column. You also want to distribute the chunks
 of the hypertable on two data nodes `dn1.example.com` and `dn2.example.com`:
 
 ```sql

--- a/api/add_data_node.md
+++ b/api/add_data_node.md
@@ -101,16 +101,14 @@ TimescaleDB extension on the data node unless it is already installed.
 
 ### Sample usage
 
-Let's assume that you have an existing hypertable `conditions` and
-want to use `time` as the time partitioning column and `location` as
-the space partitioning column. You also want to distribute the chunks
-of the hypertable on two data nodes `dn1.example.com` and
-`dn2.example.com`:
+Let's assume that you have an existing hypertable `conditions` and want to use
+`time` as the time partitioning column. You also want to distribute the chunks
+of the hypertable on two data nodes `dn1.example.com` and `dn2.example.com`:
 
 ```sql
 SELECT add_data_node('dn1', host => 'dn1.example.com');
 SELECT add_data_node('dn2', host => 'dn2.example.com');
-SELECT create_distributed_hypertable('conditions', 'time', 'location');
+SELECT create_distributed_hypertable('conditions', 'time');
 ```
 
 If you want to create a distributed database with the two data nodes
@@ -119,7 +117,7 @@ local to this instance, you can write:
 ```sql
 SELECT add_data_node('dn1', host => 'localhost', database => 'dn1');
 SELECT add_data_node('dn2', host => 'localhost', database => 'dn2');
-SELECT create_distributed_hypertable('conditions', 'time', 'location');
+SELECT create_distributed_hypertable('conditions', 'time');
 ```
 
 Note that this does not offer any performance advantages over using a

--- a/api/create_hypertable.md
+++ b/api/create_hypertable.md
@@ -147,19 +147,6 @@ SELECT create_hypertable('conditions', 'time', chunk_time_interval => 8640000000
 SELECT create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '1 day');
 ```
 
-Convert table `conditions` to hypertable with time partitioning on `time` and
-space partitioning (4 partitions) on `location`:
-
-```sql
-SELECT create_hypertable('conditions', 'time', 'location', 4);
-```
-
-The same as above, but using a custom partitioning function:
-
-```sql
-SELECT create_hypertable('conditions', 'time', 'location', 4, partitioning_func => 'location_hash');
-```
-
 Convert table `conditions` to hypertable. Do not raise a warning
 if `conditions` is already a hypertable:
 

--- a/self-hosted/distributed-hypertables/create-distributed-hypertables.md
+++ b/self-hosted/distributed-hypertables/create-distributed-hypertables.md
@@ -35,8 +35,7 @@ hypertable. To set up multi-node, see the
 
 1.  Convert the table to a distributed hypertable. Specify the name of the table
     you want to convert, the column that holds its time values, and a
-    space-partitioning parameter. For more information about space partitions,
-    see the [space-partitioning section][space-partitions].
+    space-partitioning parameter.
 
      ```sql
      SELECT create_distributed_hypertable('conditions', 'time', 'location');
@@ -46,4 +45,3 @@ hypertable. To set up multi-node, see the
 
 [multi-node]: /self-hosted/:currentVersion:/multinode-timescaledb/
 [postgres-createtable]: https://www.postgresql.org/docs/current/sql-createtable.html
-[space-partitions]: /use-timescale/:currentVersion:/hypertables/about-hypertables#space-partitions-for-distributed-hypertables

--- a/use-timescale/hypertables/about-hypertables.md
+++ b/use-timescale/hypertables/about-hypertables.md
@@ -73,24 +73,6 @@ For a detailed analysis of how to optimize your chunk sizes, see the
 to view and set your chunk time intervals, see the section on
 [changing hypertable chunk intervals][change-chunk-intervals].
 
-### Space partitioning
-
-Space partitioning is optional. It is not usually recommended for regular
-hypertables.
-
-A good alternative way to increase input/output performance on single
-hypertables is to use RAID (redundant array of inexpensive disks). RAID
-virtualizes multiple physical disks into a single logical disk. You can then use
-this single logical disk to store your hypertable, without any space
-partitioning.
-
-Space partitioning is useful if you have multiple physical disks, each
-corresponding to a separate tablespace. Each disk can then store some of the
-space partitions. If you partition by space without this setup, you increase
-query planning complexity without increasing I/O performance. For more
-information, see the
-[distributed hypertables][about-distributed-hypertables] section.
-
 ## Hypertable indexes
 
 By default, indexes are automatically created when you create a hypertable. You


### PR DESCRIPTION
# Description

_ removed the references to the space partition in examples
_ removed the references to the space partition in create_hypertable sections
_ retained the references only in distributed hyper table sections

# Links

Fixes https://github.com/timescale/docs/issues/2595

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
