### PR TITLE
Update metrics page

### DIFF
--- a/use-timescale/integrations/index.md
+++ b/use-timescale/integrations/index.md
@@ -15,10 +15,10 @@ and extend what you can do with your data.
 |&#x1F6E0; [Query and administration][query-admin]|&#x1F50E; [Observability and alerting][observability-alerting]|&#x270D; [Data ingestion][data-ingest]
 |-|-|-|
 |[psql][psql]|[Grafana][grafana]|[Telegraf][telegraf]|
-|[DBeaver][dbeaver]|[Tableau][tableau]|
-|[Azure Data Studio][ads]|
-|[pgAdmin][pgadmin]|
-|[qStudio][qstudio]|
+|[DBeaver][dbeaver]|[Tableau][tableau]||
+|[Azure Data Studio][ads]|AWS CloudWatch[cloudwatch]||
+|[pgAdmin][pgadmin]|DataDog[datadog]||
+|[qStudio][qstudio]|||
 
 [query-admin]: /use-timescale/:currentVersion:/integrations/query-admin/
 [observability-alerting]: /use-timescale/:currentVersion:/integrations/observability-alerting/
@@ -31,3 +31,5 @@ and extend what you can do with your data.
 [grafana]: /use-timescale/:currentVersion:/integrations/observability-alerting/grafana/
 [telegraf]: /use-timescale/:currentVersion:/integrations/data-ingest/telegraf/
 [tableau]: /use-timescale/:currentVersion:/integrations/observability-alerting/tableau/
+[cloudwatch]: /use-timescale/:currentVersion:/integrations/observability-alerting/aws-cloudwatch/
+[datadog]: /use-timescale/:currentVersion:/integrations/observability-alerting/datadog/

--- a/use-timescale/integrations/index.md
+++ b/use-timescale/integrations/index.md
@@ -16,8 +16,8 @@ and extend what you can do with your data.
 |-|-|-|
 |[psql][psql]|[Grafana][grafana]|[Telegraf][telegraf]|
 |[DBeaver][dbeaver]|[Tableau][tableau]||
-|[Azure Data Studio][ads]|AWS CloudWatch[cloudwatch]||
-|[pgAdmin][pgadmin]|DataDog[datadog]||
+|[Azure Data Studio][ads]|[AWS CloudWatch][cloudwatch]||
+|[pgAdmin][pgadmin]|[DataDog][datadog]||
 |[qStudio][qstudio]|||
 
 [query-admin]: /use-timescale/:currentVersion:/integrations/query-admin/

--- a/use-timescale/integrations/observability-alerting/aws-cloudwatch.md
+++ b/use-timescale/integrations/observability-alerting/aws-cloudwatch.md
@@ -62,9 +62,8 @@ safe location.
 </Highlight>
 
 <img class="main-content__illustration"
-width={1375} height={944}
 src="https://assets.timescale.com/docs/images/tsc-integrations-cloudwatch.webp"
-alt="Screenshot of the menu for adding a Datadog exporter" />
+alt="Screenshot of the menu for adding a CloudWatch exporter" />
 
 </Procedure>
 

--- a/use-timescale/integrations/observability-alerting/aws-cloudwatch.md
+++ b/use-timescale/integrations/observability-alerting/aws-cloudwatch.md
@@ -1,8 +1,8 @@
 ---
-title: Integrate Timescale services with third-party monitoring
-excerpt: Export telemetry metrics to Datadog or AWS CloudWatch
+title: Integrate Timescale services with AWS CloudWatch
+excerpt: Export telemetry metrics to AWS CloudWatch
 products: [cloud]
-keywords: [integration, metrics, Datadog, AWS CloudWatch]
+keywords: [integration, metrics, logging, AWS CloudWatch]
 tags: [telemetry, monitor]
 cloud_ui:
     path:
@@ -12,11 +12,11 @@ cloud_ui:
 
 import ExporterRegionNote from 'versionContent/_partials/_cloud-integrations-exporter-region.mdx';
 
-# Integrate Timescale services with third-party monitoring tools
+# Integrate Timescale services with AWS CloudWatch
 
-You can export your service telemetry to a third-party monitoring tool, such as
-[Datadog][datadog] or [AWS CloudWatch][cloudwatch]. Exported metrics include
-CPU usage, RAM usage, and storage.
+You can export your service telemetry to [AWS CloudWatch][cloudwatch] for
+third-party metrics monitoring. Exported metrics include CPU usage, RAM usage,
+and storage.
 
 ## Export telemetry data
 
