### PR TITLE
Improved hierarchical caggs example

### DIFF
--- a/use-timescale/continuous-aggregates/hierarchical-continuous-aggregates.md
+++ b/use-timescale/continuous-aggregates/hierarchical-continuous-aggregates.md
@@ -122,10 +122,17 @@ WITH (timescaledb.continuous)
 AS SELECT
     time_bucket('1 d'::interval, bucket) as bucket_daily,
     api_id,
+    mean(rollup(percentile_hourly)) as mean,
     rollup(percentile_hourly) as percentile_daily
 FROM response_times_hourly
 GROUP BY 1, 2;
 ```
+
+The `mean` function of the TimescaleDB Toolkit is used to calculate the concrete
+mean value of the rolled up values. The additional `percentile_daily` attribute
+contains the raw rolled up values, which can be used in an additional continuous
+aggregate on top of this continuous aggregate (for example a continuous
+aggregate for the daily values).
 
 For more information and examples about using `rollup` functions to stack
 calculations, see the [percentile approximation API documentation][percentile_agg_api].


### PR DESCRIPTION
# Description

The hierarchical CAgg example does not calculate a concrete value. Instead, a `uddsketch` is produced which is hard to understand:

```
(version:1,alpha:0.001,max_buckets:200,num_buckets:5,compactions:0,count:6,sum:59.82,buckets:[(Positive(805),2),(Positive(1256),1),(Positive(1259),1),(Positive(1263),1),(Positive(1267),1)]))
```

This PR changes the CAgg definition to provide a concrete `mean` value. 

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
