### PR TITLE
Add a direct link to migration index

### DIFF
--- a/use-timescale/migration/index.md
+++ b/use-timescale/migration/index.md
@@ -8,8 +8,8 @@ tags: [ingest, migrate, RDS]
 
 # Migrate your data to Timescale
 
-You can migrate data from another database into Timescale using the PostgreSQL
-`pg_dump` and `pg_restore` commands. You can also use these tools to migrate
+You can migrate data from another database into Timescale [using the PostgreSQL
+`pg_dump` and `pg_restore` commands][pg-migrate]. You can also use these tools to migrate
 your data from Managed Service for TimescaleDB, from a self-hosted Timescale
 instance, or from another PostgreSQL database, including Amazon RDS.
 
@@ -17,3 +17,4 @@ If you want to import data from another format, such as a `.csv` file, into a
 new Timescale service, see the [data ingest section][data-ingest].
 
 [data-ingest]: /use-timescale/:currentVersion:/ingest-data/
+[pg-migrate]: /use-timescale/:currentVersion:/migration/pg-dump-and-restore.md


### PR DESCRIPTION
# Description

It's not immediately obvious on this page, that there are instructions on how to migrate with pg_dump and pg_restore in docs.  This PR adds a link to the that page inline to supplement the "next" link at the bottom of the page

# Links

Fixes #[insert issue link, if any]

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