@@ -25,47 +25,13 @@ Export telemetry data by:
 1.  [Creating a data exporter][create-exporter]
 1.  [Attaching the exporter to a database service][attach-exporter]
 
-### Create a data exporter
+## Create a data exporter
 
 <ExporterRegionNote />
 
-<Tabs label="Create a data exporter">
-
-<Tab title="Datadog">
-
 <Procedure>
 
-#### Creating a data exporter for Datadog
-
-1.  In the Timescale console, navigate to `Integrations`.
-1.  Click `Create exporter`.
-1.  Choose the telemetry data type that you would like to send to a provider.
-1.  Under `Choose a provider`, choose `Datadog`.
-1.  Choose an AWS region for your exporter to live within Timescale. The
-    exporter is only available to database services in the same AWS region.
-1.  Name your exporter. This name appears in the Cloud console, so choose a
-    descriptive name.
-1.  Add a Datadog API key. If you don't have an API key yet, you can create one
-    by following the instructions in the [Datadog
-    documentation][datadog-api-key].
-1.  Under Site, choose your Datadog region. You can choose a region to meet any
-    regulatory requirements or application needs you might have.
-1.  Click `Create exporter`.
-
-<img class="main-content__illustration"
-width={1375} height={944}
-src="https://assets.timescale.com/docs/images/tsc-integrations-datadog.webp"
-alt="Screenshot of the menu for adding a Datadog exporter" />
-
-</Procedure>
-
-</Tab>
-
-<Tab title="AWS CloudWatch">
-
-<Procedure>
-
-#### Creating a data exporter for AWS CloudWatch
+### Creating a data exporter for AWS CloudWatch
 
 1.  In the Timescale console, navigate to `Integrations`.
 1.  Click `Create exporter`.
@@ -102,10 +68,6 @@ alt="Screenshot of the menu for adding a Datadog exporter" />
 
 </Procedure>
 
-</Tab>
-
-</Tabs>
-
 ### Attach a data exporter to a service
 
 Once you create a data exporter, you can attach it to a service. The exporter
@@ -125,8 +87,8 @@ You can only have one exporter per service.
 1.  Select an exporter and click `Attach exporter`.
 
 <Highlight type="warning">
-If you would like to attach a logs exporter to an already existing 
-service, you do not need to restart the service. The service only 
+If you would like to attach a logs exporter to an already existing
+service, you do not need to restart the service. The service only
 needs to be restarted when you attach the first logs exporter.
 </Highlight>
 
@@ -134,9 +96,8 @@ needs to be restarted when you attach the first logs exporter.
 
 ## Monitor service metrics
 
-You can now monitor your service metrics from the [metrics explorer in
-Datadog][datadog-metrics-explorer], or query them from the cloudWatch metrics
-page in AWS Console. For more information, see the [Datadog][datadog-docs] or
+You can now monitor your service metrics by querying them from the CloudWatch
+metrics page in the AWS Console. For more information, see the
 [Cloudwatch][cloudwatch-docs] documentation.
 
 When you have set up your integration, you can check that it is working
@@ -203,7 +164,3 @@ Delete any data exporters that you no longer need.
 [cloudwatch-docs]: https://docs.aws.amazon.com/cloudwatch/index.html
 [cloudwatch-log-naming]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
 [create-exporter]: #create-a-data-exporter
-[datadog]: https://www.datadoghq.com
-[datadog-api-key]: https://docs.datadoghq.com/account_management/api-app-keys/#add-an-api-key-or-client-token
-[datadog-docs]: https://docs.datadoghq.com/
-[datadog-metrics-explorer]: https://app.datadoghq.com/metric/explorer

