### PR TITLE
Adding ap-northeast-1 and eu-west-2 regions

### DIFF
--- a/use-timescale/regions.md
+++ b/use-timescale/regions.md
@@ -6,16 +6,22 @@ product: cloud
 
 # Available regions
 
-Timescale is available in these clouds and regions:
-
-Amazon Web Services:
+Timescale is available in these AWS (Amazon Web Services) regions:
 
 |Region|Zone|Location|
 |-|-|-|
 |`ap-southeast-1`|Asia|Singapore|
 |`ap-southeast-2`|Australia|Sydney|
+|`ap-northeast-1`|Japan|Tokyo|
 |`eu-central-1`|Europe|Frankfurt|
 |`eu-west-1`|Europe|Ireland|
 |`us-east-1`|United States|North Virginia|
 |`us-east-2`|United States|Ohio|
 |`us-west-2`|United States|Oregon|
+
+Timescale is working on releasing 🔜 in the following AWS regions:
+
+|Region|Zone|Location|
+|-|-|-|
+|`ap-northeast-1`|Japan|Tokyo|
+|`eu-west-2`|Europe|London|


### PR DESCRIPTION
Includes a new section for the "coming soon" regions.

# Description

When we have regions on the roadmap I'd like to add them to the docs to make customers aware. Once we've landed them I'll merge the lists again and hide the "coming soon" section.

