### PR TITLE
force collapsible headings to H3

### DIFF
--- a/getting-started/services.md
+++ b/getting-started/services.md
@@ -40,7 +40,7 @@ For more information, see
 
 ## Create your Timescale account
 
-<Collapsible heading="Creating your Timescale account" defaultExpanded={false}>
+<Collapsible heading="Creating your Timescale account" defaultExpanded={false} headingLevel={3}>
 
 <Install />
 
@@ -50,7 +50,7 @@ For more information, see
 
 Create a service to use for the tasks in this guide. You can use the default values.
 
-<Collapsible heading="Creating your first service" defaultExpanded={false}>
+<Collapsible heading="Creating your first service" defaultExpanded={false} headingLevel={3}>
 
 <CreateService demoData={false} />
 
@@ -58,7 +58,7 @@ Create a service to use for the tasks in this guide. You can use the default val
 
 ## Connect to your service
 
-<Collapsible heading="Connecting to your service">
+<Collapsible heading="Connecting to your service" headingLevel={3}>
 
 <Connect />
 


### PR DESCRIPTION
# Description

The collapsible heading levels default to H2. This forces them to H3.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
