### PR TITLE
Fix broken link to enterprise page

### DIFF
--- a/use-timescale/account-management.md
+++ b/use-timescale/account-management.md
@@ -18,7 +18,7 @@ It also shows you how to add a payment method, or update to a new credit card.
 
 ## Enterprise Tier 
 
-The Enterprise Tier is available to all customers, please reach out to your customer success contact person to set this up. For more information, visit [here](https://www.timescale.com/enterprise-tier).
+The Enterprise Tier is available to all customers, reach out to your customer success contact person to set this up. For more information, visit [here](https://www.timescale.com/enterprise).
 
 ## Usage-based storage
 


### PR DESCRIPTION
Fixes a broken link to timescale.com/enterprise.

Note: the link is not yet live, but will be going live later today. The current preview is here: http://www-dev.timescale.com.s3-website-us-east-1.amazonaws.com/2499-merge/enterprise and the backing PR is here: https://github.com/timescale/web-splash/pull/2499