### PR TITLE
Fix troubleshooting section for Tiered Storage

### DIFF
--- a/_troubleshooting/scheduled-jobs-stop-running.md
+++ b/_troubleshooting/scheduled-jobs-stop-running.md
@@ -2,7 +2,7 @@
 title: Scheduled jobs stop running
 section: troubleshooting
 products: [cloud, mst, self_hosted]
-topics: [jobs, continuous aggregates, data retention, compression, tiered storage]
+topics: [jobs, continuous aggregates, data retention, compression, data tiering]
 apis:
   - [continuous aggregates, add_continuous_aggregate_policy()]
   - [continuous aggregates, add_policies()]

--- a/_troubleshooting/slow-tiering-chunks.md
+++ b/_troubleshooting/slow-tiering-chunks.md
@@ -2,7 +2,7 @@
 title: Slow tiering of chunks
 section: troubleshooting
 products: [cloud]
-topics: [tiered storage]
+topics: [data tiering]
 keywords: [tiered storage]
 tags: [tiered storage]
 ---


### PR DESCRIPTION
# Description

Fix troubleshooting section for Tiered Storage

The topic should be rolled back to `data tiering` as we have kept the old directory structure to skip adding redirects