### PR TITLE
Fix dead link and Timescale Team list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,9 +200,3 @@ Timescale has comprehensive writing and style standards, that are constantly
 being updated and improved. For the current guidelines, see
 [contributing to documentation](https://docs.timescale.com/about/latest/contribute-to-docs/).
 
-## The Timescale documentation team
-
-*   Lana Brindley <https://github.com/Loquacity>
-*   Rajakavitha Kodhandapani <https://github.com/Rajakavitha1>
-*   Charis Lam <https://github.com/charislam>
-*   Jacob Prall <https://github.com/jacobprall>

--- a/tutorials/nyc-taxi-cab/compress-nyc.md
+++ b/tutorials/nyc-taxi-cab/compress-nyc.md
@@ -143,6 +143,6 @@ Try it yourself and see what you get!
 
 
 [segment-by-columns]: /use-timescale/:currentVersion:/compression/about-compression/#segment-by-columns
-[automatic-compression]: /tutorials/:currentVersion:/nyc-tax-cab/compress-nyc/#add-a-compression-policy
+[automatic-compression]: /tutorials/:currentVersion:/nyc-taxi-cab/compress-nyc/#add-a-compression-policy
 [compression-design]: /use-timescale/:currentVersion:/compression/compression-design/
 [add_compression_policy]: /api/:currentVersion:/compression/add_compression_policy/


### PR DESCRIPTION
- fixed a link typo which is driving the `markdown-link-check` check crazy
- removed the `Timescale Team` section of the Contributing page (out of date)