### PR TITLE
docs: playbook for AWS RDS to Timescale

### DIFF
--- a/_partials/_migrate_dump_source_schema.md
+++ b/_partials/_migrate_dump_source_schema.md
@@ -19,3 +19,5 @@ pg_dump -d "$SOURCE" \
   making a dump of the database.
 
 <ExplainPgDumpFlags />
+
+[snapshot]: https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-SNAPSHOT-SYNCHRONIZATION

--- a/_partials/_migrate_dump_source_schema.md
+++ b/_partials/_migrate_dump_source_schema.md
@@ -1,0 +1,21 @@
+import ExplainPgDumpFlags from "versionContent/_partials/_migrate_explain_pg_dump_flags.mdx";
+
+```sh
+pg_dump -d "$SOURCE" \
+  --format=plain \
+  --quote-all-identifiers \
+  --no-tablespaces \
+  --no-owner \
+  --no-privileges \
+  --schema-only \
+  --file=dump.sql \
+  --snapshot=$(cat /tmp/pgcopydb/snapshot)
+```
+
+- `--schema-only` is used to dump only the object definitions (schema), not
+  data.
+
+- `--snapshot` is used to specified the synchronized [snapshot][snapshot] when
+  making a dump of the database.
+
+<ExplainPgDumpFlags />

--- a/_partials/_migrate_live_migration_rds_roles.md
+++ b/_partials/_migrate_live_migration_rds_roles.md
@@ -1,0 +1,62 @@
+```sh
+pg_dumpall -d "$SOURCE" \
+  --quote-all-identifiers \
+  --roles-only \
+  --no-role-passwords \
+  --file=roles.sql
+```
+
+<Highlight type="important">
+Please note that AWS RDS does not permit dumping of roles with passwords, which
+is why the above command is executed with the `--no-role-passwords`. However,
+when the migration of roles to your Timescale instance is complete, you will
+need to manually assign passwords to the necessary roles using the following
+command: `ALTER ROLE role_name WITH PASSWORD 'password';`
+</Highlight>
+
+Timescale services do not support roles with superuser access. If your SQL dump
+includes roles that have such permissions, you'll need to modify the file to be
+compliant with the security model.
+
+You can use the following `sed` command to remove unsupported statements and
+permissions from your `roles.sql` file:
+```sh
+sed -i -E \
+-e '/CREATE ROLE "postgres";/d' \
+-e '/ALTER ROLE "postgres"/d' \
+-e '/CREATE ROLE "rds/d' \
+-e '/ALTER ROLE "rds/d' \
+-e '/TO "rds/d' \
+-e '/GRANT "rds/d' \
+-e 's/(NO)*SUPERUSER//g' \
+-e 's/(NO)*REPLICATION//g' \
+-e 's/(NO)*BYPASSRLS//g' \
+-e 's/GRANTED BY "[^"]*"//g' \
+roles.sql
+```
+
+<Highlight type="info">
+This command works only with the GNU implementation of `sed` (sometimes referred
+to as `gsed`). For the BSD implementation (the default on macOS), you need to add
+an extra argument to change the `-i` flag to `-i ''`.
+
+To check the sed version, you can use the command `sed --version`. While the
+GNU version explicitly identifies itself as GNU, the BSD version of sed
+generally doesn't provide a straightforward `--version` flag and simply outputs
+an "illegal option" error.
+</Highlight>
+
+A brief explanation of this script is:
+* `CREATE ROLE "postgres";` and `ALTER ROLE "postgres"`: These statements are
+removed because they require superuser access, which is not supported by Timescale.
+* `CREATE ROLE "rds`, `ALTER ROLE “rds`, `TO "rds`, `GRANT "rds`: Any creation
+or alteration of rds prefixed roles are removed because of their lack of any use
+in a Timescale instance. Similarly, any grants to or from "rds" prefixed roles
+are ignored as well.
+* `(NO)SUPERUSER`, `(NO)REPLICATION`, `(NO)BYPASSRLS`: Assigning these permissions
+to a role is an action that requires superuser privileges.
+* `GRANTED BY` role_specification: The GRANTED BY clause can also have permissions
+that require superuser access and should therefore be removed. Note: As per the
+TimescaleDB documentation, the GRANTOR in the GRANTED BY clause must be the
+current user, and this clause mainly serves the purpose of SQL compatibility.
+Therefore, it's safe to remove it.

--- a/_partials/_migrate_live_migration_rds_roles.md
+++ b/_partials/_migrate_live_migration_rds_roles.md
@@ -1,4 +1,4 @@
-```sh
+```bash
 pg_dumpall -d "$SOURCE" \
   --quote-all-identifiers \
   --roles-only \
@@ -7,20 +7,21 @@ pg_dumpall -d "$SOURCE" \
 ```
 
 <Highlight type="important">
-Please note that AWS RDS does not permit dumping of roles with passwords, which
+AWS RDS does not permit dumping of roles with passwords, which
 is why the above command is executed with the `--no-role-passwords`. However,
-when the migration of roles to your Timescale instance is complete, you will
+when the migration of roles to your Timescale instance is complete, you
 need to manually assign passwords to the necessary roles using the following
-command: `ALTER ROLE role_name WITH PASSWORD 'password';`
+command: `ALTER ROLE name WITH PASSWORD 'password';`
 </Highlight>
 
-Timescale services do not support roles with superuser access. If your SQL dump
-includes roles that have such permissions, you'll need to modify the file to be
-compliant with the security model.
+Timescale services do not support roles with superuser access. If your SQL
+dump includes roles that have such permissions, you'll need to modify the file
+to be compliant with the security model.
 
 You can use the following `sed` command to remove unsupported statements and
-permissions from your `roles.sql` file:
-```sh
+permissions from your roles.sql file:
+
+```bash
 sed -i -E \
 -e '/CREATE ROLE "postgres";/d' \
 -e '/ALTER ROLE "postgres"/d' \
@@ -35,28 +36,33 @@ sed -i -E \
 roles.sql
 ```
 
