### PR TITLE
chore: add a note about timescale.enable_chunk_skipping.

### DIFF
--- a/api/enable_chunk_skipping.md
+++ b/api/enable_chunk_skipping.md
@@ -13,34 +13,35 @@ api:
 
 Enable range statistics for a specific column in a **compressed** hypertable. This tracks a range of values for that column per chunk. Used for chunk pruning during query optimization.
 
-### Required arguments
+Best practice is to enable range tracking on columns that are correlated to the
+partitioning column. In other words, enable tracking on secondary columns which are
+referenced in the `WHERE` clauses in your queries.
 
-|Name|Type|Description|
-|-|-|-|
-|`hypertable`|REGCLASS|Hypertable that the column belongs to|
-|`column_name`|TEXT|Column to track range statistics for|
+TimescaleDB supports min/max range tracking for the `smallint`, `int`,
+`bigint`, `serial`, `bigserial`, `date`, `timestamp`, and `timestamptz` data types. The 
+min/max ranges are calculated when a chunk belonging to
+this hypertable is compressed using the [compress_chunk][compress_chunk] function.
+The range is stored in start (inclusive) and end (exclusive) form in the
+`chunk_column_stats` catalog table.
 
-### Optional arguments
+This way you store the min/max values for such columns in this catalog
+table at the per-chunk level. These min/max range values do
+not participate in partitioning of the data. These ranges are
+used for chunk pruning when the `WHERE` clause of an SQL query specifies
+ranges on the column.
 
-|Name|Type|Description|
-|-|-|-|
-|`if_not_exists`|BOOLEAN|Set to `true` so that a notice is sent when ranges are not being tracked for a column. By default, an error is thrown|
+A [DROP COLUMN](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-DESC-DROP-COLUMN)
+on a column with statistics tracking enabled on it ends up removing all relevant entries
+from the catalog table.
 
-### Returns
+A [decompress_chunk][decompress_chunk] invocation on a compressed chunk resets its entries
+from the `chunk_column_stats` catalog table since now it's available for DML and the
+min/max range values can change on any further data manipulation in the chunk.
 
-|Column|Type|Description|
-|-|-|-|
-|`column_stats_id`|INTEGER|ID of the entry in the TimescaleDB internal catalog|
-|`enabled`|BOOLEAN|Returns `true` when tracking is enabled, `if_not_exists` is `true`, and when a new entry is not
-added|
+By default, this feature is disabled. To enable chunk skipping, set `timescale.enable_chunk_skipping = on` in
+`postgresql.cnf`.
 
-<Highlight type="note">
- TimescaleDB supports min/max range tracking for the `smallint`, `int`,
- `bigint`, `serial`, `bigserial`, `date`, `timestamp`, and `timestamptz` data types.
-
-</Highlight>
-
-### Sample use
+## Samples
 
 In this sample, you convert the `conditions` table to a hypertable with
 partitioning on the `time` column. You then specify and enable additional columns to track ranges for.
@@ -50,31 +51,28 @@ SELECT create_hypertable('conditions', 'time');
 SELECT enable_chunk_skipping('conditions', 'device_id');
 ```
 
+## Arguments
+
+| Name        | Type             | Default | Required | Description                            |
+|-------------|------------------|---------|-|----------------------------------------|
+|`column_name`| `TEXT`        | -       | ✔ | Column to track range statistics for |
+|`hypertable`| `REGCLASS`        | -       | ✔ | Hypertable that the column belongs to  |
+|`if_not_exists`| `BOOLEAN`        | `false` | ✖ | Set to `true` so that a notice is sent when ranges are not being tracked for a column. By default, an error is thrown |
+
+
+## Returns
+
+|Column|Type|Description|
+|-|-|-|
+|`column_stats_id`|INTEGER|ID of the entry in the TimescaleDB internal catalog|
+|`enabled`|BOOLEAN|Returns `true` when tracking is enabled, `if_not_exists` is `true`, and when a new entry is not
+added|
+
 <Highlight type="note">
- Best practice is to enable range tracking on columns that are correlated to the
- partitioning column. In other words, enable tracking on secondary columns which are
- referenced in the `WHERE` clauses in your queries.
 
- The min/max ranges are calculated when a chunk belonging to
- this hypertable is compressed using the [compress_chunk][compress_chunk] function.
- The range is stored in start (inclusive) and end (exclusive) form in the
- `chunk_column_stats` catalog table.
-
- This way you store the min/max values for such columns in this catalog
- table at the per-chunk level. These min/max range values do
- not participate in partitioning of the data. These ranges are
- used for chunk pruning when the `WHERE` clause of an SQL query specifies
- ranges on the column.
-
- A [DROP COLUMN](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-DESC-DROP-COLUMN)
- on a column with statistics tracking enabled on it ends up removing all relevant entries
- from the catalog table.
-
- A [decompress_chunk][decompress_chunk] invocation on a compressed chunk resets its entries
- from the `chunk_column_stats` catalog table since now it's available for DML and the
- min/max range values can change on any further data manipulation in the chunk.
 
 </Highlight>
+
 
 [compress_chunk]: /api/:currentVersion:/compression/compress_chunk/
 [decompress_chunk]: /api/:currentVersion:/compression/decompress_chunk/

--- a/api/enable_chunk_skipping.md
+++ b/api/enable_chunk_skipping.md
@@ -39,7 +39,7 @@ from the `chunk_column_stats` catalog table since now it's available for DML and
 min/max range values can change on any further data manipulation in the chunk.
 
 By default, this feature is disabled. To enable chunk skipping, set `timescale.enable_chunk_skipping = on` in
-`postgresql.cnf`. When you upgrade from a database instance that uses compression but does not support chunk 
+`postgresql.conf`. When you upgrade from a database instance that uses compression but does not support chunk 
 skipping, you need to recompress the previously compressed chunks for chunk skipping to work.
 
 ## Samples

--- a/api/enable_chunk_skipping.md
+++ b/api/enable_chunk_skipping.md
@@ -69,11 +69,5 @@ SELECT enable_chunk_skipping('conditions', 'device_id');
 |`enabled`|BOOLEAN|Returns `true` when tracking is enabled, `if_not_exists` is `true`, and when a new entry is not
 added|
 
-<Highlight type="note">
-
-
-</Highlight>
-
-
 [compress_chunk]: /api/:currentVersion:/compression/compress_chunk/
 [decompress_chunk]: /api/:currentVersion:/compression/decompress_chunk/

--- a/api/enable_chunk_skipping.md
+++ b/api/enable_chunk_skipping.md
@@ -39,7 +39,8 @@ from the `chunk_column_stats` catalog table since now it's available for DML and
 min/max range values can change on any further data manipulation in the chunk.
 
 By default, this feature is disabled. To enable chunk skipping, set `timescale.enable_chunk_skipping = on` in
-`postgresql.cnf`.
+`postgresql.cnf`. When you upgrade from a database instance that uses compression but does not support chunk 
+skipping, you need to recompress the previously compressed chunks for chunk skipping to work.
 
 ## Samples
 


### PR DESCRIPTION
This is for https://timescaledb.slack.com/archives/C4GT3N90X/p1730724406834719?thread_ts=1730713968.262729&cid=C4GT3N90X ( I can't see this param in Timescale Cloud so have only mentioned the self-hosted config.) and https://timescaledb.slack.com/archives/C5X6UVB24/p1732473441815019?thread_ts=1731620394.349939&cid=C5X6UVB24

Page structure is updated to match https://docs.timescale.com/api/latest/hypertable/create_hypertable/. 