### PR TITLE
Recommend adjusting maintenance window during migration

### DIFF
--- a/_partials/_migrate_prerequisites.md
+++ b/_partials/_migrate_prerequisites.md
@@ -21,4 +21,4 @@ Before you migrate your data:
 [upgrade instructions]: /self-hosted/:currentVersion:/upgrades/about-upgrades/
 [pg_hbaconf]: https://www.timescale.com/blog/5-common-connection-errors-in-postgresql-and-how-to-solve-them/#no-pg_hbaconf-entry-for-host
 [create-ec2-instance]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html#ec2-launch-instance
-[adjust-maintenance-window]: /use-timescale/:currentVersion/upgrades/#adjusting-your-maintenance-window
+[adjust-maintenance-window]: /upgrades/#adjusting-your-maintenance-window

--- a/_partials/_migrate_prerequisites.md
+++ b/_partials/_migrate_prerequisites.md
@@ -10,7 +10,8 @@ Before you migrate your data:
   Each Timescale Cloud service [has a single database] that supports the
   [most popular extensions][all available extensions]. Timescale Cloud services do not support [tablespaces],
   and [there is no superuser associated with a Timescale service][no-superuser-for-timescale-instance].
- 
+
+- [Adjust the maintenance window][adjust-maintenance-window] to ensure that maintenance does not run while the migration is in progress.
 
 [created-a-database-service-in-timescale]: /getting-started/:currentVersion:/services/
 [has a single database]: /migrate/:currentVersion:/troubleshooting/#only-one-database-per-instance
@@ -20,3 +21,4 @@ Before you migrate your data:
 [upgrade instructions]: /self-hosted/:currentVersion:/upgrades/about-upgrades/
 [pg_hbaconf]: https://www.timescale.com/blog/5-common-connection-errors-in-postgresql-and-how-to-solve-them/#no-pg_hbaconf-entry-for-host
 [create-ec2-instance]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html#ec2-launch-instance
+[adjust-maintenance-window]: /use-timescale/:currentVersion/upgrades/#adjusting-your-maintenance-window

--- a/_partials/_migrate_prerequisites.md
+++ b/_partials/_migrate_prerequisites.md
@@ -11,7 +11,7 @@ Before you migrate your data:
   [most popular extensions][all available extensions]. Timescale Cloud services do not support [tablespaces],
   and [there is no superuser associated with a Timescale service][no-superuser-for-timescale-instance].
 
-- [Adjust the maintenance window][adjust-maintenance-window] to ensure that maintenance does not run while the migration is in progress.
+- To ensure that maintenance does not run while migration is in progress, best practice is to [adjust the maintenance window][adjust-maintenance-window]. 
 
 [created-a-database-service-in-timescale]: /getting-started/:currentVersion:/services/
 [has a single database]: /migrate/:currentVersion:/troubleshooting/#only-one-database-per-instance

--- a/_partials/_migrate_prerequisites.md
+++ b/_partials/_migrate_prerequisites.md
@@ -21,4 +21,4 @@ Before you migrate your data:
 [upgrade instructions]: /self-hosted/:currentVersion:/upgrades/about-upgrades/
 [pg_hbaconf]: https://www.timescale.com/blog/5-common-connection-errors-in-postgresql-and-how-to-solve-them/#no-pg_hbaconf-entry-for-host
 [create-ec2-instance]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html#ec2-launch-instance
-[adjust-maintenance-window]: /:currentVersion:/upgrades/#adjusting-your-maintenance-window
+[adjust-maintenance-window]: /use-timescale/:currentVersion:/upgrades/#adjusting-your-maintenance-window

--- a/_partials/_migrate_prerequisites.md
+++ b/_partials/_migrate_prerequisites.md
@@ -21,4 +21,4 @@ Before you migrate your data:
 [upgrade instructions]: /self-hosted/:currentVersion:/upgrades/about-upgrades/
 [pg_hbaconf]: https://www.timescale.com/blog/5-common-connection-errors-in-postgresql-and-how-to-solve-them/#no-pg_hbaconf-entry-for-host
 [create-ec2-instance]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html#ec2-launch-instance
-[adjust-maintenance-window]: /upgrades/#adjusting-your-maintenance-window
+[adjust-maintenance-window]: /:currentVersion:/upgrades/#adjusting-your-maintenance-window


### PR DESCRIPTION
# Description

While testing, I found that the maintenance job kicked in and upgraded the extension, which caused the migration to fail. Therefore, I recommend adjusting the maintenance window to avoid this issue.

Fixes https://linear.app/timescale/issue/DAT-72/docs-add-a-note-about-the-maintenance-window-not-overlapping-with

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