-<Highlight type="info">
-This command works only with the GNU implementation of `sed` (sometimes referred
-to as `gsed`). For the BSD implementation (the default on macOS), you need to add
-an extra argument to change the `-i` flag to `-i ''`.
+<Highlight type="note">
+This command works only with the GNU implementation of sed (sometimes referred
+to as gsed). For the BSD implementation (the default on macOS), you need to
+add an extra argument to change the `-i` flag to `-i ''`.
 
 To check the sed version, you can use the command `sed --version`. While the
 GNU version explicitly identifies itself as GNU, the BSD version of sed
-generally doesn't provide a straightforward `--version` flag and simply outputs
+generally doesn't provide a straightforward --version flag and simply outputs
 an "illegal option" error.
 </Highlight>
 
 A brief explanation of this script is:
-* `CREATE ROLE "postgres";` and `ALTER ROLE "postgres"`: These statements are
-removed because they require superuser access, which is not supported by Timescale.
-* `CREATE ROLE "rds`, `ALTER ROLE “rds`, `TO "rds`, `GRANT "rds`: Any creation
-or alteration of rds prefixed roles are removed because of their lack of any use
-in a Timescale instance. Similarly, any grants to or from "rds" prefixed roles
-are ignored as well.
-* `(NO)SUPERUSER`, `(NO)REPLICATION`, `(NO)BYPASSRLS`: Assigning these permissions
-to a role is an action that requires superuser privileges.
-* `GRANTED BY` role_specification: The GRANTED BY clause can also have permissions
-that require superuser access and should therefore be removed. Note: As per the
-TimescaleDB documentation, the GRANTOR in the GRANTED BY clause must be the
-current user, and this clause mainly serves the purpose of SQL compatibility.
-Therefore, it's safe to remove it.
+
+- `CREATE ROLE "postgres"`; and `ALTER ROLE "postgres"`: These statements are
+  removed because they require superuser access, which is not supported
+  by Timescale.
+
+- `(NO)SUPERUSER` | `(NO)REPLICATION` | `(NO)BYPASSRLS`: These are permissions
+  that require superuser access.
+
+- `CREATE ROLE "rds`, `ALTER ROLE “rds`, `TO "rds`, `GRANT "rds`: Any creation
+  or alteration of rds prefixed roles are removed because of their lack of any use
+  in a Timescale instance. Similarly, any grants to or from "rds" prefixed roles
+  are ignored as well.
+
+- `GRANTED BY role_specification`: The GRANTED BY clause can also have permissions that
+  require superuser access and should therefore be removed. Note: Per the
+  TimescaleDB documentation, the GRANTOR in the GRANTED BY clause must be the
+  current user, and this clause mainly serves the purpose of SQL compatibility.
+  Therefore, it's safe to remove it.

--- a/migrate/index.md
+++ b/migrate/index.md
@@ -75,6 +75,8 @@ and importing it with [timescaledb-parallel-copy][parallel-copy].
 
 For other ingestion methods, see the [data ingest section][data-ingest].
 
