### PR TITLE
Make CAggs materialized only by default

### DIFF
--- a/api/create_materialized_view.md
+++ b/api/create_materialized_view.md
@@ -70,7 +70,7 @@ Optional `WITH` clause options:
 
 |Name|Type|Description|Default value|
 |-|-|-|-|
-|`timescaledb.materialized_only`|BOOLEAN|Return only materialized data when querying the continuous aggregate view|`FALSE`|
+|`timescaledb.materialized_only`|BOOLEAN|Return only materialized data when querying the continuous aggregate view|`TRUE`|
 |`timescaledb.create_group_indexes`|BOOLEAN|Create indexes on the continuous aggregate for columns in its `GROUP BY` clause. Indexes are in the form `(<GROUP_BY_COLUMN>, time_bucket)`|`TRUE`|
 |`timescaledb.finalized`|BOOLEAN|In TimescaleDB 2.7 and above, use the new version of continuous aggregates, which stores finalized results for aggregate functions. Supports all aggregate functions, including ones that use `FILTER`, `ORDER BY`, and `DISTINCT` clauses.|`TRUE`|
 

--- a/use-timescale/continuous-aggregates/real-time-aggregates.md
+++ b/use-timescale/continuous-aggregates/real-time-aggregates.md
@@ -12,10 +12,10 @@ import CaggsRealTimeHistoricalDataRefreshes from 'versionContent/_partials/_cagg
 Continuous aggregates do not include the most recent data chunk from the
 underlying hypertable. Real time aggregates use the aggregated data and add the
 most recent raw data to it to provide accurate and up to date results, without
-needing to aggregate data as it is being written. In Timescale&nbsp;1.7 and later,
-real time aggregates are enabled by default. When you create a continuous
+needing to aggregate data as it is being written. Starting on Timescale&nbsp;1.7 to 2.12,
+real time aggregates are enabled by default, it means when you create a continuous
 aggregate view, queries to that view include the most recent data, even if
-it has not yet been aggregated.
+it has not yet been aggregated. But on Timescale&nbsp;2.13 and later real time aggregates are *NOT* enabled by default.
 
 For more detail on the comparison between continuous and real time aggregates,
 see our [real time aggregate blog post][blog-rtaggs].

--- a/use-timescale/continuous-aggregates/real-time-aggregates.md
+++ b/use-timescale/continuous-aggregates/real-time-aggregates.md
@@ -12,10 +12,10 @@ import CaggsRealTimeHistoricalDataRefreshes from 'versionContent/_partials/_cagg
 Continuous aggregates do not include the most recent data chunk from the
 underlying hypertable. Real time aggregates use the aggregated data and add the
 most recent raw data to it to provide accurate and up to date results, without
-needing to aggregate data as it is being written. Starting on Timescale&nbsp;1.7 to 2.12,
-real time aggregates are enabled by default, it means when you create a continuous
+needing to aggregate data as it is being written. In Timescale versions 1.7 to 2.12,
+real time aggregates are enabled by default; when you create a continuous
 aggregate view, queries to that view include the most recent data, even if
-it has not yet been aggregated. But on Timescale&nbsp;2.13 and later real time aggregates are *NOT* enabled by default.
+it has not yet been aggregated. In Timescale&nbsp;2.13 and later real time aggregates are *NOT* enabled by default.
 
 For more detail on the comparison between continuous and real time aggregates,
 see our [real time aggregate blog post][blog-rtaggs].

--- a/use-timescale/continuous-aggregates/real-time-aggregates.md
+++ b/use-timescale/continuous-aggregates/real-time-aggregates.md
@@ -15,7 +15,7 @@ most recent raw data to it to provide accurate and up to date results, without
 needing to aggregate data as it is being written. In Timescale versions 1.7 to 2.12,
 real time aggregates are enabled by default; when you create a continuous
 aggregate view, queries to that view include the most recent data, even if
-it has not yet been aggregated. In Timescale&nbsp;2.13 and later real time aggregates are *NOT* enabled by default.
+it has not yet been aggregated. In Timescale&nbsp;2.13 and later real time aggregates are *DISABLED* by default.
 
 For more detail on the comparison between continuous and real time aggregates,
 see our [real time aggregate blog post][blog-rtaggs].


### PR DESCRIPTION
Historically creating a Continuous Aggregate make it realtime by default but it confuse users specially when using `WITH NO DATA` option. Also is well known that realtime Continuous Aggregates can potentially lead to issues with Hierarchical and Data Tiering.