### PR TITLE
Clarify that ALTER compression command does not compress itself

### DIFF
--- a/api/alter_table_compression.md
+++ b/api/alter_table_compression.md
@@ -16,7 +16,7 @@ options.
 
 By itself, this `ALTER` statement alone does not compress a hypertable. To do so, either create a
 compression policy using the [add_compression_policy][add_compression_policy] function or manually
-compress a specific hypertable chunk via the [compress_chunk][compress_chunk] function.
+compress a specific hypertable chunk using the [compress_chunk][compress_chunk] function.
 
 The syntax is:
 
@@ -52,9 +52,9 @@ ALTER TABLE <table_name> SET (timescaledb.compress,
 
 ## Sample usage
 
-Configure a hypertable that ingests device data to use compression. Here, because we will
-often query the hypertable about a specific device or set of devices, we segment the
-compression using the `device_id` for greater performance.
+Configure a hypertable that ingests device data to use compression. Here, if the hypertable
+is often queried about a specific device or set of devices, the compression should be
+segmented using the `device_id` for greater performance.
 
 ```sql
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC', timescaledb.compress_segmentby = 'device_id');

--- a/api/alter_table_compression.md
+++ b/api/alter_table_compression.md
@@ -38,8 +38,8 @@ ALTER TABLE <table_name> SET (timescaledb.compress,
 
 |Name|Type|Description|
 |-|-|-|
-|`timescaledb.compress_segmentby`|TEXT|Column list on which to key the compressed segments. An identifier representing the source of the data such as `device_id` or `tags_id` is usually a good candidate. The default is no `segment by` columns.|
 |`timescaledb.compress_orderby`|TEXT|Order used by compression, specified in the same way as the ORDER BY clause in a SELECT query. The default is the descending order of the hypertable's time column.|
+|`timescaledb.compress_segmentby`|TEXT|Column list on which to key the compressed segments. An identifier representing the source of the data such as `device_id` or `tags_id` is usually a good candidate. The default is no `segment by` columns.|
 |`timescaledb.compress_chunk_time_interval`|TEXT|EXPERIMENTAL: Set compressed chunk time interval used to roll compressed chunks into. This parameter compresses every chunk, and then merges it into a previous adjacent chunk if possible, to reduce the total number of chunks in the hypertable. It should be set to a multiple of the current chunk interval. This option can be changed independently of other compression settings and does not require the `timescaledb.compress` argument.|
 
 ## Parameters

--- a/api/alter_table_compression.md
+++ b/api/alter_table_compression.md
@@ -12,13 +12,19 @@ api:
 # ALTER TABLE (Compression) <Tag type="community" content="community" />
 
 'ALTER TABLE' statement is used to turn on compression and set compression
-options.
+options.  
+
+By itself, this `ALTER` statement alone does not compress a hypertable. To do so, either create a
+compression policy using the [add_compression_policy][add_compression_policy] function or manually
+compress a specific hypertable chunk via the [compress_chunk][compress_chunk] function.
 
 The syntax is:
 
 ``` sql
-ALTER TABLE <table_name> SET (timescaledb.compress, timescaledb.compress_orderby = '<column_name> [ASC | DESC] [ NULLS { FIRST | LAST } ] [, ...]',
-timescaledb.compress_segmentby = '<column_name> [, ...]', timescaledb.compress_chunk_time_interval='interval'
+ALTER TABLE <table_name> SET (timescaledb.compress,
+   timescaledb.compress_orderby = '<column_name> [ASC | DESC] [ NULLS { FIRST | LAST } ] [, ...]',
+   timescaledb.compress_segmentby = '<column_name> [, ...]',
+   timescaledb.compress_chunk_time_interval='interval'
 );
 ```
 
@@ -32,8 +38,8 @@ timescaledb.compress_segmentby = '<column_name> [, ...]', timescaledb.compress_c
 
 |Name|Type|Description|
 |-|-|-|
-|`timescaledb.compress_orderby`|TEXT|Order used by compression, specified in the same way as the ORDER BY clause in a SELECT query. The default is the descending order of the hypertable's time column.|
 |`timescaledb.compress_segmentby`|TEXT|Column list on which to key the compressed segments. An identifier representing the source of the data such as `device_id` or `tags_id` is usually a good candidate. The default is no `segment by` columns.|
+|`timescaledb.compress_orderby`|TEXT|Order used by compression, specified in the same way as the ORDER BY clause in a SELECT query. The default is the descending order of the hypertable's time column.|
 |`timescaledb.compress_chunk_time_interval`|TEXT|EXPERIMENTAL: Set compressed chunk time interval used to roll compressed chunks into. This parameter compresses every chunk, and then merges it into a previous adjacent chunk if possible, to reduce the total number of chunks in the hypertable. It should be set to a multiple of the current chunk interval. This option can be changed independently of other compression settings and does not require the `timescaledb.compress` argument.|
 
 ## Parameters
@@ -46,7 +52,9 @@ timescaledb.compress_segmentby = '<column_name> [, ...]', timescaledb.compress_c
 
 ## Sample usage
 
-Configure a hypertable that ingests device data to use compression:
+Configure a hypertable that ingests device data to use compression. Here, because we will
+often query the hypertable about a specific device or set of devices, we segment the
+compression using the `device_id` for greater performance.
 
 ```sql
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC', timescaledb.compress_segmentby = 'device_id');
@@ -64,3 +72,6 @@ To disable the previously set option, set the interval to 0:
 ```sql
 ALTER TABLE metrics SET (timescaledb.compress_chunk_time_interval = '0');
 ```
+
+[add_compression_policy]: /api/:currentVersion:/compression/add_compression_policy/
+[compress_chunk]: /api/:currentVersion:/compression/compress_chunk/


### PR DESCRIPTION
# Description

- Clarify that ALTER compression command should often be used  in combination with compression policy or compress_chunk
- Clarify that segmentby is important field