--- a/use-timescale/integrations/observability-alerting/datadog.md
+++ b/use-timescale/integrations/observability-alerting/datadog.md
@@ -1,0 +1,152 @@
+---
+title: Integrate Timescale services with Datadog for monitoring
+excerpt: Export telemetry metrics to Datadog
+products: [cloud]
+keywords: [integration, metrics, logging, Datadog]
+tags: [telemetry, monitor]
+cloud_ui:
+    path:
+        - [integrations]
+        - [services, :serviceId, operations, integrations]
+---
+
+import ExporterRegionNote from 'versionContent/_partials/_cloud-integrations-exporter-region.mdx';
+
+# Integrate Timescale services with Datadog
+
+You can export your service telemetry to [Datadog][datadog] for third-party
+metrics monitoring. Exported metrics include CPU usage, RAM usage, and storage.
+
+## Export telemetry data
+
+Export telemetry data by:
+
+1.  [Creating a data exporter][create-exporter]
+1.  [Attaching the exporter to a database service][attach-exporter]
+
+### Create a data exporter
+
+<ExporterRegionNote />
+
+<Procedure>
+
+### Creating a data exporter for Datadog
+
+1.  In the Timescale console, navigate to `Integrations`.
+1.  Click `Create exporter`.
+1.  Choose the telemetry data type that you would like to send to a provider.
+1.  Under `Choose a provider`, choose `Datadog`.
+1.  Choose an AWS region for your exporter to live within Timescale. The
+    exporter is only available to database services in the same AWS region.
+1.  Name your exporter. This name appears in the Cloud console, so choose a
+    descriptive name.
+1.  Add a Datadog API key. If you don't have an API key yet, you can create one
+    by following the instructions in the [Datadog
+    documentation][datadog-api-key].
+1.  Under Site, choose your Datadog region. You can choose a region to meet any
+    regulatory requirements or application needs you might have.
+1.  Click `Create exporter`.
+
+<img class="main-content__illustration"
+width={1375} height={944}
+src="https://assets.timescale.com/docs/images/tsc-integrations-datadog.webp"
+alt="Screenshot of the menu for adding a Datadog exporter" />
+
+</Procedure>
+
+## Attach a data exporter to a service
+
+Once you create a data exporter, you can attach it to a service. The exporter
+then exports that service's telemetry data.
+
+You can only have one exporter per service.
+
+<ExporterRegionNote />
+
+<Procedure>
+
+### Attaching a data exporter to a service
+
+1.  Navigate to `Services`. Click on the service you want to connect to your
+    exporter.
+1.  Navigate to `Operations`, then `Integrations`.
+1.  Select an exporter and click `Attach exporter`.
+
+<Highlight type="warning">
+If you would like to attach a logs exporter to an already existing
+service, you do not need to restart the service. The service only
+needs to be restarted when you attach the first logs exporter.
+</Highlight>
+
+</Procedure>
+
+## Monitor service metrics
+
+You can now monitor your service metrics from the
+[metrics explorer in Datadog][datadog-metrics-explorer].
+For more information, see the [Datadog][datadog-docs] documentation.
+
+When you have set up your integration, you can check that it is working
+correctly by looking for the metrics that Timescale exports. The metric
+names are:
+
+*   `timescale.cloud.system.cpu.usage.millicores`
+*   `timescale.cloud.system.cpu.total.millicores`
+*   `timescale.cloud.system.memory.usage.bytes`
+*   `timescale.cloud.system.memory.total.bytes`
+*   `timescale.cloud.system.disk.usage.bytes`
+*   `timescale.cloud.system.disk.total.bytes`
+
+Additionally, Timescale exports tags that you can use to filter your
+results. You can also check that these tags are being correctly exported:
+
+|Tag|Example variable|Description|
+|-|-|-|
+|`host`|`us-east-1.timescale.cloud`||
+|`project-id`|||
+|`service-id`|||
+|`region`|`us-east-1`|Timescale region|
+|`role`|`replica` or `primary`|For services with replicas|
+|`node-id`||For multi-node services|
+
+## Edit a data exporter
+
+You can edit a data exporter after you create it. Some fields, such as the
+provider and AWS region, can't be changed.
+
+<Procedure>
+
+### Editing a data exporter
+
+1.  Navigate to `Integrations`.
+1.  Beside the exporter you want to edit, click the menu button. Click `Edit`.
+1.  Edit the exporter fields and save your changes.
+
+</Procedure>
+
+## Delete a data exporter
+
+Delete any data exporters that you no longer need.
+
+<Procedure>
+
+### Deleting a data exporter
+
+1.  Before deleting a data exporter, remove all connected services.
+1.  For each connected service, navigate to the service `Operations` tab.
+1.  Click `Integrations`.
+1.  Click the trash can icon to remove the exporter from the service. This
+    doesn't delete the exporter itself.
+1.  In the main menu, navigate to `Integrations`.
+1.  Beside the exporter you want to delete, click the menu button. Click
+    `Delete`.
+1.  Confirm that you want to delete.
+
+</Procedure>
+
+[attach-exporter]: #attach-a-data-exporter-to-a-service
+[create-exporter]: #create-a-data-exporter
+[datadog]: https://www.datadoghq.com
+[datadog-api-key]: https://docs.datadoghq.com/account_management/api-app-keys/#add-an-api-key-or-client-token
+[datadog-docs]: https://docs.datadoghq.com/
+[datadog-metrics-explorer]: https://app.datadoghq.com/metric/explorer

--- a/use-timescale/integrations/observability-alerting/datadog.md
+++ b/use-timescale/integrations/observability-alerting/datadog.md
@@ -48,7 +48,6 @@ Export telemetry data by:
 1.  Click `Create exporter`.
 
 <img class="main-content__illustration"
