### PR TITLE
Restrict usage of time_bucket_ng in CAggs

### DIFF
--- a/api/time_bucket_ng.md
+++ b/api/time_bucket_ng.md
@@ -202,10 +202,10 @@ This table shows which `time_bucket_ng()` functions can be used in a continuous 
 
 |Function|Available in continuous aggregate|TimescaleDB version|
 |-|-|-|
-|Buckets by seconds, minutes, hours, days, and weeks|✅|2.4.0 and later|
-|Buckets by months and years|✅|2.6.0 or later|
-|Timezones support|✅|2.6.0 or later|
-|Specify custom origin|✅|2.7.0 or later|
+|Buckets by seconds, minutes, hours, days, and weeks|✅|2.4.0 - 2.14.2|
+|Buckets by months and years|✅|2.6.0 - 2.14.2|
+|Timezones support|✅|2.6.0 - 2.14.2|
+|Specify custom origin|✅|2.7.0 - 2.14.2|
 
 [time_bucket]: /api/:currentVersion:/hyperfunctions/time_bucket/
 [caggs]: /use-timescale/:currentVersion:/continuous-aggregates/


### PR DESCRIPTION
The function time_bucket_ng is deprecated and should not be used in new CAggs. 2.15.0 (https://github.com/timescale/timescaledb/pull/6798) will also block the usage of this function.

# Description

[Short summary of why you created this PR]

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
