### PR TITLE
docs: remove resume warning from live-migration

### DIFF
--- a/migrate/live-migration/index.md
+++ b/migrate/live-migration/index.md
@@ -26,8 +26,6 @@ this means that you may run into the following shortcomings:
   replicated).
 - Live migration does not yet support mutable compression (`INSERT`, `UPDATE`,
   `DELETE` on compressed data).
-- In most cases it is not possible to resume a failed migration, and must be
-  restarted from the beginning.
 - By default, numeric fields containing `NaN`/`+Inf`/`-Inf` values are not
   correctly replicated, and will be converted to `NULL`. A workaround is
   available, but is not enabled by default.


### PR DESCRIPTION
# Description

With live-migration v0.0.7, we are able to resume from a failure in most scenarios that occur during data migration or live-replay.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