-width={1375} height={944}
 src="https://assets.timescale.com/docs/images/tsc-integrations-datadog.webp"
 alt="Screenshot of the menu for adding a Datadog exporter" />
 

--- a/use-timescale/integrations/observability-alerting/index.md
+++ b/use-timescale/integrations/observability-alerting/index.md
@@ -10,8 +10,12 @@ tags: [integrations, observability, alerting]
 
 # Observability and alerting
 
+*   [AWS CloudWatch][cloudwatch]
+*   [Datadog][datadog]
 *   [Grafana][grafana]
 *   [Tableau][tableau]
 
 [grafana]: /use-timescale/:currentVersion:/integrations/observability-alerting/grafana/
 [tableau]: /use-timescale/:currentVersion:/integrations/observability-alerting/tableau/
+[cloudwatch]: /use-timescale/:currentVersion:/integrations/observability-alerting/aws-cloudwatch/
+[datadog]: /use-timescale/:currentVersion:/integrations/observability-alerting/datadog/

--- a/use-timescale/metrics-logging/index.md
+++ b/use-timescale/metrics-logging/index.md
@@ -12,13 +12,4 @@ cloud_ui:
 
 # Metrics and logging
 
-You can see metrics and logs for your Timescale services in the dashboard. You
-can also integrate with third-party logging services.
-
-*   View [service metrics][metrics] in the dashboard.
-*   View [service logs][logs] in the dashboard.
-*   Integrate with a [third-party logging service][integrations].
-
-[metrics]: /use-timescale/:currentVersion:/metrics-logging/service-metrics/
-[logs]: /use-timescale/:currentVersion:/metrics-logging/service-logs/
-[integrations]: /use-timescale/:currentVersion:/metrics-logging/integrations/
+You can see metrics and logs for your services in the Timescale console.

--- a/use-timescale/metrics-logging/service-metrics.md
+++ b/use-timescale/metrics-logging/service-metrics.md
@@ -51,7 +51,6 @@ The metrics available are:
 *   Storage bandwidth
 
 <img class="main-content__illustration"
-width={1375}
 src="https://assets.timescale.com/docs/images/tsc_metrics_all.webp"
 alt="All metrics available in the Timescale dashboard"/>
 

--- a/use-timescale/metrics-logging/service-metrics.md
+++ b/use-timescale/metrics-logging/service-metrics.md
@@ -40,22 +40,21 @@ You can view metrics for your services for any of these time ranges:
 *   Last seven days, with one hour granularity
 *   Last 30 days, with one hour granularity
 
-To change the view, select the time range from the drop-down menu.
+To change the view, select the time range from the drop-down menu. Additionally,
+you can turn automatic metric refreshes on and off. When automatic metric
+refresh is on, the dashboard updates every thirty seconds.
 
 The metrics available are:
 
 *   CPU
 *   Memory
-*   Storage use
+*   Storage used
 *   Storage IO
 *   Storage bandwidth
 
 <img class="main-content__illustration"
 src="https://assets.timescale.com/docs/images/tsc_metrics_all.webp"
 alt="All metrics available in the Timescale dashboard"/>
-
-Additionally, you can turn automatic metric refreshes on and off. When automatic
-metric refresh is on, the dashboard updates every thirty seconds.
 
 In some cases, gray vertical bars display on the metrics dashboard, like this:
 
@@ -71,7 +70,7 @@ does not mean that your Timescale service was down.
 
 Disk bandwidth and disk IO metrics provide insight into the load and performance
 of the storage associated with your Timescale services, indicating the number of
-bytes/sec being written or read from storage, and the number of disk IO
+bytes per second written or read from storage, and the number of disk IO
 operations (IOPS) per second.
 
 Each Timescale service has a maximum limit for storage bandwidth and IO, which

--- a/use-timescale/metrics-logging/service-metrics.md
+++ b/use-timescale/metrics-logging/service-metrics.md
@@ -15,11 +15,16 @@ import EarlyAccess from "versionContent/_partials/_early_access.mdx";
 
 You can view your service metrics from the Timescale
 [metrics dashboard][metrics-dashboard]. This dashboard gives you service-level
-information, such as CPU, memory, and storage usage.
+information, such as CPU, memory, storage usage, and storage performance.
 
 You can view query-level statistics from the `Query stats` tab. You can also
 view your query-level statistics by using the pre-installed
 [`pg_stat_statements`][pg-stat] extension from a PostgreSQL client.
