### PR TITLE
add note about using pg_ctlcluster command

### DIFF
--- a/self-hosted/multinode-timescaledb/multinode-auth.md
+++ b/self-hosted/multinode-timescaledb/multinode-auth.md
@@ -79,6 +79,9 @@ this method in production. It is not a secure method of operation.
     pg_ctl reload
     ```
 
+    On some operating systems, you might need to use the `pg_ctlcluster` command
+    instead.
+
 1.  If you have not already done so, add the data nodes to the access node. For
     instructions, see the [multi-node setup][multi-node-setup] section.
 1.  On the access node, create the trust role. In this example, we call
@@ -252,7 +255,7 @@ node certificate to create and sign new user certificates for the data nodes.
 Keys and certificates serve different purposes on the data nodes and access
 node. For the access node, a signed certificate is used to verify user
 certificates for access. For the data nodes, a signed certificate authenticates
-the node to the access node.  
+the node to the access node.
 
 <Procedure>
 
@@ -394,7 +397,7 @@ the access node to log in to the data nodes.
     openssl genpkey -algorithm RSA -out "$key_file"
     ```
 
-1.  Generate a certificate signing request (CSR). This file is temporary,  
+1.  Generate a certificate signing request (CSR). This file is temporary,
     stored in the `data` directory, and is deleted later on:
 
     ```bash


### PR DESCRIPTION
# Description

On some OSs (Ubuntu, AFAICT) you shouldn't call pg_ctl directly. This adds a note to explain that readers might need a different command.

# Links

Fixes https://github.com/timescale/docs/issues/2641

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
