### PR TITLE
Remove loading extension step from Ruby quick start

### DIFF
--- a/quick-start/ruby.md
+++ b/quick-start/ruby.md
@@ -72,24 +72,6 @@ on Rails application.
     A new migration file `<migration-datetime>_add_timescale.rb` is created in
     the `my_app/db/migrate` directory.
 
-1.  Update the contents of the `<migration-datetime>_add_timescale.rb` file with
-    these instructions to load the TimescaleDB extension to PostgreSQL:
-
-    ```ruby
-    class AddTimescale < ActiveRecord::Migration[7.0]
-      def change
-       enable_extension("timescaledb") unless extensions.include? "timescaledb"
-       end
-      end
-    end
-    ```
-
-1.  Add the TimescaleDB extension to the PostgreSQL database:
-
-    ```ruby
-       rails db:migrate
-    ```
-
 1.  Connect to TimescalDB Cloud using Rails:
 
     ```bash


### PR DESCRIPTION
# Description

The extension should already be loaded when connecting to a Timescale service or installing TimescaleDB so the instructions don't need a migration to add the extension to a postgres database

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