+
+<img class="main-content__illustration"
+width={1375} height={944}
+src="https://assets.timescale.com/docs/images/tsc-metrics_lastmonth.webp"
+alt="Timescale Metrics dashboard"/>
 
 ## Metrics dashboard
 
@@ -37,10 +42,18 @@ You can view metrics for your services for any of these time ranges:
 
 To change the view, select the time range from the drop-down menu.
 
+The metrics available are:
+
+*   CPU
+*   Memory
+*   Storage use
+*   Storage IO
+*   Storage bandwidth
+
 <img class="main-content__illustration"
-width={1375} height={944}
-src="https://assets.timescale.com/docs/images/tsc-metrics_lastmonth.webp"
-alt="Timescale Metrics dashboard"/>
+width={1375}
+src="https://assets.timescale.com/docs/images/tsc_metrics_all.webp"
+alt="All metrics available in the Timescale dashboard"/>
 
 Additionally, you can turn automatic metric refreshes on and off. When automatic
 metric refresh is on, the dashboard updates every thirty seconds.
@@ -55,7 +68,38 @@ alt="Timescale Metrics not collected"/>
 This indicates that metrics have not been collected for the period shown. It
 does not mean that your Timescale service was down.
 
-## Continuous storage monitoring
+## Storage performance metrics
+
+Disk bandwidth and disk IO metrics provide insight into the load and performance
+of the storage associated with your Timescale services, indicating the number of
+bytes/sec being written or read from storage, and the number of disk IO
+operations (IOPS) per second.
+
+Each Timescale service has a maximum limit for storage bandwidth and IO, which
+is automatically adjusted based on the total volume of data stored. To see the
+limits for your service, hover on the storage IO or storage bandwidth graph.
+
+<img class="main-content__illustration"
+src="https://assets.timescale.com/docs/images/tsc_storageperf_hover.webp"
+width={1375} height={944}
+alt="Timescale storage performance metrics, showing additional information on hover"/>
+
+The auto-adjusted limits work well in most cases. However, you might need higher
+limits for some workloads. If you want to increase your storage limits,
+[contact us][contact-us].
+
+## Additional service metrics
+
+More metrics are available from the PostgreSQL `pg_stats` view within your
+Timescale service. These include additional metrics, including the number of
+database connections, active rows, and deadlocks.
+
+If you'd like to collect and store these metrics in an external observability
+platform, there are a variety of tools you can use. For more information about
+using third-party tools for Timescale metrics and observability, see the
+[integration][integrations] section.
+
+## Continuous monitoring
 
 Timescale continuously monitors the health and resource consumption of all
 database services. You can check your health data by navigating to the `metrics`
@@ -144,7 +188,7 @@ run:
 SELECT * FROM pg_stat_statements WHERE pg_get_userbyid(userid) = current_user;
 ```
 
-### Example usage
+### Example use
 
 With `pg_stat_statements`, you can view performance statistics that help you
 monitor and optimize your queries.
@@ -186,3 +230,5 @@ performance bottlenecks with `pg_stat_statements`][blog-pg_stat_statements].
 [pg-stat]: /use-timescale/:currentVersion:/metrics-logging/service-metrics/#query-level-statistics-with-pg_stat_statements
 [blog-pg_stat_statements]: <https://www.timescale.com/blog/identify-postgresql-performance-bottlenecks-with-pg_stat_statements/>
 [psql]: /use-timescale/:currentVersion:/connecting/about-psql/
+[integrations]: /use-timescale/:currentVersion:/integrations/observability-alerting/
+[contact-us]: https://www.timescale.com/contact/

--- a/use-timescale/page-index/page-index.js
+++ b/use-timescale/page-index/page-index.js
@@ -803,6 +803,16 @@ module.exports = [
             children:
               [
                 {
+                  title: "AWS CloudWatch",
+                  href: "aws-cloudwatch",
+                  excerpt: "Use AWS CloudWatch with Timescale",
+                },
+                {
+                  title: "Datadog",
+                  href: "datadog",
+                  excerpt: "Use Datadog with Timescale",
+                },
+                {
                   title: "Grafana",
                   href: "grafana",
                   excerpt: "Use Grafana with Timescale",


### PR DESCRIPTION
# Description

Updates metrics page (including screenshots), moves the AWS CloudWatch and Datadog content to the integrations page, and links to them. Have not included the pgexporter content, because it seems like it's a much more manual process (not to mention incomplete in the instructions I have). 

@jamescmeehan Is there a way we can set up Prometheus as an integration using a data exporter from within the console? If so, let's get that documented 👍 

# Links

Fixes https://github.com/timescale/docs-private/issues/166

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