+For a detailed, step-by-step guide on migrating from various databases to Timescale, please refer to the migration [playbooks].
+
 If you encounter any difficulties while migrating, consult the
 [troubleshooting] documentation, open a support requestl, or take
 your issue to the `#migration` channel in the [community slack](https://slack.timescale.com/),
@@ -89,3 +91,4 @@ where the developers of this migration method are there to help.
 [troubleshooting]: /migrate/:currentVersion:/troubleshooting/
 [live-migration]: /migrate/:currentVersion:/live-migration/
 [pgcopydb]: https://github.com/dimitri/pgcopydb
+[playbooks]: /migrate/:currentVersion:/playbooks/

--- a/migrate/live-migration/live-migration-from-postgres.md
+++ b/migrate/live-migration/live-migration-from-postgres.md
@@ -10,7 +10,7 @@ import GettingHelp from "versionContent/_partials/_migrate_dual_write_backfill_g
 import SourceTargetNote from "versionContent/_partials/_migrate_source_target_note.mdx";
 import StepOne from "versionContent/_partials/_migrate_dual_write_step1.mdx";
 import DumpDatabaseRoles from "versionContent/_partials/_migrate_dual_write_dump_database_roles.mdx";
-import ExplainPgDumpFlags from "versionContent/_partials/_migrate_explain_pg_dump_flags.mdx";
+import DumpSourceSchema from "versionContent/_partials/_migrate_dump_source_schema.mdx";
 
 # Live migration from PostgreSQL database with pgcopydb
 
@@ -208,25 +208,7 @@ longer the buffered files need to be stored.
 
 ### 4b. Dump the database schema from the source database
 
-```sh
-pg_dump -d "$SOURCE" \
-  --format=plain \
-  --quote-all-identifiers \
-  --no-tablespaces \
-  --no-owner \
-  --no-privileges \
-  --schema-only \
-  --file=dump.sql \
-  --snapshot=$(cat /tmp/pgcopydb/snapshot)
-```
-
-- `--schema-only` is used to dump only the object definitions (schema), not
-  data.
-
-- `--snapshot` is used to specified the synchronized [snapshot][snapshot] when
-  making a dump of the database.
-
-<ExplainPgDumpFlags />
+<DumpSourceSchema />
 
 ### 4c. Load the roles and schema into the target database
 

--- a/migrate/page-index/page-index.js
+++ b/migrate/page-index/page-index.js
@@ -75,6 +75,19 @@ module.exports = [
         ],
       },
       {
+        title: "Playbooks",
+        href: "playbooks",
+        excerpt: "Step-by-step migration playbook to Timescale",
+        children: [
+          {
+            title: "From RDS using pg_dump",
+            href: "rds-timescale-pg-dump",
+            excerpt:
+                "Migrate from RDS to Timescale using pg_dump",
+          },
+        ],
+      },
+      {
         title: "Troubleshooting",
         href: "troubleshooting",
         excerpt:

--- a/migrate/page-index/page-index.js
+++ b/migrate/page-index/page-index.js
@@ -80,10 +80,16 @@ module.exports = [
         excerpt: "Step-by-step migration playbook to Timescale",
         children: [
           {
-            title: "From RDS using pg_dump",
+            title: "From AWS RDS using pg_dump",
             href: "rds-timescale-pg-dump",
             excerpt:
                 "Migrate from RDS to Timescale using pg_dump",
+          },
+          {
+            title: "From AWS RDS using live migration",
+            href: "rds-timescale-live-migration",
+            excerpt:
+                "Migrate from RDS to Timescale using live migration",
           },
         ],
       },

--- a/migrate/playbooks/index.md
+++ b/migrate/playbooks/index.md
@@ -11,5 +11,7 @@ tags: [recovery, logical backup, replication]
 Migration playbooks serve as comprehensive tutorials, providing step-by-step instructions on how to migrate your database to Timescale. The available migration guides are as follows:
 
 1. [With downtime: AWS RDS PostgreSQL database to Timescale using pg_dump/pg_restore][rds-timescale-downtime]
+1. [With low-downtime: AWS RDS PostgreSQL database to Timescale using live migration][rds-timescale-low-downtime]
 
 [rds-timescale-downtime]: /migrate/:currentVersion:/playbooks/rds-timescale-pg-dump/
+[rds-timescale-low-downtime]: /migrate/:currentVersion:/playbooks/rds-timescale-live-migration/

--- a/migrate/playbooks/index.md
+++ b/migrate/playbooks/index.md
@@ -1,0 +1,15 @@
+---
+title: Playbooks
+excerpt: Step-by-step playbooks on migrating your database to Timescale
+products: [cloud]
+keywords: [migration, low-downtime, pg_dump, tutorial]
+tags: [recovery, logical backup, replication]
+---
+
+# Playbooks
+
+Migration playbooks serve as comprehensive tutorials, providing step-by-step instructions on how to migrate your database to Timescale. The available migration guides are as follows:
+
+1. [With downtime: AWS RDS PostgreSQL database to Timescale using pg_dump/pg_restore][rds-timescale-downtime]
+
+[rds-timescale-downtime]: /migrate/:currentVersion:/playbooks/rds-timescale-pg-dump/

--- a/migrate/playbooks/rds-timescale-live-migration.md
+++ b/migrate/playbooks/rds-timescale-live-migration.md
@@ -1,0 +1,414 @@
+---
+title: Migrate from RDS to Timescale using live migration
+excerpt: Migrate from a PostgreSQL database in AWS RDS to Timescale using live migration
+products: [cloud]
+keywords: [data migration, postgresql, RDS]
+tags: [migrate, AWS, RDS, low-downtime, pg_dump, pgcopydb]
+---
+
+import GettingHelp from "versionContent/_partials/_migrate_dual_write_backfill_getting_help.mdx";
+import SourceTargetNote from "versionContent/_partials/_migrate_source_target_note.mdx";
+import StepOne from "versionContent/_partials/_migrate_dual_write_step1.mdx";
+import LiveMigrationRoles from "versionContent/_partials/_migrate_live_migration_rds_roles.mdx";
+import DumpDatabaseRoles from "versionContent/_partials/_migrate_dual_write_dump_database_roles.mdx";
+import DumpSourceSchema from "versionContent/_partials/_migrate_dump_source_schema.mdx";
+
+# Migrate from AWS RDS to Timescale using live migration with low-downtime
+This document provides a step-by-step guide to migrating a database from an AWS
+RDS Postgres instance to Timescale using our [Live migration] strategy to achieve
+low application downtime (on the order of minutes).
+
+Live migration's replication mechanism is fundamentally based on Postgres' logical
+decoding feature. However, for the purpose of this guide, an in-depth understanding
+of logical decoding is not necessary. It is important to note that the "Live migration"
+strategy is significantly more complicated than a migration using [pg_dump/pg_restore].
+
+<SourceTargetNote />
+
+## Prerequisites
+Before you start the migration process, you will need to:
+1. Gather information about your RDS instance.
+1. Prepare your RDS instance for Live Migration.
+1. Prepare an intermediate machine.
+
+### Gather information about your RDS instance
+You will need the following information about your Postgres RDS instance:
+* Endpoint
+* Port
+* Master username
+* Master password
+* VPC
+* DB instance parameter group
+
+To gather the required information, navigate to the "Databases" panel and select your
+RDS instance.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+Note the **Endpoint**, **Port**, and **VPC** details from the "Connectivity & Security"
+tab, and the **Master Username**, and **DB instance parameter group** from the "Configuration"
+tab. Remember to use the **Master Password** that was supplied when the Postgres RDS instance
+was created.
+
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+### Prepare your RDS instance for Live Migration
+To use your RDS instance as the source database for a Live migration, and to ensure the
+replication process runs smoothly, set the following configuration parameters:
+
+| Configuration | Required Values |
+|---------------|-----------------|
+| wal_level | logical |
+| old_snapshot_threshold | -1 |
+
+You can check the value of above configuration parameters
+```sh
+postgres=> show wal_level;
+ wal_level
+-----------
+ minimal
+(1 row)
+
+postgres=> show old_snapshot_threshold;
+ old_snapshot_threshold
+------------------------
+ 0
+(1 row)
+```
+
+If the values returned do not match the ones required (as in this situation), you will
+have to adjust them.
+
+<Highlight type="important">
+Modifying either of these parameters requires restarting PostgreSQL, which will cause
+your database to be briefly unavailable. Ensure that you make the following configuration
+changes when you're comfortable with a database restart.
+</Highlight>
+
+For users to make modifications, RDS requires the creation of a parameter group with the
+desired configuration values.
+
+A "DB parameter group" can be thought of as a set of key-value pairs that serve as the
+configuration settings for the database. To find the current DB parameter group that your
+RDS instance is using, go to the "Configuration" tab of your RDS service and look for the
+value listed under "DB instance parameter group".
+
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+#### Create DB parameter group for configuring replication
+Let’s create a DB parameter group that modifies the values for "wal_level" and "old_snapshot_threshold"
+fields. We will base this group on the existing "prod-pr-group" so that we can maintain
+the other fields as they are while only changing the ones we need.
+
+<Highlight type="important">
+If your RDS service is a Multi-AZ DB Cluster deployment, then you will need to use
+"DB Cluster Parameter Group" instead of "DB Parameter Group".
+</Highlight>
+
+1. Navigate to the "Parameter groups" panel using the sidebar.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+2. Copy the parameter group that is active in your RDS instance.
+<Highlight type="important">
+If the "DB parameter group" of your RDS instance displays "default.postgres15", you need to create
+a new DB parameter group. To do this, select "Create parameter group" and opt for "postgres15" in
+the "Parameter group family" field.
+</Highlight>
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+3. Rename the parameter group, provide a description and click on "Create".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+* You will find the new parameter group in the "Parameter group" panel. Open the newly created
+parameter group by clicking on it.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+4. Click on "Edit".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+5. Locate "rds.logical_replication" using the search box and adjust its value from 0 to 1. Next,
+locate "old_snapshot_threshold" and set its value to -1. Once you’ve made these changes, remember
+to click on "Save Changes".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+6. Navigate back to your RDS instance and click on "Modify".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+7. Navigate to the "Additional configuration" section and change the "DB parameter group" value
+to the new DB parameter group that includes the updated parameter values. After making this
+change, click "Continue" located at the bottom of the page.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+8. Once you have verified the new parameter group value, select "Apply immediately" and click
+on "Modify DB Instance".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+<Highlight type="important">
+Configuring the new parameter group will not cause your database to be restarted. In the next
+step you will manually reboot the database.
+</Highlight>
+
+9. Your RDS service will be in the "Modifying" state for a short while, after which, you should
+see that the parameter group is in the "Pending reboot" state and must be rebooted to be applied.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+10. Manually reboot your service in order to apply the changes. In the "Actions" dropdown, click
+"Reboot" and then "Confirm".
+
+11. After your service reboots, ensure that the new "DB parameter group" is applied in your RDS
+instance.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+12. Reconnect to your RDS instance and verify the configuration parameter values.
+```sh
+postgres=> show wal_level;
+ wal_level
+-----------
+ logical
+(1 row)
+
+postgres=> show old_snapshot_threshold ;
+ old_snapshot_threshold
+------------------------
+ -1
+(1 row)
+```
+
+### Prepare an intermediate machine
+Live Migration must be executed from a dedicated machine. The live migration tools
+connect to the source and target databases, and all data will flow through the
+dedicated machine between the source and the target. This instance must be able
+to access your RDS service and ideally is in the same region as your Timescale
+instance. We will set up an EC2 instance in the same VPC as the RDS service.
+
+#### Create an EC2 instance
+1. In the AWS search, type "EC2" and select the "EC2" option under services.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+2. Click on "Launch instance".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+3. Configure your EC2 instance.
+* For "Instance type", use 2 CPU and 8 GB memory at least. If your migration
+involves a larger database, you should choose accordingly.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+<Highlight type="info">
+The procedures outlined in this, as well as subsequent sections, are based on the
+assumption that an Ubuntu Amazon Machine Image (AMI) was selected during the setup
+of the EC2 instance.
+</Highlight>
+
+* For "Key pair", you can choose to use an existing key pair or create a new one.
+This will be necessary when connecting to the EC2 instance from your local machine.
+* For "Network Settings", select the same VPC that your RDS instance is located in.
+Also, modify the "Source Type" of the security group to "My IP" so that your local
+machine can connect to the EC2 instance.
+
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+* For "Configure Storage" section, adjust the volume size to match the *1.5x the size of your database*.
+If necessary, you should enable encryption on your volume.
+
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+* Review the summary of the instance and click "Launch instance".
+
+### Prepare the EC2 instance
+To prepare your EC2 instance for a low-downtime migration:
+1. Navigate to your EC2 instance and click on "Connect".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+2. Select the "SSH client" tab.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+3. Connect to your EC2 instance using the "Key pair" you received while creating the EC2 instance.
+```sh
+chmod 400 <key-pair>.pem
+ssh -i "<key-pair>.pem" ubuntu@<EC2 instance's Public IPv4>
+```
+
+4. Install PostgreSQL client and pgcopydb.
+```sh
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
+sudo apt update
+sudo apt install postgresql-client-15 pgcopydb -y
+psql --version && pg_dump --version && pgcopydb --version
+# psql (PostgreSQL) 15.5 (Ubuntu 15.5-1.pgdg22.04+1)
+# pg_dump (PostgreSQL) 15.5 (Ubuntu 15.5-1.pgdg22.04+1)
+# 10:20:32 3037 INFO   Running pgcopydb version 0.13-1.pgdg22.04+1 from "/usr/bin/pgcopydb"
+# pgcopydb version 0.13-1.pgdg22.04+1
+# compiled with PostgreSQL 15.3 (Ubuntu 15.3-1.pgdg22.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0, 64-bit
+# compatible with Postgres 10, 11, 12, 13, 14, and 15
+```
+
+5. To allow an EC2 instance to connect to an RDS instance, you need to modify the
+security group associated with your RDS instance.
+* Note the Private IPv4 address of your EC2 instance.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+* Go to the security group associated with your RDS instance and select "Edit inbound rules".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+* Click "Add rule". In the "Type" field, select "PostgreSQL". For "Source", select
+"Custom" and input the Private IPv4 address of your EC2 instance. Add a suitable
+description for this rule. Finally, click on "Save rules" to apply the changes.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-live-migration/TODO.jpeg"
+ alt="TODO"/>
+
+6. Verify the connection to the RDS service from your EC2 instance. Please note,
+you will be prompted to enter the master password. This should be the same password
+that you used when creating your AWS RDS service.
+```sh
+# psql -h <rds_endpoint> -p <rds_port> -U postgres -c "select 1"
+psql -h aws-rds-low-downtime-migration-db.c8tzn206yp6f.us-west-2.rds.amazonaws.com -p 5432 -U postgres -c "select 1"
+Password for user postgres:
+ ?column?
+----------
+        1
+(1 row)
+```
+
+## Performing data migration
+The migration process consists of the following steps:
+1. Set up a target database instance in Timescale.
+1. Prepare the source database for the live migration.
+1. Set up a replication slot and snapshot.
+1. Migrate roles and schema from source to target.
+1. Follow the remaining steps from "Live migration" documentation.
+
+<StepOne />
+
+## 2. Prepare the source database for the live migration
+In order to replicate `UPDATE` and `DELETE` operations on tables in the source database,
+the tables must have either a primary key or `REPLICA IDENTITY`. Replica identity
+assists logical decoding in identifying the rows being modified. It defaults to
+using the table's primary key.
+
+If a table doesn't have a primary key, you'll have to manually set the replica identity.
+One option is to use a unique, non-partial, non-deferrable index that includes only
+columns marked as `NOT NULL`.
+
+```sql
+ALTER TABLE {table_name} REPLICA IDENTITY USING INDEX {_index_name};
+```
+
+If there's no primary key or viable unique index to use, you will have to set
+`REPLICA IDENTITY` to `FULL`. If you are expecting a large number of `UPDATE` or `DELETE`
+operations on the table, we do not recommend using `FULL`. For each `UPDATE` or `DELETE`
+statement, Postgres will have to read the whole table to find all matching rows, which
+will result in significantly slower replication.
+
+```sql
+ALTER TABLE {table_name} REPLICA IDENTITY FULL;
+```
+
+## 3. Set up a replication slot and snapshot
+Once you're sure that the tables which will be affected by `UPDATE` and `DELETE`
+queries have `REPLICA IDENTITY` set, you will need to create a replication slot.
+
+Replication slots keep track of transactions (recorded in Write-Ahead Log files)
+in the source database that have not been streamed to the target database yet. We
+will use `pgcopydb` to create a replication slot in the source database.
+
+```sh
+pgcopydb follow \
+  --source "$SOURCE" \
+  --target "$TARGET" \
+  --fail-fast \
+  --plugin wal2json
+```
+
+This command is going to be active during most of the migration process. You can
+run it in the background or use terminal multiplexers like `screen` or `tmux`.
+
+The `follow` command sets up a replication slot in the source database to stream
+changes. These changes are held in "intermediate machine" on disk until "apply" is
+given. We will discuss about apply command in subsequent steps.
+
+Additionally, `follow` command exports a snapshot ID to `/tmp/pgcopydb/snapshot`.
+This ID can be utilized to migrate data that was in the database before the replication
+slot was created.
+
+## 4. Migrate roles and schema from source to target
+Before the stream of changes can be applied, the schema and data that existed prior
+to the creation of the replication slot in the source database must be migrated.
+The larger the size of the source database, the more time it takes to perform the
+initial migration, and the longer the buffered files need to be stored.
+
+### 4.a Migrate database roles from source database
+<LiveMigrationRoles />
+
+### 4.b Dump the database schema from the source database
+<DumpSourceSchema />
+
+### 4.c Load the roles and schema into the target database
+```sh
+psql -X -d "$TARGET" \
+  -v ON_ERROR_STOP=1 \
+  --echo-errors \
+  -f roles.sql \
+  -f schema.sql
+```
+
+## 5. Follow the remaining steps from Live migration documentation
+The remaining steps for migrating data from a RDS Postgres instance to Timescale
+with low-downtime are the same as the ones mentioned in "Live migration"
+documentation from [Step 5] onwards. You should follow the mentioned steps
+to successfully complete the migration process.
+
+[pg_dump/pg_restore]: /migrate/:currentVersion:/playbooks/rds-timescale-pg-dump/
+[Live migration]: /migrate/:currentVersion:/live-migration/live-migration-from-postgres/
+[Step 5]: /migrate/:currentVersion:/live-migration/live-migration-from-postgres/#5-enable-hypertables

--- a/migrate/playbooks/rds-timescale-pg-dump.md
+++ b/migrate/playbooks/rds-timescale-pg-dump.md
@@ -1,0 +1,353 @@
+---
+title: Migrate from RDS to Timescale using pg_dump
+excerpt: Migrate from a PostgreSQL database in AWS RDS to Timescale using pg_dump
+products: [cloud]
+keywords: [data migration, postgresql, RDS]
+tags: [migrate, AWS, RDS, downtime, pg_dump, psql]
+---
+
+import GettingHelp from "versionContent/_partials/_migrate_dual_write_backfill_getting_help.mdx";
+import SourceTargetNote from "versionContent/_partials/_migrate_source_target_note.mdx";
+import StepOne from "versionContent/_partials/_migrate_dual_write_step1.mdx";
+
+# Migrate from AWS RDS to Timescale using pg_dump with downtime
+This guide illustrates the process of migrating a Postgres database from an
+AWS RDS service to a Timescale instance. We will use Postgres community tools
+like `pg_dump` and `pg_restore` to facilitate the migration process.
+
+<Highlight type="important">
+Please be aware that this migration process requires a period of downtime for
+your production database, the duration of which is subject to the size of your
+database. If you want a migration solution from your RDS instance to Timescale
+that offers low downtime, please refer the following document: TODO HARKISHEN
+</Highlight>
+
+## Prerequisites
+Before initiating the migration process, you will require:
+
+1. Details of your AWS RDS instance
+2. Intermediate machine
+
+### Details of your AWS RDS instance
+You will need the following information about your Postgres RDS instance:
+
+* Endpoint
+* Port
+* Master username
+* Master password
+* VPC
+
+To gather the required information, navigate to the "Databases" panel and select your RDS instance.
+
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/list-of-databases.jpeg"
+ alt="List of databases in RDS panel"/>
+
+Record the **Endpoint**, **Port**, and **VPC** details from the "Connectivity & Security" tab, and the
+**Master Username** from the "Configuration" tab. Remember to use the **Master Password** that was supplied
+when the Postgres RDS instance was created.
+
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/db-config-1.jpeg"
+ alt="Record endpoint, port, VPC details"/>
+
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/db-config-2.jpeg"
+ alt="Record master username"/>
+
+### Intermediate machine
+In order to execute `pg_dump` and `pg_restore`, we need an EC2 instance. This
+instance should have access to your RDS service. Therefore, we will set up the EC2
+machine in the same VPC as the RDS service.
+
+#### Create an EC2 instance
+
+1. In the AWS search, type "EC2" and select the "EC2" option under services.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/create-ec2-instance.jpeg"
+ alt="Create an EC2 instance"/>
+
+2. Click on "Launch instance".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/prepare-to-launch-ec2.jpeg"
+ alt="Start configuring your instance"/>
+
+3. Configure your EC2 instance.
+* For "Instance type", use 2 CPU and 8 GB memory at least. If your migration involves
+a larger database, you should choose accordingly.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-1.jpeg"
+ alt="Choose instance type"/>
+
+* For "Key pair", you can choose to use an existing key pair or create a new one.
+This will be necessary when connecting to the EC2 instance from your local machine.
+* For "Network Settings", select the same VPC that your RDS instance is located in.
+Also, modify the "Source Type" of the security group to "My IP" so that your local
+machine can connect to the EC2 instance.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-2.jpeg"
+ alt="Configure network"/>
+
+* For "Configure Storage" section, adjust the volume size to match the size of
+your database. If necessary, you should enable encryption on your volume.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-3.jpeg"
+ alt="Configure storage"/>
+
+* Review the summary of the instance and click "Launch instance".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-4.jpeg"
+ alt="Review EC2 instance"/>
+
+#### Prepare the EC2 instance
+
+<Highlight type="important">
+The procedures outlined in this, as well as subsequent sections, are based on the
+assumption that an Ubuntu Amazon Machine Image (AMI) was selected during the
+setup of the EC2 instance.
+</Highlight>
+
+To prepare your EC2 instance for migration:
+1. Navigate to your EC2 instance and click on the "Connect" button.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/prepare-ec2-instance.jpeg"
+ alt="Connect to EC2 instance"/>
+
+2. Select the "SSH client" tab.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/select-ssh-client.jpeg"
+ alt="Use SSH client"/>
+
+3. Connect to your EC2 instance using the "Key pair" downloaded in the previous step.
+```sh
+chmod 400 <key-pair>.pem
+ssh -i "<key-pair>.pem" ubuntu@<EC2 instance's Public IPv4>
+```
+
+4. Install PostgreSQL client.
+```sh
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
+sudo apt update
+sudo apt install postgresql-client-15 -y # "postgresql-client-16" if your source DB is using PG 16.
+psql --version && pg_dump --version
+```
+
+5. To allow an EC2 instance to connect to an RDS instance, you need to modify the
+security group associated with your RDS instance.
+* Note the Private IPv4 address of your EC2 instance.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/private-ipv4-address.jpeg"
+ alt="Note private IPv4 address of your EC2 instance"/>
+
+* Go to the security group associated with your RDS instance and select
+"Edit inbound rules".
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/modify-firewall-rules.jpeg"
+ alt="Edit inbound rules"/>
+
+* Choose "Add rule". In the "Type" field, select "PostgreSQL". For "Source", select
+"Custom" and input the Private IPv4 address of your EC2 instance. Add a
+suitable description for this rule. Finally, click on "Save rules" to apply the changes.
+<img class="main-content__illustration"
+ src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/add-firewall-rule.jpeg"
+ alt="Add a new rule"/>
+
+6. Verify the connection to the RDS service from your EC2 instance. Please note,
+you will be prompted to enter the master password. This should be the same password
+that you used when creating your AWS RDS service.
+```sh
+# psql -h <rds_endpoint> -p <rds_port> -U postgres -c "select 1"
+psql -h aws-rds-migration-guide-db.csupoydrdg9f.us-east-1.rds.amazonaws.com -p 5432 -U postgres -c "select 1"
+Password for user postgres:
+ ?column?
+----------
+        1
+(1 row)
+```
+
+## Performing data migration
+
+<GettingHelp />
+
+<SourceTargetNote />
+
+The migration process consists of the following steps:
+1. Set up a target database instance in Timescale.
+2. Migrate roles and schema from source to target.
+3. [optional] Enable TimescaleDB Hypertables.
+4. Migrate data from source to target.
+5. Verify data in target by comparing with source.
+
+<StepOne />
+
+## 2. Migrate roles and schema from source to target
+Before starting the migration process, you should ensure that your source database
+is not receiving any DML queries. This is important to guarantee a consistent
+migration and to ensure that the resulting database accurately reflects your source database.
+
+<Highlight type="important">
+This will cause a downtime on applications that depend (write) on the source
+database. The duration of downtime depends on the size of the source database.
+
+For a low-downtime migration solution from AWS RDS Postgres service to Timescale,
+please refer the following document: TODO Harkishen
+</Highlight>
+
+### 2.a Migrate database roles from the source to target
+```sh
+pg_dumpall -d "$SOURCE" \
+  --quote-all-identifiers \
+  --roles-only \
+  --no-role-passwords \
+  --file=roles.sql
+```
+
+<Highlight type="important">
+Please note that AWS RDS does not permit dumping of roles with passwords, which
+is why the above command is executed with the `--no-role-passwords`. However,
+when the migration of roles to your Timescale instance is complete, you will
+need to manually assign passwords to the necessary roles using the following
+command: `ALTER ROLE role_name WITH PASSWORD 'password';`
+</Highlight>
+
+Timescale services do not support roles with superuser access. If your SQL dump
+includes roles that have such permissions, you'll need to modify the file to be
+compliant with the security model.
+
+You can use the following `sed` command to remove unsupported statements and
+permissions from your `roles.sql` file:
+```sh
+sed -i -E \
+-e '/CREATE ROLE "postgres";/d' \
+-e '/ALTER ROLE "postgres"/d' \
+-e '/CREATE ROLE "rds/d' \
+-e '/ALTER ROLE "rds/d' \
+-e '/TO "rds/d' \
+-e '/GRANT "rds/d' \
+-e 's/(NO)*SUPERUSER//g' \
+-e 's/(NO)*REPLICATION//g' \
+-e 's/(NO)*BYPASSRLS//g' \
+-e 's/GRANTED BY "[^"]*"//g' \
+roles.sql
+```
+
+<Highlight type="info">
+This command works only with the GNU implementation of `sed` (sometimes referred
+to as `gsed`). For the BSD implementation (the default on macOS), you need to add
+an extra argument to change the `-i` flag to `-i ''`.
+
+To check the sed version, you can use the command `sed --version`. While the
+GNU version explicitly identifies itself as GNU, the BSD version of sed
+generally doesn't provide a straightforward `--version` flag and simply outputs
+an "illegal option" error.
+</Highlight>
+
+A brief explanation of this script is:
+* `CREATE ROLE "postgres";` and `ALTER ROLE "postgres"`: These statements are
+removed because they require superuser access, which is not supported by Timescale.
+* `CREATE ROLE "rds`, `ALTER ROLE “rds`, `TO "rds`, `GRANT "rds`: Any creation
+or alteration of rds prefixed roles are removed because of their lack of any use
+in a Timescale instance. Similarly, any grants to or from "rds" prefixed roles
+are ignored as well.
+* `(NO)SUPERUSER`, `(NO)REPLICATION`, `(NO)BYPASSRLS`: Assigning these permissions
+to a role is an action that requires superuser privileges.
+* `GRANTED BY` role_specification: The GRANTED BY clause can also have permissions
+that require superuser access and should therefore be removed. Note: As per the
+TimescaleDB documentation, the GRANTOR in the GRANTED BY clause must be the
+current user, and this clause mainly serves the purpose of SQL compatibility.
+Therefore, it's safe to remove it.
+
+### 2.b Dump the database schema from the source database
+```sh
+pg_dump -d "$SOURCE" \
+  --format=plain \
+  --quote-all-identifiers \
+  --no-tablespaces \
+  --no-owner \
+  --no-privileges \
+  --schema-only \
+  --file=schema.sql
+```
+* `--schema-only` is used to dump only the object definitions (schema), not data.
+* `--no-tablespaces` is required because Timescale does not support tablespaces
+other than the default. This is a known limitation.
+* `--no-owner` is required because Timescale's tsdbadmin user is not a superuser
+and cannot assign ownership in all cases. This flag means that everything is owned
+by the user used to connect to the target, regardless of ownership in the source.
+This is a known limitation.
+* `--no-privileges` is required because Timescale's tsdbadmin user is not a
+superuser and cannot assign privileges in all cases. This flag means that
+privileges assigned to other users must be reassigned in the target database as a
+manual clean-up task. This is a known limitation.
+
+#### 2.c Load the roles and schema into the target database
+```sh
+psql -X -d "$TARGET" \
+  -v ON_ERROR_STOP=1 \
+  --echo-errors \
+  -f roles.sql \
+  -f schema.sql
+```
+
+### 3. [Optional] Enable TimescaleDB Hypertables
+Before restoring data from your source database, you might consider converting
+standard Postgres tables into TimescaleDB Hypertables. This stage of the migration
+process presents an optimal opportunity for such a conversion. Essentially, you’ll
+want to transform Postgres tables that contains time series data. For each table
+that you plan to convert into a Hypertable in the target database, execute the
+following command:
+
+```sh
+psql -X -d "$TARGET" \
+  -v ON_ERROR_STOP=1 \
+  -c "SELECT create_hypertable('<table name>', '<time column name>')"
+```
+
+A more detailed explanation can be found in the [hypertable documentation][hypertable-docs].
+Once the table is converted, you can follow the guides to enable more Timescale
+features like [retention] and [compression].
+
+<Highlight type="important">
+This step is optional, but we strongly recommend that you perform it now.
+
+While it is possible to convert a table to a Hypertable after the migration is
+complete, this requires effectively rewriting all data in the table, which locks
+the table for the duration of the operation and prevents writes.
+</Highlight>
+
+## 4. Migrate data from source to target database
+### 4.a Dump data from source database
+Using pg_dump, dump the data from source database into intermediate storage
+```sh
+pg_dump -d "$SOURCE" \
+  --format=plain \
+  --quote-all-identifiers \
+  --no-tablespaces \
+  --no-owner \
+  --no-privileges \
+  --data-only \
+  --file=dump.sql
+```
+
+### 4.b Restore data to target database
+Restore the dump file to Timescale instance
+```sh
+psql -d $TARGET -v ON_ERROR_STOP=1 --echo-errors \
+    -f dump.sql
+```
+Update the table statistics by running ANALYZE on all data
+```sh
+psql -d $TARGET -c "ANALYZE;"
+```
+
+## 5. Verify data in the target database
+Verify that the data has been successfully restored by connecting to the target
+database and querying the restored data.
+
+Once you have verified that the data is present, and returns the results that you
+expect, you can reconfigure your applications to use the target database.
+
+[hypertable-docs]: https://docs.timescale.com/use-timescale/latest/hypertables/
+[retention]: https://docs.timescale.com/use-timescale/latest/data-retention/
+[compression]: https://docs.timescale.com/use-timescale/latest/compression/

--- a/migrate/playbooks/rds-timescale-pg-dump.md
+++ b/migrate/playbooks/rds-timescale-pg-dump.md
@@ -1,5 +1,5 @@
 ---
-title: Migrate from RDS to Timescale using pg_dump
+title: Migrate from AWS RDS to Timescale using pg_dump
 excerpt: Migrate from a PostgreSQL database in AWS RDS to Timescale using pg_dump
 products: [cloud]
 keywords: [data migration, postgresql, RDS]
@@ -17,12 +17,13 @@ This guide illustrates the process of migrating a Postgres database from an
 AWS RDS service to a Timescale instance. We will use Postgres community tools
 like `pg_dump` and `pg_restore` to facilitate the migration process.
 
-<Highlight type="important">
-Please be aware that this migration process requires a period of downtime for
-your production database, the duration of which is subject to the size of your
-database. If you want a migration solution from your RDS instance to Timescale
-that offers low downtime, please refer the following document: TODO HARKISHEN
-</Highlight>
+Migrating data using pg_dump requires a period of downtime for
+your production database, the duration of which is proportional to the size of your
+database. Your applications will not be able to write to your production database
+during the migration process. If you want a migration solution from your RDS instance to Timescale
+that offers low downtime, please refer to [AWS RDS to Timescale using live migration][live-migration]
+
+<SourceTargetNote />
 
 ## Prerequisites
 Before initiating the migration process, you will require:
@@ -75,40 +76,37 @@ machine in the same VPC as the RDS service.
  alt="Start configuring your instance"/>
 
 3. Configure your EC2 instance.
-* For "Instance type", use 2 CPU and 8 GB memory at least. If your migration involves
-a larger database, you should choose accordingly.
-<img class="main-content__illustration"
- src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-1.jpeg"
- alt="Choose instance type"/>
 
-* For "Key pair", you can choose to use an existing key pair or create a new one.
-This will be necessary when connecting to the EC2 instance from your local machine.
-* For "Network Settings", select the same VPC that your RDS instance is located in.
-Also, modify the "Source Type" of the security group to "My IP" so that your local
-machine can connect to the EC2 instance.
-<img class="main-content__illustration"
- src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-2.jpeg"
- alt="Configure network"/>
+  a. For "Application and OS image", choose Ubuntu Server LTS.
 
-* For "Configure Storage" section, adjust the volume size to match the size of
-your database. If necessary, you should enable encryption on your volume.
-<img class="main-content__illustration"
- src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-3.jpeg"
- alt="Configure storage"/>
+  b. For "Instance type", use 2 CPU and 8 GB memory at least. If your migration involves
+  a larger database, you should choose accordingly.
+  <img class="main-content__illustration"
+    src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-1.jpeg"
+    alt="Choose instance type"/>
 
-* Review the summary of the instance and click "Launch instance".
+  c. For "Key pair", you can choose to use an existing key pair or create a new one.
+  This will be necessary when connecting to the EC2 instance from your local machine.
+
+  d. For "Network Settings", select the same VPC that your RDS instance is located in.
+  Also, modify the "Source Type" of the security group to "My IP" so that your local
+  machine can connect to the EC2 instance.
+  <img class="main-content__illustration"
+    src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-2.jpeg"
+    alt="Configure network"/>
+
+  e. For "Configure Storage" section, adjust the volume size to match the size of
+  your database. If necessary, you should enable encryption on your volume.
+  <img class="main-content__illustration"
+    src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-3.jpeg"
+    alt="Configure storage"/>
+
+4. Review the summary of the instance and click "Launch instance".
 <img class="main-content__illustration"
  src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/configure-ec2-4.jpeg"
  alt="Review EC2 instance"/>
 
 #### Prepare the EC2 instance
-
-<Highlight type="important">
-The procedures outlined in this, as well as subsequent sections, are based on the
-assumption that an Ubuntu Amazon Machine Image (AMI) was selected during the
-setup of the EC2 instance.
-</Highlight>
-
 To prepare your EC2 instance for migration:
 1. Navigate to your EC2 instance and click on the "Connect" button.
 <img class="main-content__illustration"
@@ -137,23 +135,24 @@ psql --version && pg_dump --version
 
 5. To allow an EC2 instance to connect to an RDS instance, you need to modify the
 security group associated with your RDS instance.
-* Note the Private IPv4 address of your EC2 instance.
-<img class="main-content__illustration"
- src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/private-ipv4-address.jpeg"
- alt="Note private IPv4 address of your EC2 instance"/>
 
-* Go to the security group associated with your RDS instance and select
-"Edit inbound rules".
-<img class="main-content__illustration"
- src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/modify-firewall-rules.jpeg"
- alt="Edit inbound rules"/>
+  a. Note the Private IPv4 address of your EC2 instance.
+  <img class="main-content__illustration"
+    src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/private-ipv4-address.jpeg"
+    alt="Note private IPv4 address of your EC2 instance"/>
 
-* Choose "Add rule". In the "Type" field, select "PostgreSQL". For "Source", select
-"Custom" and input the Private IPv4 address of your EC2 instance. Add a
-suitable description for this rule. Finally, click on "Save rules" to apply the changes.
-<img class="main-content__illustration"
- src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/add-firewall-rule.jpeg"
- alt="Add a new rule"/>
+  b. Go to the security group associated with your RDS instance and select
+  "Edit inbound rules".
+  <img class="main-content__illustration"
+    src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/modify-firewall-rules.jpeg"
+    alt="Edit inbound rules"/>
+
+  c. Choose "Add rule". In the "Type" field, select "PostgreSQL". For "Source", select
+  "Custom" and input the Private IPv4 address of your EC2 instance. Add a
+  suitable description for this rule. Finally, click on "Save rules" to apply the changes.
+  <img class="main-content__illustration"
+    src="https://assets.timescale.com/docs/images/playbooks/rds-to-ts-pg_dump/add-firewall-rule.jpeg"
+    alt="Add a new rule"/>
 
 6. Verify the connection to the RDS service from your EC2 instance. Please note,
 you will be prompted to enter the master password. This should be the same password
@@ -168,11 +167,9 @@ Password for user postgres:
 (1 row)
 ```
 
-## Performing data migration
-
 <GettingHelp />
 
-<SourceTargetNote />
+## Performing data migration
 
 The migration process consists of the following steps:
 1. Set up a target database instance in Timescale.
@@ -189,11 +186,13 @@ is not receiving any DML queries. This is important to guarantee a consistent
 migration and to ensure that the resulting database accurately reflects your source database.
 
 <Highlight type="important">
-This will cause a downtime on applications that depend (write) on the source
-database. The duration of downtime depends on the size of the source database.
+For a consistent migration of data from source to target, your production applications
+should not be writing to your source database (i.e., they will have to undergo a downtime),
+otherwise, the data written to the source database after starting the migration process
+will not be present on the target database.
 
-For a low-downtime migration solution from AWS RDS Postgres service to Timescale,
-please refer the following document: TODO Harkishen
+If you want to write to your source database during the migration process, please refer
+to the [live-migration] playbook.
 </Highlight>
 
 ### 2.a Migrate database roles from the source to target
@@ -269,6 +268,7 @@ database and querying the restored data.
 Once you have verified that the data is present, and returns the results that you
 expect, you can reconfigure your applications to use the target database.
 
+[live-migration]: /migrate/:currentVersion:/playbooks/rds-timescale-live-migration/
 [hypertable documentation]: /use-timescale/:currentVersion:/hypertables/
 [retention]: /use-timescale/:currentVersion:/data-retention/
 [compression]: /use-timescale/:currentVersion:/compression/


### PR DESCRIPTION
# Description

This pull request introduces two playbooks aimed at facilitating the migration of a Postgres RDS database to Timescale. One playbook utilizes pg_dump, involving downtime, while the other employs live migration for minimal disruption. These comprehensive playbooks serve as detailed guides, outlining a precise process for transitioning from the AWS RDS Postgres platform.

# Links

Fixes https://github.com/timescale/team-data-onboarding/issues/16

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
