### PR TITLE
Add troubleshooting note about partial continuous aggregates

### DIFF
--- a/migrate/troubleshooting.md
+++ b/migrate/troubleshooting.md
@@ -225,7 +225,7 @@ operations and mitigate before migrating.
 ## Migrate partial continuous aggregates
 
 In order to improve the performance and compatibility of continuous aggregates, 
-[TimescaleDB v2.7][release-270] replaces _partial_ continuous aggregate with 
+[TimescaleDB v2.7][release-270] replaces _partial_ continuous aggregates with 
 _finalized_ continuous aggregates.
 
 To test your database for partial continuous aggregates, run the following query:
@@ -234,14 +234,14 @@ To test your database for partial continuous aggregates, run the following query
 SELECT exists (SELECT 1 FROM timescaledb_information.continuous_aggregates WHERE NOT finalized);
 ```
 
-If you have partial continuous aggregates in your database,  [migrate your existing database][migrate] 
-from partial to finalized continuous aggregates before you upgrade your PostgreSQL installation 
+If you have partial continuous aggregates in your database, [convert them][migrate] 
+from partial to finalized before you migrate your database.
 
 If you accidentally migrate partial continuous aggregates across PostgreSQL
 versions, you see the following error when you query any continuous aggregates:
 
 ```
-ERROR:  insufficient data left in message`.
+ERROR:  insufficient data left in message.
 ```
 
 [migrate]: /migrate/:currentVersion:/live-migration/

--- a/migrate/troubleshooting.md
+++ b/migrate/troubleshooting.md
@@ -221,3 +221,25 @@ Timescale instance or "merge" source databases to target schemas.
 The `tsdbadmin` database user is the most powerful available on Timescale, but it
 is not a true superuser. Review your application for use of superuser privileged
 operations and mitigate before migrating.
+
+## Migrating partial continuous aggregates (created before TimescaleDB 2.7)
+
+TimescaleDB 2.7 introduced "finalized" continuous aggregates to improve
+performance and compatibility of continuous aggregates. These have now replaced
+the previous "partial" form of continuous aggregate. Partial form continuous
+aggregates cannot be migrated across PostgreSQL versions. If you have partial
+form continuous aggregates and intend to migrate across PostgreSQL versions,
+you must first [migrate] the continuous aggregates from partial to finalized
+form.
+
+The following query returns true if you have partial continuous aggregates:
+
+```SQL
+SELECT exists (SELECT 1 FROM timescaledb_information.continuous_aggregates WHERE NOT finalized);
+```
+
+If you do happen to migrate partial continuous aggregates across PostgreSQL
+versions, the following error appears when the continuous aggregate is queried:
+`ERROR:  insufficient data left in message`.
+
+[migrate]: /migrate/:currentVersion:/live-migration/

--- a/migrate/troubleshooting.md
+++ b/migrate/troubleshooting.md
@@ -222,24 +222,28 @@ The `tsdbadmin` database user is the most powerful available on Timescale, but i
 is not a true superuser. Review your application for use of superuser privileged
 operations and mitigate before migrating.
 
-## Migrating partial continuous aggregates (created before TimescaleDB 2.7)
+## Migrate partial continuous aggregates
 
-TimescaleDB 2.7 introduced "finalized" continuous aggregates to improve
-performance and compatibility of continuous aggregates. These have now replaced
-the previous "partial" form of continuous aggregate. Partial form continuous
-aggregates cannot be migrated across PostgreSQL versions. If you have partial
-form continuous aggregates and intend to migrate across PostgreSQL versions,
-you must first [migrate] the continuous aggregates from partial to finalized
-form.
+In order to improve the performance and compatibility of continuous aggregates, 
+[TimescaleDB v2.7][release-270] replaces _partial_ continuous aggregate with 
+_finalized_ continuous aggregates.
 
-The following query returns true if you have partial continuous aggregates:
+To test your database for partial continuous aggregates, run the following query:
 
 ```SQL
 SELECT exists (SELECT 1 FROM timescaledb_information.continuous_aggregates WHERE NOT finalized);
 ```
 
-If you do happen to migrate partial continuous aggregates across PostgreSQL
-versions, the following error appears when the continuous aggregate is queried:
-`ERROR:  insufficient data left in message`.
+If you have partial continuous aggregates in your database,  [migrate your existing database][migrate] 
+from partial to finalized continuous aggregates before you upgrade your PostgreSQL installation 
+
+If you accidentally migrate partial continuous aggregates across PostgreSQL
+versions, you see the following error when you query any continuous aggregates:
+
+```
+ERROR:  insufficient data left in message`.
+```
 
 [migrate]: /migrate/:currentVersion:/live-migration/
+[release-270]: /about/:currentVersion:/release-notes/past-releases/#270-2022-05-24
+

--- a/migrate/troubleshooting.md
+++ b/migrate/troubleshooting.md
@@ -234,7 +234,7 @@ To test your database for partial continuous aggregates, run the following query
 SELECT exists (SELECT 1 FROM timescaledb_information.continuous_aggregates WHERE NOT finalized);
 ```
 
-If you have partial continuous aggregates in your database, [convert them][migrate] 
+If you have partial continuous aggregates in your database, [migrate them][migrate] 
 from partial to finalized before you migrate your database.
 
 If you accidentally migrate partial continuous aggregates across PostgreSQL


### PR DESCRIPTION
# Description

Partial continuous aggregates cannot be migrated across PostgreSQL versions.