### PR TITLE
Fix incremental cagg refresh example

### DIFF
--- a/api/refresh_continuous_aggregate.md
+++ b/api/refresh_continuous_aggregate.md
@@ -66,6 +66,7 @@ DECLARE
 BEGIN
   WHILE start_timestamp < '2020-02-01T00:00:00Z' LOOP
     CALL refresh_continuous_aggregate('conditions', start_timestamp, end_timestamp);
+    COMMIT;
     RAISE NOTICE 'finished with timestamp %', end_timestamp;
     start_timestamp = end_timestamp;
     end_timestamp = end_timestamp + refresh_interval;


### PR DESCRIPTION
After call the `refresh_continuous_aggregate` procedure we should execute a `COMMIT` because the refresh cannot execute into transaction.

Related to timescale/timescaledb#6124