### PR TITLE
Fix deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
           repository: timescale/web-documentation
           event-type: build-docs-content-prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
           repository: timescale/web-documentation
           event-type: build-docs-content
           client-payload: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'


### PR DESCRIPTION
Dispatch to the web-documentation repository broke, presumably because
the PAT which was being used for it expired. This change uses the
org-wide PAT associated with the timescale-automation account.
