### PR TITLE
Add pg_dumpall error note

### DIFF
--- a/_partials/_migrate_dual_write_dump_database_roles.md
+++ b/_partials/_migrate_dual_write_dump_database_roles.md
@@ -1,9 +1,23 @@
 ```bash
 pg_dumpall -d "$SOURCE" \
+  -l $DB_NAME \
   --quote-all-identifiers \
   --roles-only \
   --file=roles.sql
 ```
+
+<Highlight type="important">
+Some providers like Managed Service for TimescaleDB (MST) and AWS RDS don't
+support role password dumps. If dumping the passwords results in the error:
+
+```
+pg_dumpall: error: query failed: ERROR:  permission denied for table pg_authid
+```
+
+Execute the command adding the `--no-role-passwords` flag. After restoring the
+roles into the target database, manually set passwords with `ALTER ROLE name
+WITH PASSWORD '<YOUR_PASSOWRD>';`
+</Highlight>
 
 Timescale services do not support roles with superuser access. If your SQL
 dump includes roles that have such permissions, you'll need to modify the file

--- a/_partials/_migrate_set_up_source_and_target.md
+++ b/_partials/_migrate_set_up_source_and_target.md
@@ -5,7 +5,7 @@ databases are referred to as `$SOURCE` and `$TARGET` throughout this guide.
 This can be set in your shell, for example:
 
 ```bash
-export SOURCE=postgres://<user>:<password>@<source host>:<source port>/<dbname>
-export TARGET=postgres://<user>:<password>@<target host>:<target port>/<dbname>
+export SOURCE=postgres://<user>:<password>@<source host>:<source port>/<db_name>
+export TARGET=postgres://<user>:<password>@<target host>:<target port>/<db_name>
 ```
 </Highlight>

--- a/migrate/pg-dump-and-restore/pg-dump-restore-from-postgres.md
+++ b/migrate/pg-dump-and-restore/pg-dump-restore-from-postgres.md
@@ -11,6 +11,7 @@ import MinimalDowntime from "versionContent/_partials/_migrate_pg_dump_minimal_d
 import SetupSourceTarget from "versionContent/_partials/_migrate_set_up_source_and_target.mdx";
 import SourceTargetNote from "versionContent/_partials/_migrate_source_target_note.mdx";
 import ExplainPgDumpFlags from "versionContent/_partials/_migrate_explain_pg_dump_flags.mdx";
+import DumpDatabaseRoles from "versionContent/_partials/_migrate_dual_write_dump_database_roles.mdx";
 
 # Migrate from PostgreSQL using pg_dump/restore
 
@@ -48,17 +49,12 @@ Before you begin, ensure that you have:
 
 ## Dump the source database
 
+<SetupSourceTarget />
+
 Dump the roles from the source database (only necessary if you're using roles
 other than the default `postgres` role in your database):
 
-```bash
-pg_dumpall -d "$SOURCE" \
-  --quote-all-identifiers \
-  --roles-only \
-  --file=roles.sql
-```
-
-<SetupSourceTarget />
+<DumpDatabaseRoles />
 
 Dump the source database schema and data:
 

--- a/migrate/pg-dump-and-restore/pg-dump-restore-from-timescaledb.md
+++ b/migrate/pg-dump-and-restore/pg-dump-restore-from-timescaledb.md
@@ -12,6 +12,7 @@ import SetupSourceTarget from "versionContent/_partials/_migrate_set_up_source_a
 import TimescaleDBVersion from "versionContent/_partials/_migrate_from_timescaledb_version.mdx";
 import ExplainPgDumpFlags from "versionContent/_partials/_migrate_explain_pg_dump_flags.mdx";
 import MinimalDowntime from "versionContent/_partials/_migrate_pg_dump_minimal_downtime.mdx";
+import DumpDatabaseRoles from "versionContent/_partials/_migrate_dual_write_dump_database_roles.mdx";
 
 # Migrate from TimescaleDB using pg_dump/restore
 
@@ -49,17 +50,12 @@ Before you begin, ensure that you have:
 
 ## Dump the source database
 
+<SetupSourceTarget />
+
 Dump the roles from the source database (only necessary if you're using roles
 other than the default `postgres` role in your database):
 
-```bash
-pg_dumpall -d "$SOURCE" \
-  --quote-all-identifiers \
-  --roles-only \
-  --file=roles.sql
-```
-
-<SetupSourceTarget />
+<DumpDatabaseRoles />
 
 Dump the source database schema and data:
 


### PR DESCRIPTION
# Description

When running pg_dumpall from MST or RDS some additional flags are required otherwise the command will throw an error:

- `--no-role-password` will not dump the passwords for the roles, this solves the `permission denied for table pg_authid` error. Since it means an extra step for the customer, they would have to manually set the passwords, we put it as an important note. Let them try first to see if it works and they can dump the password.
- `-l DB_NAME` solves the connection to `template1` error. Since this won't incur in additional steps for the user, we always set it up in the instructions.

# Links

Fixes https://github.com/timescale/team-data-onboarding/issues/8

*   [ ] Have you checked the built version of this content?
