### PR TITLE
Move multinode migration under playbooks

### DIFF
--- a/migrate/page-index/page-index.js
+++ b/migrate/page-index/page-index.js
@@ -25,12 +25,6 @@ module.exports = [
         ]
       },
       {
-        title: "With downtime: Multi-node to TimescaleDB service",
-        href: "multi-node-to-timescale-service",
-        excerpt:
-            "Migrate an entire multi-node deployment to a TimescaleDB service",
-      },
-      {
         title: "Low-downtime: Live migration",
         href: "live-migration",
         excerpt: "Migrate a large database with low downtime",
@@ -96,6 +90,12 @@ module.exports = [
             href: "rds-timescale-live-migration",
             excerpt:
                 "Migrate from RDS to Timescale using live migration",
+          },
+          {
+            title: "Multi-node to Timescale",
+            href: "multi-node-to-timescale-service",
+            excerpt:
+                "Migrate an entire multi-node deployment to Timescale",
           },
         ],
       },

--- a/migrate/playbooks/multi-node-to-timescale-service.md
+++ b/migrate/playbooks/multi-node-to-timescale-service.md
@@ -1,6 +1,6 @@
 ---
-title: Migrate from Multi-node to TimescaleDB
-excerpt: Migrate an entire multi-node deployment to a TimescaleDB instance with downtime using COPY
+title: Migrate from Multi-node to Timescale
+excerpt: Migrate an entire multi-node deployment to a Timescale instance with downtime using COPY
 products: [cloud]
 keywords: [migration, downtime]
 tags: [migration, multi-node, timescaledb]
@@ -59,7 +59,7 @@ Before you begin, ensure that you have:
 
 ## Migrate schema pre-data
 
-Migrate your pre-data from your source database to TimescaleDB instance. This
+Migrate your pre-data from your source database to your Timescale instance. This
 includes table and schema definitions, as well as information on sequences,
 owners, and settings. This doesn't include Timescale-specific schemas.
 
@@ -90,11 +90,11 @@ owners, and settings. This doesn't include Timescale-specific schemas.
 
 </Procedure>
 
-## Restore hypertables in TimescaleDB instance
+## Restore hypertables in your Timescale instance
 
 After pre-data migration, your distributed hypertables from your source database
 become regular PostgreSQL tables. Recreate them as regular hypertables
-in TimescaleDB instance to restore them. 
+in your Timescale instance to restore them. 
 
 <Highlight type="note">
 Distributed hypertables are typically created with additional
@@ -165,7 +165,7 @@ and copy each range individually. For example:
 ## Restore data into TimescaleDB instance
 
 When you have copied your data into `.csv` files, you can restore it to
-TimescaleDB instance by copying from the `.csv` files. There are two methods: using
+Timescale instance by copying from the `.csv` files. There are two methods: using
 regular PostgreSQL [`COPY`][copy], or using the TimescaleDB
 [`timescaledb-parallel-copy`][timescaledb-parallel-copy] function. The `timescaledb-parallel-copy`
 tool is not included by default. You must install the tool.


### PR DESCRIPTION
# Description

The multinode piece in the `Migrations` section disrupts the flow and is no longer very relevant. Saving the real estate for customers looking to migrate into Timescale by moving this under `Playbooks`.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
