### PR TITLE
Use correct HA image name.

### DIFF
--- a/self-hosted/install/installation-docker.md
+++ b/self-hosted/install/installation-docker.md
@@ -34,7 +34,7 @@ instead.
 1.  At the command prompt, run the TimescaleDB Docker image:
 
     ```bash
-    docker pull timescale/timescaledb-ha:pg14-latest
+    docker pull timescale/timescaledb-ha:pg14
     ```
 
 <Highlight type="important">
@@ -76,7 +76,7 @@ If you want to run the image directly from the container, you can use this
 command:
 
 ```bash
-docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14-latest
+docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14
 ```
 
 The `-p` flag binds the container port to the host port. This means that
@@ -91,7 +91,7 @@ using this command:
 
 ```bash
 docker run -d --name timescaledb -p 127.0.0.1:5432:5432 \
--e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14-latest
+-e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14
 ```
 
 If you don't want to install `psql` and other PostgreSQL client tools locally,
@@ -127,7 +127,7 @@ make sure you select the correct one to mount:
 ```bash
 docker run -d --name timescaledb -p 5432:5432 \
 -v /your/data/dir:/home/postgres/pgdata/data \
--e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14-latest
+-e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14
 ```
 
 When you install TimescaleDB using a Docker container, the PostgreSQL settings

--- a/self-hosted/install/installation-docker.md
+++ b/self-hosted/install/installation-docker.md
@@ -34,7 +34,7 @@ instead.
 1.  At the command prompt, run the TimescaleDB Docker image:
 
     ```bash
-    docker pull timescale/timescaledb-ha:pg14
+    docker pull timescale/timescaledb-ha:pg16
     ```
 
 <Highlight type="important">
@@ -43,7 +43,7 @@ offers the most complete TimescaleDB experience. It
 includes the
 [TimescaleDB Toolkit](https://github.com/timescale/timescaledb-toolkit),
 and support for PostGIS and Patroni. If you need the smallest possible image, use
-the `timescale/timescaledb:latest-pg14` image instead.
+the `timescale/timescaledb:latest-pg16` image instead.
 </Highlight>
 
 </Procedure>
@@ -76,7 +76,7 @@ If you want to run the image directly from the container, you can use this
 command:
 
 ```bash
-docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14
+docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg16
 ```
 
 The `-p` flag binds the container port to the host port. This means that
@@ -91,7 +91,7 @@ using this command:
 
 ```bash
 docker run -d --name timescaledb -p 127.0.0.1:5432:5432 \
--e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14
+-e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg16
 ```
 
 If you don't want to install `psql` and other PostgreSQL client tools locally,
@@ -127,7 +127,7 @@ make sure you select the correct one to mount:
 ```bash
 docker run -d --name timescaledb -p 5432:5432 \
 -v /your/data/dir:/home/postgres/pgdata/data \
--e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg14
+-e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg16
 ```
 
 When you install TimescaleDB using a Docker container, the PostgreSQL settings

--- a/self-hosted/install/installation-docker.md
+++ b/self-hosted/install/installation-docker.md
@@ -43,7 +43,7 @@ offers the most complete TimescaleDB experience. It
 includes the
 [TimescaleDB Toolkit](https://github.com/timescale/timescaledb-toolkit),
 and support for PostGIS and Patroni. If you need the smallest possible image, use
-the `timescale/timescaledb:latest-pg16` image instead.
+the `timescale/timescaledb:latest-pg14` image instead.
 </Highlight>
 
 </Procedure>

--- a/self-hosted/tooling/install-toolkit.md
+++ b/self-hosted/tooling/install-toolkit.md
@@ -44,7 +44,7 @@ The recommended way to install the Toolkit is to use the
 To get Toolkit, use the high availability image, `timescaledb-ha`:
 
 ```bash
-docker pull timescale/timescaledb-ha:pg14-latest
+docker pull timescale/timescaledb-ha:pg14
 ```
 
 <Highlight type="important">

--- a/self-hosted/tooling/install-toolkit.md
+++ b/self-hosted/tooling/install-toolkit.md
@@ -44,7 +44,7 @@ The recommended way to install the Toolkit is to use the
 To get Toolkit, use the high availability image, `timescaledb-ha`:
 
 ```bash
-docker pull timescale/timescaledb-ha:pg14
+docker pull timescale/timescaledb-ha:pg16
 ```
 
 <Highlight type="important">

--- a/self-hosted/upgrades/upgrade-docker.md
+++ b/self-hosted/upgrades/upgrade-docker.md
@@ -84,7 +84,7 @@ data.
     [TimescaleDB HA Docker Hub repository](https://hub.docker.com/r/timescale/timescaledb-ha/tags).
 
     ```bash
-    docker pull timescale/timescaledb-ha:pg14
+    docker pull timescale/timescaledb-ha:pg16
     ```
 
 1.  Stop the old container, and remove it:

--- a/self-hosted/upgrades/upgrade-docker.md
+++ b/self-hosted/upgrades/upgrade-docker.md
@@ -84,7 +84,7 @@ data.
     [TimescaleDB HA Docker Hub repository](https://hub.docker.com/r/timescale/timescaledb-ha/tags).
 
     ```bash
-    docker pull timescale/timescaledb-ha:pg14-latest
+    docker pull timescale/timescaledb-ha:pg14
     ```
 
 1.  Stop the old container, and remove it:


### PR DESCRIPTION
This change is reflected in the timescale/timescaledb-docker-ha:README.md here: https://github.com/timescale/timescaledb-docker-ha/commit/3130e39131cb14f6b58b51434679ab2c2e9308d2

This is due to the 'Refactor base HA image' commit https://github.com/timescale/timescaledb-docker-ha/commit/880b01f9cd81f60d3d078a4bb119228d3979b712

# Description

[Short summary of why you created this PR]

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
