### PR TITLE
Release notes 2.15.0

### DIFF
--- a/about/release-notes/index.md
+++ b/about/release-notes/index.md
@@ -17,6 +17,73 @@ GitHub and be notified by email whenever a new release is available. On the
 click `Watch`, select `Custom` and then check `Releases`.
 </Highlight>
 
+## TimescaleDB&nbsp;2.15.0 on 2024-05-08
+
+<Highlight type="note">
+This release contains performance improvements and bug fixes since
+the 2.14.2 release. We recommend that you upgrade at the next
+available opportunity.
+</Highlight>
+
+#### Highlighted features in this release
+* Support `time_bucket` with `origin` and/or `offset` on Continuous Aggregate
+* Compression improvements:
+  - Improve expression pushdown
+  - Add minmax sparse indexes when compressing columns with btree indexes
+  - Make compression use the defaults functions
+  - Vectorize filters in WHERE clause that contain text equality operators and LIKE expressions
+
+#### Deprecation warning
+* Starting on this release will not be possible to create Continuous Aggregate using `time_bucket_ng` anymore and it will be completely removed on the upcoming releases.
+* Recommend users to [migrate their old Continuous Aggregate format to the new one](https://docs.timescale.com/use-timescale/latest/continuous-aggregates/migrate/) because it support will be completely removed in next releases prevent them to migrate.
+* This is the last release supporting PostgreSQL 13.
+
+#### For on-premise users and this release only
+You will need to run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql) after running `ALTER EXTENSION`. More details can be found in the pull request [#6786](#6797).
+
+### Complete list of features
+* #6382 Support for time_bucket with origin and offset in CAggs
+* #6696 Improve defaults for compression segment_by and order_by
+* #6705 Add sparse minmax indexes for compressed columns that have uncompressed btree indexes
+* #6754 Allow DROP CONSTRAINT on compressed hypertables
+* #6767 Add metadata table `_timestaledb_internal.bgw_job_stat_history` for tracking job execution history
+* #6798 Prevent usage of deprecated time_bucket_ng in CAgg definition
+* #6810 Add telemetry for access methods
+* #6811 Remove no longer relevant timescaledb.allow_install_without_preload GUC
+* #6837 Add migration path for CAggs using time_bucket_ng
+* #6865 Update the watermark when truncating a CAgg
+
+### Complete list of bugfixes
+* #6617 Fix error in show_chunks
+* #6621 Remove metadata when dropping chunks
+* #6677 Fix snapshot usage in CAgg invalidation scanner
+* #6698 Define meaning of 0 retries for jobs as no retries
+* #6717 Fix handling of compressed tables with primary or unique index in COPY path
+* #6726 Fix constify cagg_watermark using window function when querying a CAgg
+* #6729 Fix NULL start value handling in CAgg refresh
+* #6732 Fix CAgg migration with custom timezone / date format settings
+* #6752 Remove custom autovacuum setting from compressed chunks
+* #6770 Fix plantime chunk exclusion for OSM chunk
+* #6789 Fix deletes with subqueries and compression
+* #6796 Fix a crash involving a view on a hypertable
+* #6797 Fix foreign key constraint handling on compressed hypertables
+* #6816 Fix handling of chunks with no contraints
+* #6820 Fix a crash when the ts_hypertable_insert_blocker was called directly
+* #6849 Use non-orderby compressed metadata in compressed DML
+* #6867 Clean up compression settings when deleting compressed cagg
+* #6869 Fix compressed DML with constraints of form value OP column
+* #6870 Fix bool expression pushdown for queries on compressed chunks
+
+### Acknowledgments
+* @brasic for reporting a crash when the ts_hypertable_insert_blocker was called directly
+* @bvanelli for reporting an issue with the jobs retry count
+* @djzurawsk For reporting error when dropping chunks
+* @Dzuzepppe for reporting an issue with DELETEs using subquery on compressed chunk working incorrectly.
+* @hongquan For reporting a 'timestamp out of range' error during CAgg migrations
+* @kevcenteno for reporting an issue with the show_chunks API showing incorrect output when 'created_before/created_after' was used with time-partitioned columns.
+* @mahipv For starting working on the job history PR
+* @rovo89 For reporting constify cagg_watermark not working using window function when querying a CAgg
+
 ## TimescaleDB&nbsp;2.14.2 on 2024-02-20
 
 <Highlight type="note">

--- a/about/release-notes/index.md
+++ b/about/release-notes/index.md
@@ -20,68 +20,75 @@ click `Watch`, select `Custom` and then check `Releases`.
 ## TimescaleDB&nbsp;2.15.0 on 2024-05-08
 
 <Highlight type="note">
-This release contains performance improvements and bug fixes introduced since
+This release contains the performance improvements and bug fixes introduced since
 TimescaleDB v2.14.2. Best practice is to upgrade at the next available opportunity.
 </Highlight>
 
 #### Highlighted features in this release
-* [Continuous Aggregate](/api/:currentVersion:/continuous-aggregates/create_materialized_view/#sample-usage) now support `time_bucket` with `origin` and/or `offset`.
+
+* [Continuous Aggregate](/api/:currentVersion:/continuous-aggregates/create_materialized_view/#sample-usage) now supports `time_bucket` with `origin` and/or `offset`.
 * The following improvements have been introduced for [hypertable compression](/api/:currentVersion:/compression/):
-  - Add planner support to check more kinds of WHERE conditions before decompression, therefore reducing the number of rows that have to be decompressed.
+  - Added planner support to check more kinds of WHERE conditions before decompression. 
+    This reduces the number of rows that have to be decompressed.
   - You can now use `minmax` sparse indexes when you compress columns with `btree` indexes.
-  - Make compression use the defaults functions.
-  - Vectorize filters in WHERE clause that contain text equality operators and LIKE expressions.
+  - Make compression uses the defaults functions.
+  - Vectorize filters in the WHERE clause contain text equality operators and LIKE expressions.
 
 #### Deprecation warning
-* You can no longer create continuous aggregates using `time_bucket_ng`. Best practice is to [migrate your current continuous aggregates to the new format](/use-timescale/:currentVersion:/continuous-aggregates/migrate/), this feature will be completely removed the next release.
-* Recommend users to [migrate their old Continuous Aggregate format to the new one](https://docs.timescale.com/use-timescale/latest/continuous-aggregates/migrate/) because it support will be completely removed in next releases prevent them to migrate.
+
+* You can no longer create continuous aggregates using `time_bucket_ng`.
+  This feature will be completely removed the next release. Best practice is to 
+  [migrate your current continuous aggregates to the new form](/use-timescale/:currentVersion:/continuous-aggregates/migrate/), 
 * This is the last release supporting PostgreSQL 13.
 
-#### For self-hosted deployments of TimescaleDB v2.15.0 only
-After you run `ALTER EXTENSION`, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull requests [#6786](#6797).
+#### For self-hosted TimescaleDB v2.15.0 deployments only
+
+After you run `ALTER EXTENSION`, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the 
+following pull requests [#6786](#6797).
 
 ### Complete list of features
-* #6382 Support for time_bucket with origin and offset in CAggs
-* #6696 Improve defaults for compression segment_by and order_by
-* #6705 Add sparse minmax indexes for compressed columns that have uncompressed btree indexes
-* #6754 Allow DROP CONSTRAINT on compressed hypertables
-* #6767 Add metadata table `_timestaledb_internal.bgw_job_stat_history` for tracking job execution history
-* #6798 Prevent usage of deprecated time_bucket_ng in CAgg definition
-* #6810 Add telemetry for access methods
-* #6811 Remove no longer relevant timescaledb.allow_install_without_preload GUC
-* #6837 Add migration path for CAggs using time_bucket_ng
-* #6865 Update the watermark when truncating a CAgg
+* #6382 Support for `time_bucket` with origin and offset in CAggs.
+* #6696 Improve the defaults for compression `segment_by` and `order_by`.
+* #6705 Add sparse minmax indexes for compressed columns that have uncompressed btree indexes.
+* #6754 Allow `DROP CONSTRAINT` on compressed hypertables.
+* #6767 Add metadata table `_timestaledb_internal.bgw_job_stat_history` for tracking job execution history.
+* #6798 Prevent usage of the deprecated `time_bucket_ng` in the CAgg definition.
+* #6810 Add telemetry for access methods.
+* #6811 Remove the no longer relevant `timescaledb.allow_install_without_preload` GUC.
+* #6837 Add migration path for CAggs using `time_bucket_ng`.
+* #6865 Update the watermark when truncating a CAgg.
 
 ### Complete list of bugfixes
-* #6617 Fix error in show_chunks
-* #6621 Remove metadata when dropping chunks
-* #6677 Fix snapshot usage in CAgg invalidation scanner
-* #6698 Define meaning of 0 retries for jobs as no retries
-* #6717 Fix handling of compressed tables with primary or unique index in COPY path
-* #6726 Fix constify cagg_watermark using window function when querying a CAgg
-* #6729 Fix NULL start value handling in CAgg refresh
-* #6732 Fix CAgg migration with custom timezone / date format settings
-* #6752 Remove custom autovacuum setting from compressed chunks
-* #6770 Fix plantime chunk exclusion for OSM chunk
-* #6789 Fix deletes with subqueries and compression
-* #6796 Fix a crash involving a view on a hypertable
-* #6797 Fix foreign key constraint handling on compressed hypertables
-* #6816 Fix handling of chunks with no contraints
-* #6820 Fix a crash when the ts_hypertable_insert_blocker was called directly
-* #6849 Use non-orderby compressed metadata in compressed DML
-* #6867 Clean up compression settings when deleting compressed cagg
-* #6869 Fix compressed DML with constraints of form value OP column
-* #6870 Fix bool expression pushdown for queries on compressed chunks
+* #6617 Fix error in show_chunks.
+* #6621 Remove metadata when dropping chunks.
+* #6677 Fix snapshot usage in CAgg invalidation scanner.
+* #6698 Define meaning of 0 retries for jobs as no retries.
+* #6717 Fix handling of compressed tables with primary or unique index in COPY path.
+* #6726 Fix constify cagg_watermark using window function when querying a CAgg.
+* #6729 Fix NULL start value handling in CAgg refresh.
+* #6732 Fix CAgg migration with custom timezone / date format settings.
+* #6752 Remove custom autovacuum setting from compressed chunks.
+* #6770 Fix plantime chunk exclusion for OSM chunk.
+* #6789 Fix deletes with subqueries and compression.
+* #6796 Fix a crash involving a view on a hypertable.
+* #6797 Fix foreign key constraint handling on compressed hypertables.
+* #6816 Fix handling of chunks with no constraints.
+* #6820 Fix a crash when the ts_hypertable_insert_blocker was called directly.
+* #6849 Use non-orderby compressed metadata in compressed DML.
+* #6867 Clean up compression settings when deleting compressed CAgg.
+* #6869 Fix compressed DML with constraints of form value OP column.
+* #6870 Fix bool expression pushdown for queries on compressed chunks.
 
 ### Acknowledgments
-* @brasic for reporting a crash when `ts_hypertable_insert_blocker` was called directly
-* @bvanelli for reporting an issue with the jobs retry count
-* @djzurawsk for reporting an error about dropping chunks
-* @Dzuzepppe for reporting the issue that DELETEs using a subquery on compressed chunks was working incorrectly
-* @hongquan for reporting a 'timestamp out of range' error during CAgg migrations
-* @kevcenteno for reporting that the `show_chunks` API returned an incorrect output when 'created_before/created_after' was used with time-partitioned columns
-* @mahipv for starting working on the job history PR
-* @rovo89 for reporting that constify `cagg_watermark` was not working using the window function when querying a CAgg
+* @brasic for reporting a crash when `ts_hypertable_insert_blocker` was called directly.
+* @bvanelli for reporting an issue with the jobs retry count.
+* @djzurawsk for reporting an error about dropping chunks.
+* @Dzuzepppe for reporting the issue that DELETEs using a subquery on compressed chunks was working incorrectly.
+* @hongquan for reporting a 'timestamp out of range' error during CAgg migrations.
+* @kevcenteno for reporting that the `show_chunks` API returned an incorrect output when 'created_before/created_after' 
+  was used with time-partitioned columns.
+* @mahipv for starting working on the job history PR.
+* @rovo89 for reporting that constify `cagg_watermark` was not working using the window function when querying a CAgg.
 
 ## TimescaleDB&nbsp;2.14.2 on 2024-02-20
 

--- a/about/release-notes/index.md
+++ b/about/release-notes/index.md
@@ -37,7 +37,7 @@ TimescaleDB v2.14.2. Best practice is to upgrade at the next available opportuni
 * Recommend users to [migrate their old Continuous Aggregate format to the new one](https://docs.timescale.com/use-timescale/latest/continuous-aggregates/migrate/) because it support will be completely removed in next releases prevent them to migrate.
 * This is the last release supporting PostgreSQL 13.
 
-#### For on-premise users and this release only
+#### For self-hosted deployments of TimescaleDB v2.15.0 only
 You will need to run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql) after running `ALTER EXTENSION`. More details can be found in the pull request [#6786](#6797).
 
 ### Complete list of features

--- a/about/release-notes/index.md
+++ b/about/release-notes/index.md
@@ -38,7 +38,7 @@ TimescaleDB v2.14.2. Best practice is to upgrade at the next available opportuni
 * This is the last release supporting PostgreSQL 13.
 
 #### For self-hosted deployments of TimescaleDB v2.15.0 only
-You will need to run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql) after running `ALTER EXTENSION`. More details can be found in the pull request [#6786](#6797).
+After you run `ALTER EXTENSION`, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull requests [#6786](#6797).
 
 ### Complete list of features
 * #6382 Support for time_bucket with origin and offset in CAggs

--- a/about/release-notes/index.md
+++ b/about/release-notes/index.md
@@ -20,21 +20,20 @@ click `Watch`, select `Custom` and then check `Releases`.
 ## TimescaleDB&nbsp;2.15.0 on 2024-05-08
 
 <Highlight type="note">
-This release contains performance improvements and bug fixes since
-the 2.14.2 release. We recommend that you upgrade at the next
-available opportunity.
+This release contains performance improvements and bug fixes introduced since
+TimescaleDB v2.14.2. Best practice is to upgrade at the next available opportunity.
 </Highlight>
 
 #### Highlighted features in this release
-* Support `time_bucket` with `origin` and/or `offset` on Continuous Aggregate
-* Compression improvements:
-  - Improve expression pushdown
-  - Add minmax sparse indexes when compressing columns with btree indexes
-  - Make compression use the defaults functions
-  - Vectorize filters in WHERE clause that contain text equality operators and LIKE expressions
+* [Continuous Aggregate](/api/:currentVersion:/continuous-aggregates/create_materialized_view/#sample-usage) now support `time_bucket` with `origin` and/or `offset`.
+* The following improvements have been introduced for [hypertable compression](/api/:currentVersion:/compression/):
+  - Add planner support to check more kinds of WHERE conditions before decompression, therefore reducing the number of rows that have to be decompressed.
+  - You can now use `minmax` sparse indexes when you compress columns with `btree` indexes.
+  - Make compression use the defaults functions.
+  - Vectorize filters in WHERE clause that contain text equality operators and LIKE expressions.
 
 #### Deprecation warning
-* Starting on this release will not be possible to create Continuous Aggregate using `time_bucket_ng` anymore and it will be completely removed on the upcoming releases.
+* You can no longer create continuous aggregates using `time_bucket_ng`. Best practice is to [migrate your current continuous aggregates to the new format](/use-timescale/:currentVersion:/continuous-aggregates/migrate/), this feature will be completely removed the next release.
 * Recommend users to [migrate their old Continuous Aggregate format to the new one](https://docs.timescale.com/use-timescale/latest/continuous-aggregates/migrate/) because it support will be completely removed in next releases prevent them to migrate.
 * This is the last release supporting PostgreSQL 13.
 
@@ -77,12 +76,12 @@ You will need to run [this SQL script](https://github.com/timescale/timescaledb-
 ### Acknowledgments
 * @brasic for reporting a crash when the ts_hypertable_insert_blocker was called directly
 * @bvanelli for reporting an issue with the jobs retry count
-* @djzurawsk For reporting error when dropping chunks
-* @Dzuzepppe for reporting an issue with DELETEs using subquery on compressed chunk working incorrectly.
-* @hongquan For reporting a 'timestamp out of range' error during CAgg migrations
-* @kevcenteno for reporting an issue with the show_chunks API showing incorrect output when 'created_before/created_after' was used with time-partitioned columns.
-* @mahipv For starting working on the job history PR
-* @rovo89 For reporting constify cagg_watermark not working using window function when querying a CAgg
+* @djzurawsk for reporting an error about dropping chunks
+* @Dzuzepppe for reporting the issue that DELETEs using a subquery on compressed chunks was working incorrectly
+* @hongquan for reporting a 'timestamp out of range' error during CAgg migrations
+* @kevcenteno for reporting that the `show_chunks` API returned an incorrect output when 'created_before/created_after' was used with time-partitioned columns
+* @mahipv for starting working on the job history PR
+* @rovo89 for reporting that constify `cagg_watermark` was not working using the window function when querying a CAgg
 
 ## TimescaleDB&nbsp;2.14.2 on 2024-02-20
 

--- a/about/release-notes/index.md
+++ b/about/release-notes/index.md
@@ -37,7 +37,7 @@ TimescaleDB v2.14.2. Best practice is to upgrade at the next available opportuni
 #### Deprecation warning
 
 * You can no longer create continuous aggregates using `time_bucket_ng`.
-  This feature will be completely removed the next release. Best practice is to 
+  This feature will be completely removed in the next release. Best practice is to 
   [migrate your current continuous aggregates to the new form](/use-timescale/:currentVersion:/continuous-aggregates/migrate/), 
 * This is the last release supporting PostgreSQL 13.
 

--- a/about/release-notes/index.md
+++ b/about/release-notes/index.md
@@ -74,7 +74,7 @@ After you run `ALTER EXTENSION`, you must run [this SQL script](https://github.c
 * #6870 Fix bool expression pushdown for queries on compressed chunks
 
 ### Acknowledgments
-* @brasic for reporting a crash when the ts_hypertable_insert_blocker was called directly
+* @brasic for reporting a crash when `ts_hypertable_insert_blocker` was called directly
 * @bvanelli for reporting an issue with the jobs retry count
 * @djzurawsk for reporting an error about dropping chunks
 * @Dzuzepppe for reporting the issue that DELETEs using a subquery on compressed chunks was working incorrectly


### PR DESCRIPTION
# Description

Release notes for TimescaleDB 2.15.0


# Links
https://github.com/timescale/timescaledb/pull/6887
