### PR TITLE
Fix broken links in migration documentation

### DIFF
--- a/_partials/_migrate_dual_write_backfill_getting_help.md
+++ b/_partials/_migrate_dual_write_backfill_getting_help.md
@@ -3,11 +3,9 @@ import OpenSupportRequest from "versionContent/_partials/_migrate_open_support_r
 <Highlight type="tip">
 
 If you get stuck, you can get help by either opening a support request, or take
-your issue to the `#migration` channel in the [community slack], where the
-developers of this migration method are there to help.
+your issue to the `#migration` channel in the [community slack](https://slack.timescale.com/),
+where the developers of this migration method are there to help.
 
 <OpenSupportRequest />
 
 </Highlight>
-
-[community slack]: https://slack.timescale.com/

--- a/migrate/pg-dump-and-restore/index.md
+++ b/migrate/pg-dump-and-restore/index.md
@@ -35,14 +35,14 @@ you must be aware of:
 
 [//]: # (TODO: more caveats?)
 
-<Highlight type="info">
+<Highlight type="note">
 A long-running `pg_dump` against a database can cause various issues due to the
 types of locks that `pg_dump` takes. Consult the troubleshooting section
-[Dumping and locks] for more details.
+[dumping and locks](/migrate/:currentVersion:/troubleshooting/#dumping-and-locks)
+for more details.
 </Highlight>
 
 [pg_dump]: https://www.postgresql.org/docs/current/static/app-pgdump.html
 [pg_restore]: https://www.postgresql.org/docs/current/static/app-pgrestore.html
 [from-timescaledb]: /migrate/:currentVersion:/pg-dump-and-restore/pg-dump-restore-from-timescaledb/
 [from-postgres]: /migrate/:currentVersion:/pg-dump-and-restore/pg-dump-restore-from-postgres/
-[Dumping and locks]: /migrate/:currentVersion:/troubleshooting/#dumping-and-locks

--- a/migrate/pg-dump-and-restore/pg-dump-restore-from-postgres.md
+++ b/migrate/pg-dump-and-restore/pg-dump-restore-from-postgres.md
@@ -75,10 +75,8 @@ pg_dump -d "$SOURCE" \
 <Highlight type="note">
 It is possible to dump using multiple connections to the source database, which
 may dramatically reduce the time taken to dump the source database. For more
-information, see [dumping with concurrency] and [restoring with concurrency].
-
-[dumping with concurrency]: /migrate/:currentVersion:/troubleshooting/#dumping-with-concurrency
-[restoring with concurrency]: /migrate/:currentVersion:/troubleshooting/##restoring-with-concurrency
+information, see [dumping with concurrency](/migrate/:currentVersion:/troubleshooting/#dumping-with-concurrency)
+and [restoring with concurrency](/migrate/:currentVersion:/troubleshooting/#restoring-with-concurrency).
 </Highlight>
 
 The following is a brief explanation of the flags used:

--- a/migrate/pg-dump-and-restore/pg-dump-restore-from-timescaledb.md
+++ b/migrate/pg-dump-and-restore/pg-dump-restore-from-timescaledb.md
@@ -44,7 +44,7 @@ Before you begin, ensure that you have:
 
 [Created a database service in Timescale]: /use-timescale/:currentVersion:/services/create-a-service/
 [list of compatible extensions]: /use-timescale/:currentVersion:/extensions/
-[upgrade instructions]: /self-hosted/latest/:currentVersion:/about-upgrades/
+[upgrade instructions]: /self-hosted/:currentVersion:/upgrades/about-upgrades/
 
 ## Dump the source database
 
@@ -75,10 +75,8 @@ pg_dump -d "$SOURCE" \
 <Highlight type="note">
 It is possible to dump using multiple connections to the source database, which
 may dramatically reduce the time taken to dump the source database. For more
-information, see [dumping with concurrency] and [restoring with concurrency].
-
-[dumping with concurrency]: /migrate/:currentVersion:/troubleshooting/#dumping-with-concurrency
-[restoring with concurrency]: /migrate/:currentVersion:/troubleshooting/##restoring-with-concurrency
+information, see [dumping with concurrency](/migrate/:currentVersion:/troubleshooting/#dumping-with-concurrency)
+and [restoring with concurrency](/migrate/:currentVersion:/troubleshooting/#restoring-with-concurrency).
 </Highlight>
 
 The following is a brief explanation of the flags used:
@@ -106,17 +104,8 @@ psql $TARGET -v ON_ERROR_STOP=1 --echo-errors \
 It uses [timescaledb_pre_restore] and [timescaledb_post_restore] to put your
 database in the right state for restoring.
 
-<Highlight type="note">
-`pg_dump` and `pg_restore` support parallel dump/restore when used in
-`directory` mode. It is possible, in principle, to use this option with
-TimescaleDB, but there are some caveats. Read the troubleshooting pages
-[Dumping with concurrency], and [Restoring with concurrency].
-</Highlight>
-
 [timescaledb_pre_restore]: /api/:currentVersion:/administration/timescaledb_pre_restore/
 [timescaledb_post_restore]: /api/:currentVersion:/administration/timescaledb_post_restore/
-[Dumping with concurrency]: /migrate/:currentVersion:/troubleshooting#dumping-with-concurrency
-[Restoring with concurrency]: /migrate/:currentVersion:/troubleshooting#restoring-with-concurrency
 
 ### Verify data in the target and restart applications
 


### PR DESCRIPTION
It turns out that reference links aren't supported in the body of a `<Highlight>` component.

There is another issue with `:currentVersion:` not being supported in links used in a `<Highlight>` component, for which I've opened a companion PR: https://github.com/timescale/web-documentation/pull/666