### PR TITLE
Adjust TimescaleDB version match for migration

### DIFF
--- a/_partials/_migrate_from_timescaledb_version.md
+++ b/_partials/_migrate_from_timescaledb_version.md
@@ -1,32 +1,18 @@
-import OpenSupportRequest from "versionContent/_partials/_migrate_open_support_request.mdx"
+It is very important that the version of the TimescaleDB extension is the same
+in the source and target databases. This requires upgrading the TimescaleDB
+extension in the source database before migrating.
 
-It is very important that the version of the TimescaleDB extension in the
-target database is the same as it was in the source database.
-
-You can determine the version of TimescaleDB in the source database with the
+You can determine the version of TimescaleDB in the target database with the
 following command:
 
 ```bash
-psql $SOURCE -c "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb';"
+psql $TARGET -c "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb';"
 ```
 
-You can alter the extension version in Timescale with the following query:
+To update the TimescaleDB extension in your source database, first ensure that
+the desired version is installed from your package repository. Then you can
+upgrade the extension with the following query:
 
 ```bash
-psql $TARGET -c "ALTER EXTENSION timescaledb UPDATE TO '<version here>';"
+psql $SOURCE -c "ALTER EXTENSION timescaledb UPDATE TO '<version here>';"
 ```
-
-The extension version must be present on Timescale in order for this to be
-successful. The following table gives an overview of the PostgreSQL version and
-lowest available TimescaleDB extension version:
-
-| pg12  | pg13  | pg14  | pg15  |
-|-------|-------|-------|-------|
-| 1.7.5 | 2.1.0 | 2.5.0 | 2.9.0 |
-
-[//]: # (Note: to update this table, consult https://timescale.slab.com/posts/migrations-and-version-compatibility-5red287x)
-
-By default, Timescale instances run on PostgreSQL version 15. If you require a
-lower version for a migration, open a support request.
-
-<OpenSupportRequest />

--- a/_partials/_migrate_from_timescaledb_version.md
+++ b/_partials/_migrate_from_timescaledb_version.md
@@ -16,3 +16,7 @@ upgrade the extension with the following query:
 ```bash
 psql $SOURCE -c "ALTER EXTENSION timescaledb UPDATE TO '<version here>';"
 ```
+
+For more information and guidance, consult the [Upgrade TimescaleDB] page.
+
+[Upgrade TimescaleDB]: https://docs.timescale.com/self-hosted/latest/upgrades/


### PR DESCRIPTION
# Description

Timescale doesn't support downgrading TimescaleDB or Postgres versions, so users must upgrade the source DB before migrating.