### PR TITLE
feat: add cta for try-it-out code blocks

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -31,7 +31,7 @@ the guide, you learn how to:
 1.  [Create your first Timescale service][services-create]
 1.  [Connect to your service][services-connect]
 1.  [Ingest some real financial data into your database][ingest-data]
-1.  [Construct some interesting queries][queries]
+1.  [Construct some interesting queries][queries] <FeaturedCTA href="/getting-started/latest/queries/#try-it-out-code-block-1" data-tracking="cta-try-out-queries">Try out some <b>live queries</b></FeaturedCTA>
 1.  [Create and query a continuous aggregates][caggs]
 
 When you have finished this guide, you might want to check out some

--- a/getting-started/queries.md
+++ b/getting-started/queries.md
@@ -60,7 +60,7 @@ LIMIT 10
     SQL query against a live instance curated by Timescale.
     </Highlight>
 
-    <TryItOutCodeBlock queryId="getting-started-srt-4-days" />
+    <TryItOutCodeBlock id="try-it-out-code-block-1" queryId="getting-started-srt-4-days" />
 
 1.  Type `q` to return to the `psql` prompt.
 


### PR DESCRIPTION
Add a CTA to track interest in try-it-out code blocks.

Related to https://github.com/timescale/docs-private/issues/173
