### PR TITLE
live-migration: Split schema dump into pre-data/post-data

### DIFF
--- a/_partials/_migrate_post_data_dump_source_schema.md
+++ b/_partials/_migrate_post_data_dump_source_schema.md
@@ -7,13 +7,14 @@ pg_dump -d "$SOURCE" \
   --no-tablespaces \
   --no-owner \
   --no-privileges \
-  --schema-only \
-  --file=dump.sql \
+  --section=post-data \
+  --file=post-data-dump.sql \
   --snapshot=$(cat /tmp/pgcopydb/snapshot)
 ```
 
-- `--schema-only` is used to dump only the object definitions (schema), not
-  data.
+- `--section=post-data` is used to dump post-data items include definitions of
+   indexes, triggers, rules, and constraints other than validated check
+   constraints.
 
 - `--snapshot` is used to specified the synchronized [snapshot][snapshot] when
   making a dump of the database.

--- a/_partials/_migrate_pre_data_dump_source_schema.md
+++ b/_partials/_migrate_pre_data_dump_source_schema.md
@@ -1,0 +1,24 @@
+import ExplainPgDumpFlags from "versionContent/_partials/_migrate_explain_pg_dump_flags.mdx";
+
+```sh
+pg_dump -d "$SOURCE" \
+  --format=plain \
+  --quote-all-identifiers \
+  --no-tablespaces \
+  --no-owner \
+  --no-privileges \
+  --section=pre-data \
+  --file=pre-data-dump.sql \
+  --snapshot=$(cat /tmp/pgcopydb/snapshot)
+```
+
+- `--section=pre-data` is used to dump only the definition of tables,
+  sequences, check constraints and inheritance hierarchy. It excludes
+  indexes, foreign key constraints, triggers and rules.
+
+- `--snapshot` is used to specified the synchronized [snapshot][snapshot] when
+  making a dump of the database.
+
+<ExplainPgDumpFlags />
+
+[snapshot]: https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-SNAPSHOT-SYNCHRONIZATION

--- a/migrate/playbooks/rds-timescale-live-migration.md
+++ b/migrate/playbooks/rds-timescale-live-migration.md
@@ -10,8 +10,7 @@ import GettingHelp from "versionContent/_partials/_migrate_dual_write_backfill_g
 import SourceTargetNote from "versionContent/_partials/_migrate_source_target_note.mdx";
 import StepOne from "versionContent/_partials/_migrate_dual_write_step1.mdx";
 import LiveMigrationRoles from "versionContent/_partials/_migrate_live_migration_rds_roles.mdx";
-import DumpDatabaseRoles from "versionContent/_partials/_migrate_dual_write_dump_database_roles.mdx";
-import DumpSourceSchema from "versionContent/_partials/_migrate_dump_source_schema.mdx";
+import DumpPreDataSourceSchema from "versionContent/_partials/_migrate_pre_data_dump_source_schema.mdx";
 
 # Migrate from AWS RDS to Timescale using live migration with low-downtime
 This document provides a step-by-step guide to migrating a database from an AWS
@@ -383,7 +382,7 @@ initial migration, and the longer the buffered files need to be stored.
 <LiveMigrationRoles />
 
 ### 4.b Dump the database schema from the source database
-<DumpSourceSchema />
+<DumpPreDataSourceSchema />
 
 ### 4.c Load the roles and schema into the target database
 ```sh
@@ -391,7 +390,7 @@ psql -X -d "$TARGET" \
   -v ON_ERROR_STOP=1 \
   --echo-errors \
   -f roles.sql \
-  -f schema.sql
+  -f pre-data-dump.sql
 ```
 
 ## 5. Perform "live migration"

--- a/migrate/playbooks/rds-timescale-pg-dump.md
+++ b/migrate/playbooks/rds-timescale-pg-dump.md
@@ -10,7 +10,8 @@ import GettingHelp from "versionContent/_partials/_migrate_dual_write_backfill_g
 import SourceTargetNote from "versionContent/_partials/_migrate_source_target_note.mdx";
 import StepOne from "versionContent/_partials/_migrate_dual_write_step1.mdx";
 import LiveMigrationRoles from "versionContent/_partials/_migrate_live_migration_rds_roles.mdx";
-import DumpSourceSchema from "versionContent/_partials/_migrate_dump_source_schema.mdx";
+import DumpPreDataSourceSchema from "versionContent/_partials/_migrate_pre_data_dump_source_schema.mdx";
+import DumpPostDataSourceSchema from "versionContent/_partials/_migrate_post_data_dump_source_schema.mdx";
 
 # Migrate from AWS RDS to Timescale using pg_dump with downtime
 This guide illustrates the process of migrating a Postgres database from an
@@ -199,7 +200,7 @@ to the [live-migration] playbook.
 <LiveMigrationRoles />
 
 ### 2.b Dump the database schema from the source database
-<DumpSourceSchema />
+<DumpPreDataSourceSchema />
 
 #### 2.c Load the roles and schema into the target database
 ```sh
@@ -207,7 +208,7 @@ psql -X -d "$TARGET" \
   -v ON_ERROR_STOP=1 \
   --echo-errors \
   -f roles.sql \
-  -f schema.sql
+  -f pre-data-dump.sql
 ```
 
 ### 3. [Optional] Enable TimescaleDB Hypertables
@@ -250,11 +251,15 @@ pg_dump -d "$SOURCE" \
   --file=dump.sql
 ```
 
+### 4b. Dump the database indexes, constraints and other objects
+<DumpPostDataSourceSchema />
+
 ### 4.b Restore data to target database
 Restore the dump file to Timescale instance
 ```sh
 psql -d $TARGET -v ON_ERROR_STOP=1 --echo-errors \
-    -f dump.sql
+    -f dump.sql \
+    -f post-data-dump.sql
 ```
 Update the table statistics by running ANALYZE on all data
 ```sh


### PR DESCRIPTION

# Description

This change avoids foreign violation error while copying table-data concurrently using pgcopydb. 

# Links

Fixes https://github.com/timescale/team-data-onboarding/issues/42

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
