### PR TITLE
Update start background workers function namespace

### DIFF
--- a/_troubleshooting/scheduled-jobs-stop-running.md
+++ b/_troubleshooting/scheduled-jobs-stop-running.md
@@ -32,7 +32,7 @@ Your scheduled jobs might stop running for various reasons. On self-hosted
 TimescaleDB, you can fix this by restarting background workers:
 
 ```sql
-SELECT _timescaledb_functions.start_background_workers();
+SELECT _timescaledb_internal.start_background_workers();
 ```
 
 <CloudMSTRestartWorkers />


### PR DESCRIPTION
# Description

The `start_background_workers()` function's namespace has changed to `_timescaledb_internal`.

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
