### PR TITLE
Remove warning about timescaledb-ha ARM64 support

### DIFF
--- a/self-hosted/tooling/install-toolkit.md
+++ b/self-hosted/tooling/install-toolkit.md
@@ -47,12 +47,6 @@ To get Toolkit, use the high availability image, `timescaledb-ha`:
 docker pull timescale/timescaledb-ha:pg16
 ```
 
-<Highlight type="important">
-The `timescaledb-ha` image does not support ARM64. For ARM64 environments, use the
-`timescaledb` Docker image. By default, this image does not contain Toolkit. You can add
-Toolkit using the package installation method, or by building from source.
-</Highlight>
-
 For more information on running TimescaleDB using Docker, see the section on
 [pre-built containers][docker-install].
 


### PR DESCRIPTION
This image is now being built for both ARM64 and AMD64, and it looks like it has been for several months now.

# Description

I was trying to build some continuous aggregates in our local environment, and it turns out these need toolkit, which isn't available in the `timescaledb` image, only the `timescaledb-ha` image. The docs said that `timescaledb-ha` wasn't available for ARM64, so I tried building the extension from source but ended up mostly banging my head against a table. After coming back to it with a fresh head I thought I'd just, for the sake of it, check whether it was really true that the image wasn't available for ARM64 and lo, I see that it is.

The image seems to work fine locally (on an M1 Mac) to my eyes, so this is hopefully just some out of date docs!

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
