### PR TITLE
Fix references to _timescaledb_functions for pre-2.12

### DIFF
--- a/_troubleshooting/cagg-watermark-in-future.md
+++ b/_troubleshooting/cagg-watermark-in-future.md
@@ -84,9 +84,20 @@ window.
 
 1.  Use the returned ID to query for the watermark's timestamp:
 
+    For TimescaleDB 2.12+:
+
     ```sql
     SELECT COALESCE(
         _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(<ID>)),
+        '-infinity'::timestamp with time zone
+    );
+    ```
+
+    For TimescaleDB < 2.12:
+
+    ```sql
+    SELECT COALESCE(
+        _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(<ID>)),
         '-infinity'::timestamp with time zone
     );
     ```

--- a/_troubleshooting/scheduled-jobs-stop-running.md
+++ b/_troubleshooting/scheduled-jobs-stop-running.md
@@ -31,8 +31,23 @@ import CloudMSTRestartWorkers from 'versionContent/_partials/_cloud-mst-restart-
 Your scheduled jobs might stop running for various reasons. On self-hosted
 TimescaleDB, you can fix this by restarting background workers:
 
+<Tabs title="Restart Background Workers">
+<Tab title="TimescaleDB >= 2.12">
+
 ```sql
 SELECT _timescaledb_functions.start_background_workers();
 ```
+
+</Tab>
+
+<Tab title="TimescaleDB < 2.12">
+
+```sql
+SELECT _timescaledb_internal.start_background_workers();
+```
+
+</Tab>
+</Tabs>
+
 
 <CloudMSTRestartWorkers />

--- a/self-hosted/multinode-timescaledb/multinode-maintenance.md
+++ b/self-hosted/multinode-timescaledb/multinode-maintenance.md
@@ -28,6 +28,9 @@ job that regularly cleans up any unfinished distributed transactions.
 
 The custom maintenance job can be run as a user-defined action. For example:
 
+<Tabs title="Custom Maintenance Job">
+<Tab title="TimescaleDB >= 2.12">
+
 ```sql
 CREATE OR REPLACE PROCEDURE data_node_maintenance(job_id int, config jsonb)
 LANGUAGE SQL AS
@@ -40,6 +43,26 @@ $$;
 
 SELECT add_job('data_node_maintenance', '5m');
 ```
+
+</Tab>
+
+<Tab title="TimescaleDB < 2.12">
+
+```sql
+CREATE OR REPLACE PROCEDURE data_node_maintenance(job_id int, config jsonb)
+LANGUAGE SQL AS
+$$
+    SELECT _timescaledb_internal.remote_txn_heal_data_node(fs.oid)
+    FROM pg_foreign_server fs, pg_foreign_data_wrapper fdw
+    WHERE fs.srvfdw = fdw.oid
+    AND fdw.fdwname = 'timescaledb_fdw';
+$$;
+
+SELECT add_job('data_node_maintenance', '5m');
+```
+
+</Tab>
+</Tabs>
 
 ## Statistics for distributed hypertables
 


### PR DESCRIPTION
We updated all references to functions in the `_timescaledb_internal` schema to point to `_timescaledb_functions`, in line with the changes which were released in TimescaleDB 2.12.

Users who do no yet have the privilege of using 2.12 may be confused by the documentation.

See #2739 