### PR TITLE
Adding sa-east and ca-central to coming soon

### DIFF
--- a/use-timescale/regions.md
+++ b/use-timescale/regions.md
@@ -24,3 +24,5 @@ Timescale is working on releasing 🔜 in the following AWS regions:
 |-|-|-|
 |`ap-northeast-1`|Japan|Tokyo|
 |`eu-west-2`|Europe|London|
+|`sa-east-1`|South America|São Paulo|
+|`ca-central-1`|Canada|Central|


### PR DESCRIPTION
# Description

Adding both to the coming soon:
- South America (São Paulo) `sa-east-1`
- Canada (Central) `ca-central-1 `

