### PR TITLE
fix: preview link url

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         id: timescale
         run: |
           echo "DEV_FOLDER=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
-          echo "HYPHENATED_BRANCH_NAME=$(echo "${GITHUB_HEAD_REF}" | sed 's|/|-|')" >> $GITHUB_ENV
+          echo "HYPHENATED_BRANCH_NAME=$(echo "${GITHUB_HEAD_REF}" | sed 's|/|-|' | sed 's/\./-/g')" >> $GITHUB_ENV
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588


### PR DESCRIPTION
During the preview site build process, periods in branch names are now replaced with hyphens. The preview URL in the generated PR comment needs to be updated accordingly.

Related to https://github.com/timescale/web-documentation/issues/615