### PR TITLE
Fix missing import statements, tweak migration docs

### DIFF
--- a/_partials/_migrate_from_timescaledb_version.md
+++ b/_partials/_migrate_from_timescaledb_version.md
@@ -1,3 +1,5 @@
+import OpenSupportRequest from "versionContent/_partials/_migrate_open_support_request.mdx"
+
 It is very important that the version of the TimescaleDB extension in the
 target database is the same as it was in the source database.
 

--- a/migrate/dual-write-and-backfill/dual-write-from-other.md
+++ b/migrate/dual-write-and-backfill/dual-write-from-other.md
@@ -6,6 +6,7 @@ keywords: [migration, low-downtime]
 tags: [migration, logical backup]
 ---
 
+import SourceTargetNote from "versionContent/_partials/_migrate_source_target_note.mdx";
 import StepOne from "versionContent/_partials/_migrate_dual_write_step1.mdx";
 import StepTwo from "versionContent/_partials/_migrate_dual_write_step2.mdx";
 import StepFour from "versionContent/_partials/_migrate_dual_write_step4.mdx";

--- a/migrate/dual-write-and-backfill/dual-write-from-other.md
+++ b/migrate/dual-write-and-backfill/dual-write-from-other.md
@@ -6,6 +6,7 @@ keywords: [migration, low-downtime]
 tags: [migration, logical backup]
 ---
 
+import GettingHelp from "versionContent/_partials/_migrate_dual_write_backfill_getting_help.mdx";
 import SourceTargetNote from "versionContent/_partials/_migrate_source_target_note.mdx";
 import StepOne from "versionContent/_partials/_migrate_dual_write_step1.mdx";
 import StepTwo from "versionContent/_partials/_migrate_dual_write_step2.mdx";
@@ -37,6 +38,8 @@ In detail, the migration process consists of the following steps:
 1. Switch application to treat target database as primary (potentially
    continuing to write into source database, as a backup).
 
+<GettingHelp />
+
 <StepOne />
 
 <StepTwo />
@@ -67,7 +70,7 @@ snapshot of the relational metadata without stopping your application. If this
 is not the case for your application, you should reconsider using the
 dual-write and backfill method.
 
-<Highlight type="information">
+<Highlight type="note">
 If you're planning on experimenting with continuous aggregates, we recommend
 that you first complete the dual-write and backfill migration, and only then
 create continuous aggregates on the data. If you create continuous aggregates

--- a/migrate/live-migration/index.md
+++ b/migrate/live-migration/index.md
@@ -5,6 +5,7 @@ products: [cloud]
 keywords: [migration, low-downtime, backup]
 tags: [recovery, logical backup, replication]
 ---
+import SourceTargetNote from "versionContent/_partials/_migrate_source_target_note.mdx";
 
 # Live migration
 

--- a/migrate/pg-dump-and-restore/pg-dump-restore-from-timescaledb.md
+++ b/migrate/pg-dump-and-restore/pg-dump-restore-from-timescaledb.md
@@ -11,6 +11,7 @@ import SourceTargetNote from "versionContent/_partials/_migrate_source_target_no
 import SetupSourceTarget from "versionContent/_partials/_migrate_set_up_source_and_target.mdx";
 import TimescaleDBVersion from "versionContent/_partials/_migrate_from_timescaledb_version.mdx";
 import ExplainPgDumpFlags from "versionContent/_partials/_migrate_explain_pg_dump_flags.mdx";
+import MinimalDowntime from "versionContent/_partials/_migrate_pg_dump_minimal_downtime.mdx";
 
 # Migrate from TimescaleDB using pg_dump/restore
 

--- a/self-hosted/install/installation-kubernetes.md
+++ b/self-hosted/install/installation-kubernetes.md
@@ -5,6 +5,8 @@ products: [self_hosted]
 keywords: [installation, self-hosted, Kubernetes]
 ---
 
+import WhereTo from "versionContent/_partials/_where-to-next.mdx";
+
 # Install TimescaleDB on Kubernetes
 
 You can install a TimescaleDB instance on any Kubernetes deployment. Use the

--- a/tutorials/OLD_grafana/installation.md
+++ b/tutorials/OLD_grafana/installation.md
@@ -5,6 +5,8 @@ products: [cloud, mst, self_hosted]
 keywords: [Grafana, visualization, analytics]
 ---
 
+import GrafanaConnect from "versionContent/_partials/_grafana-connect.mdx";
+
 # Set up TimescaleDB and Grafana
 
 This tutorial uses Managed Service for TimescaleDB to set up your database, and

--- a/tutorials/financial-ingest-real-time/financial-ingest-dataset.md
+++ b/tutorials/financial-ingest-real-time/financial-ingest-dataset.md
@@ -11,6 +11,7 @@ content_group: Ingest real-time financial websocket data
 import CreateAndConnect from "versionContent/_partials/_cloud-create-connect-tutorials.mdx";
 import CreateHypertable from "versionContent/_partials/_create-hypertable-twelvedata-stocks.mdx";
 import CreateHypertableStocks from "versionContent/_partials/_create-hypertable-twelvedata-stocks.mdx";
+import GrafanaConnect from "versionContent/_partials/_grafana-connect.mdx";
 
 # Set up the database
 


### PR DESCRIPTION
# Description

- Fix missing import statements
  When import statements are missing for partial components, the content is not present, and the build passes without a problem. Some warnings are emitted, but it appears as though there are some false positives.

- Tweak migration docs
  Add the "Getting Help" partial to the "dual-write from other" page, use correct type for Highlight.