### PR TITLE
Use schema qualified function

### DIFF
--- a/migrate/pg-dump-and-restore/pg-dump-restore-from-timescaledb.md
+++ b/migrate/pg-dump-and-restore/pg-dump-restore-from-timescaledb.md
@@ -97,9 +97,9 @@ The following command loads the dumped data into the target database:
 ```bash
 psql $TARGET -v ON_ERROR_STOP=1 --echo-errors \
     -f roles.sql \
-    -c "SELECT timescaledb_pre_restore();" \
+    -c "SELECT public.timescaledb_pre_restore();" \
     -f dump.sql \
-    -c "SELECT timescaledb_post_restore();"
+    -c "SELECT public.timescaledb_post_restore();"
 ```
 
 It uses [timescaledb_pre_restore] and [timescaledb_post_restore] to put your


### PR DESCRIPTION
The documentation for migration mentions the use of "timescaledb_post_restore" function post the loading of the data.

However, the standard dump file generated using pg_dump unsets the search_path. So, it's important to use the schema qualified function. Otherwise the command errors out at the end because it cannot find the "timescaledb_post_restore" function.

# Description

[Short summary of why you created this PR]

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
