### PR TITLE
fix: remove time condition from gsg query

### DIFF
--- a/_queries/getting-started-srt-4-days.md
+++ b/_queries/getting-started-srt-4-days.md
@@ -1,5 +1,4 @@
 SELECT * FROM stocks_real_time srt
-WHERE time > now() - INTERVAL '4 days'
 LIMIT 10;
 
 -- Output

--- a/getting-started/queries.md
+++ b/getting-started/queries.md
@@ -26,22 +26,15 @@ data is stored in your database in the way you expect it to be.
 ## Use SELECT to return data
 
 This first section uses a `SELECT` statement to ask your database to return
-everything, represented by the asterisk, from the `stocks_real_time srt` table,
-like this:
+every column, represented by the asterisk, from the `stocks_real_time srt`
+table, like this:
 
 <CodeBlock canCopy={false} showLineNumbers={false} children={`
 SELECT * FROM stocks_real_time srt
 `} />
 
-You don't want everything from the entire table, though, so you can use a `WHERE`
-statement to add a condition on to the statement. In this section, you add a
-`WHERE` condition to limit your results to only the last four days, like this:
-
-<CodeBlock canCopy={false} showLineNumbers={false} children={`
-WHERE time > now() - INTERVAL '4 days'
-`} />
-
-You can also limit the number of rows that get returned with a `LIMIT` clause:
+If your table is very big, you might not want to return every row. You can
+limit the number of rows that get returned with a `LIMIT` clause:
 
 <CodeBlock canCopy={false} showLineNumbers={false} children={`
 LIMIT 10
@@ -68,8 +61,8 @@ LIMIT 10
 
 ## Use ORDER BY to organize results
 
-In the previous section, you ordered the results of your query by time in
-descending order, so the most recent trades were at the top of the list. You can
+In the previous section, you saw a selection of rows from the table. Usually,
+you want to order the rows so that you see the most recent trades. You can
 change how your results are displayed using an `ORDER BY` statement.
 
 In this section, you query Tesla's stock with a `SELECT` query like this,


### PR DESCRIPTION
The time condition on the GSG query causes the query to return no rows if the real-time data feed is down, which is a bad user experience. Change the query so it can also return older rows, and something will always be displayed.

# Description

[Short summary of why you created this PR]

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
