### PR TITLE
update compression sql snippet to render with syntax highlighting

### DIFF
--- a/use-timescale/compression/manual-compression.md
+++ b/use-timescale/compression/manual-compression.md
@@ -111,15 +111,15 @@ Set `timescaledb.compress_orderby = 'time ASC'` to avoid this penalty.
 
 
 
-    ```sql
-    ALTER TABLE example SET (timescaledb.compress_chunk_time_interval = '<time_interval>',
-                             timescaledb.compress_orderby = 'time ASC');
-    SELECT compress_chunk(c, if_not_compressed => true)
-        FROM show_chunks(
-            'example',
-            now()::timestamp - INTERVAL '1 week'
-        ) c;
-    ```
+```sql
+ALTER TABLE example SET (timescaledb.compress_chunk_time_interval = '<time_interval>',
+                            timescaledb.compress_orderby = 'time ASC');
+SELECT compress_chunk(c, if_not_compressed => true)
+    FROM show_chunks(
+        'example',
+        now()::timestamp - INTERVAL '1 week'
+    ) c;
+```
 
 The time interval you choose must be a multiple of the uncompressed chunk
 interval. For example, if your uncompressed chunk interval is one week, your


### PR DESCRIPTION
# Description

markdown already formats indented snippet, currently not rendering as `sql` as expected

currently:
<img width="925" alt="Screenshot 2024-06-13 at 3 29 37 PM" src="https://github.com/timescale/docs/assets/4349818/02dd855a-9301-4046-b770-d585cddfab63">


# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
