### PR TITLE
Add schedule_interval param in add_retention_policy

### DIFF
--- a/api/add_retention_policy.md
+++ b/api/add_retention_policy.md
@@ -23,6 +23,7 @@ exist per hypertable.
 |-|-|-|
 |`relation`|REGCLASS|Name of the hypertable or continuous aggregate to create the policy for|
 |`drop_after`|INTERVAL or INTEGER|Chunks fully older than this interval when the policy is run are dropped|
+|`schedule_interval`|INTERVAL|The interval between the finish time of the last execution and the next start. Defaults to NULL.|
 |`initial_start`|TIMESTAMPTZ|Time the policy is first run. Defaults to NULL. If omitted, then the schedule interval is the interval between the finish time of the last execution and the next start. If provided, it serves as the origin with respect to which the next_start is calculated.|
 |`timezone`|TEXT|A valid time zone. If `initial_start` is also specified, subsequent executions of the retention policy are aligned on its initial start. However, daylight savings time (DST) changes may shift this alignment. Set to a valid time zone if this is an issue you want to mitigate. If omitted, UTC bucketing is performed. Defaults to `NULL`.|
 


### PR DESCRIPTION
# Description

In https://github.com/timescale/timescaledb/pull/4384, the `schedul_interval` parameter was added to `add_compression_policy` and `add_retention_policy` functions.

However, the documentation for `add_retention_policy` does not include an explanation for this parameter.

I just copied the explanation from the  [`add_compression_policy` page](https://docs.timescale.com/api/latest/compression/add_compression_policy/). Please let me know if it is not appropriate.

# Links


# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
