### PR TITLE
Remove live-migration reference to docker image URL

### DIFF
--- a/migrate/live-migration.md
+++ b/migrate/live-migration.md
@@ -21,10 +21,10 @@ import Troubleshooting from "versionContent/_partials/_migrate_live_migrate_faq_
 
 # Live migration
 
-You use the [live-migration][live-migration-docker-image] Docker image to move 100GB-10TB+ of data to a Timescale Cloud service 
+You use the live-migration Docker image to move 100GB-10TB+ of data to a Timescale Cloud service 
 seamlessly with only a few minutes downtime. 
 
-[Live-migration][live-migration-docker-image] is an end-to-end solution that copies the database schema and data to 
+Live-migration is an end-to-end solution that copies the database schema and data to 
 your target Timescale Cloud service, then replicates the database activity in your source database 
 to the target service in real-time. Live-migration uses the PostgreSQL logical decoding 
 functionality and leverages [pgcopydb]. 
@@ -144,4 +144,3 @@ This section shows you how to workaround issues frequently seen issues using Liv
 [FAQ]: /migrate/:currentVersion:/troubleshooting
 [pgcopydb]: https://github.com/dimitri/pgcopydb
 [install-docker]: https://docs.docker.com/engine/install/
-[live-migration-docker-image]: https://hub.docker.com/r/timescale/live-migration

--- a/migrate/live-migration.md
+++ b/migrate/live-migration.md
@@ -21,13 +21,10 @@ import Troubleshooting from "versionContent/_partials/_migrate_live_migrate_faq_
 
 # Live migration
 
-You use the live-migration Docker image to move 100GB-10TB+ of data to a Timescale Cloud service 
-seamlessly with only a few minutes downtime. 
+Live-migration is an end-to-end solution that copies the database schema and data to
+your target Timescale Cloud service, then replicates the database activity in your source database to the target service in real-time. Live-migration uses the PostgreSQL logical decoding functionality and leverages [pgcopydb].
 
-Live-migration is an end-to-end solution that copies the database schema and data to 
-your target Timescale Cloud service, then replicates the database activity in your source database 
-to the target service in real-time. Live-migration uses the PostgreSQL logical decoding 
-functionality and leverages [pgcopydb]. 
+You use the live-migration Docker image to move 100GB-10TB+ of data to a Timescale Cloud service seamlessly with only a few minutes downtime.
 
 Best practice is to use live-migration when:
 - Modifying your application logic to perform dual writes is a significant effort. 


### PR DESCRIPTION
The live-migration documentation serves as our primary resource, with the first line highlighting live-migration.

Additionally, since there's no specific content for live-migration on Docker Hub, we should avoid referencing the Docker image page.

• Additionally, I would prefer to have the live-migration definition first, rather than mentioning the distribution as a Docker image.

# Description

[Short summary of why you created this PR]

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
