### PR TITLE
Fix documentation about max_locks_per_transaction

### DIFF
--- a/self-hosted/configuration/about-configuration.md
+++ b/self-hosted/configuration/about-configuration.md
@@ -113,18 +113,20 @@ HINT:  You might need to increase max_locks_per_transaction.
 ```
 
 To avoid this issue, you can increase the `max_locks_per_transaction` setting
-from the default value, which is usually 64. Changing this parameter requires a
-database restart, so make sure you pick a larger number to allow for some
-growth. For most workloads, choose a number equal to double the
-maximum number of chunks you expect to have in a hypertable. This takes into
-account that the number of locks used by a hypertable query is roughly equal to
-the number of chunks in the hypertable, or double that number if the query uses
-an index. You can see how many chunks you currently have using the
-[`chunk_detailed_size`][chunk_detailed_size] command.
+from the default value, which is usually 64. This parameter limits the average
+number of object locks used by each transaction; individual transactions can lock
+more objects as long as the locks of all transactions fit in the lock table.
 
-Note that `max_locks_per_transaction` is not an exact setting. It only adjusts
-the average number of object locks allocated for each transaction. For more
-about lock management, see the [PostgreSQL documentation][lock-management].
+For most workloads, choose a number equal to double the maximum number of chunks
+you expect to have in a hypertable divided by `max_connections`.
+This takes into account that the number of locks used by a hypertable query is
+roughly equal to the number of chunks in the hypertable if you need to access
+all chunks in a query, or double that number if the query uses an index.
+You can see how many chunks you currently have using the
+[`timescaledb_information.hypertables`][timescaledb_information-hypertables] view.
+Changing this parameter requires a database restart, so make sure you pick a larger
+number to allow for some growth.  For more information about lock management,
+see the [PostgreSQL documentation][lock-management].
 
 <Highlight type="tip">
 You can adjust these settings in the `postgresql.conf` configuration
@@ -132,7 +134,7 @@ file.
 </Highlight>
 
 [async-commit]: https://www.postgresql.org/docs/current/static/wal-async-commit.html
-[chunk_detailed_size]: /api/:currentVersion:/hypertable/chunks_detailed_size/
+[timescaledb_information-hypertables]: /api/:currentVersion:/informational-views/hypertables
 [docker-conf]: /self-hosted/:currentVersion:/configuration/docker-config
 [lock-management]: https://www.postgresql.org/docs/current/static/runtime-config-locks.html
 [pgtune]: http://pgtune.leopard.in.ua/

--- a/self-hosted/configuration/configuration.md
+++ b/self-hosted/configuration/configuration.md
@@ -166,20 +166,19 @@ restart, it is advisable to estimate a good setting that also allows
 some growth. For most use cases we recommend the following setting:
 
 ```
-max_locks_per_transaction = 2 * num_chunks
+max_locks_per_transaction = 2 * num_chunks / max_connections
 ```
-
-where `num_chunks` is the maximum number of chunks you expect to have in a hypertable.
-This setting takes into account that the number of locks taken by a hypertable query
-is roughly equal to the
-number of chunks in the hypertable, or double that number if the query
-also uses an index. You can see how many chunks you currently have using the
-[`chunks_detailed_size`][chunks_detailed_size] command.
- Also note that `max_locks_per_transaction` is not
-an exact setting; it only controls the *average* number of object
-locks allocated for each transaction. For more information, please
-review the official PostgreSQL documentation on
-[lock management][lock-management].
+where `num_chunks` is the maximum number of chunks you expect to have in a
+hypertable and `max_connections` is the number of connections configured for
+PostgreSQL.
+This takes into account that the number of locks used by a hypertable query is
+roughly equal to the number of chunks in the hypertable if you need to access
+all chunks in a query, or double that number if the query uses an index.
+You can see how many chunks you currently have using the
+[`timescaledb_information.hypertables`][timescaledb_information-hypertables] view.
+Changing this parameter requires a database restart, so make sure you pick a larger
+number to allow for some growth.  For more information about lock management,
+see the [PostgreSQL documentation][lock-management].
 
 ## TimescaleDB configuration and tuning
 


### PR DESCRIPTION
max_locks_per_transaction is multiplied by max_connections which is the hard limit for how many locks can exist at the same time.
