### PR TITLE
fix parameter name

### DIFF
--- a/use-timescale/user-defined-actions/example-tiered-storage.md
+++ b/use-timescale/user-defined-actions/example-tiered-storage.md
@@ -82,7 +82,7 @@ to move data to low-cost object storage backed by Amazon S3.
     SELECT add_job(
       'move_chunks',
       '1d',
-      config => '{"hypertable":"metrics","lag":"12 month","tablespace":"old_chunks"}'
+      config => '{"hypertable":"metrics","lag":"12 month","destination_tablespace":"old_chunks"}'
     );
     ```
 


### PR DESCRIPTION
# Description

On the [Use a user-defined action to implement automatic tablespace management](https://docs.timescale.com/use-timescale/latest/user-defined-actions/example-tiered-storage/#use-a-user-defined-action-to-implement-automatic-tablespace-management) documentation site the parameter name in the add_job Statement does not match the parameter name in the move_chunks procedure. Thus the validation of required parameters in the move_chunks procedure will always fail.
This is fixed now.

# Links

Did not fill an issue.

