### PR TITLE
Remove note about Compression policies on continuous aggregates

### DIFF
--- a/api/add_compression_policy.md
+++ b/api/add_compression_policy.md
@@ -48,13 +48,6 @@ on the type of the time column of the hypertable or continuous aggregate:
 |-|-|-|
 |`if_not_exists`|BOOLEAN|Setting to `true` causes the command to fail with a warning instead of an error if a compression policy already exists on the hypertable. Defaults to false.|
 
-<Highlight type="important">
-Compression policies on continuous aggregates should be set up so that they do
-not overlap with refresh policies on continuous aggregates. This is due to a
-current TimescaleDB limitation that prevents refresh of compressed regions of
-continuous aggregates.
-</Highlight>
-
 ### Sample usage
 
 Add a policy to compress chunks older than 60 days on the `cpu` hypertable.


### PR DESCRIPTION
Remove note that Compression policies on continuous aggregates  should be set up so that they do not overlap with refresh policies on continuous aggregates.

This is not true any more since mutable compression has been rolled out

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
