### PR TITLE
Changed link for streaming replication

### DIFF
--- a/self-hosted/replication-and-ha/configure-replication.md
+++ b/self-hosted/replication-and-ha/configure-replication.md
@@ -17,8 +17,8 @@ more database replicas.
 Before you begin, make sure you have at least two separate instances of
 TimescaleDB running. If you installed TimescaleDB using a Docker container, use
 a [PostgreSQL entry point script][docker-postgres-scripts] to run the
-configuration. For sample Docker configuration and run scripts, see the
-[streaming replication Docker repository][timescale-streamrep-docker].
+configuration. For more advanced examples, see the
+[Timescale Helm Charts repository][timescale-streamrep-helm].
 
 To configure replication on self-hosted TimescaleDB, you need to perform these
 procedures:
@@ -436,5 +436,5 @@ check out [Patroni][patroni-github].
 [postgres-rslots-docs]: https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS
 [postgres-synchronous-commit-docs]: https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT
 [replication-modes]: /self-hosted/:currentVersion:/replication-and-ha/configure-replication#replication-modes
-[timescale-streamrep-docker]: https://github.com/timescale/streaming-replication-docker
+[timescale-streamrep-helm]: https://github.com/timescale/helm-charts/tree/main/charts/timescaledb-single
 [verify-replica]: /self-hosted/:currentVersion:/replication-and-ha/configure-replication#verify-that-the-replica-is-working


### PR DESCRIPTION
The streaming-replication-docker repository is outdated. Link to Helm charts instead.

# Description

[Short summary of why you created this PR]

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
