### PR TITLE
Update some API changes:

### DIFF
--- a/api/add_continuous_aggregate_policy.md
+++ b/api/add_continuous_aggregate_policy.md
@@ -24,7 +24,6 @@ policies that you set or the policies that already exist, see
 |`end_offset`|INTERVAL or integer|End of the refresh window as an interval relative to the time when the policy is executed. `NULL` is equivalent to `MAX(timestamp)` of the hypertable.|
 |`schedule_interval`|INTERVAL|Interval between refresh executions in wall-clock time. Defaults to 24 hours|
 |`initial_start`|TIMESTAMPTZ|Time the policy is first run. Defaults to NULL. If omitted, then the schedule interval is the intervalbetween the finish time of the last execution and the next start. If provided, it serves as the origin with respect to which the next_start is calculated |
-|`timezone`|TEXT|A valid time zone. If `initial_start` is also specified, subsequent executions of the refresh policy will be aligned on its initial start. However, daylight savings time (DST) changes may shift this alignment. Set to a valid time zone if this is an issue you want to mitigate. If omitted, UTC bucketing is performed. Defaults to `NULL`.|
 
 The `start_offset` should be greater than `end_offset`.
 
@@ -49,6 +48,8 @@ about how continuous aggregates use real-time aggregation, see the
 |Name|Type|Description|
 |-|-|-|
 |`if_not_exists`|BOOLEAN|Set to `true` to issue a notice instead of an error if the job already exists. Defaults to false.|
+|`timezone`|TEXT|A valid time zone. If `initial_start` is also specified, subsequent executions of the refresh policy will be aligned on its initial start. However, daylight savings time (DST) changes may shift this alignment. Set to a valid time zone if this is an issue you want to mitigate. If omitted, UTC bucketing is performed. Defaults to `NULL`.|
+| `include_tiered_data` | BOOLEAN | Set true to read tiered data even if `timescaledb.enable_tiered_reads` is false. Defaults to `TRUE`. |
 
 ### Returns
 

--- a/api/add_continuous_aggregate_policy.md
+++ b/api/add_continuous_aggregate_policy.md
@@ -48,7 +48,7 @@ about how continuous aggregates use real-time aggregation, see the
 |Name|Type|Description|
 |-|-|-|
 |`if_not_exists`|BOOLEAN|Set to `true` to issue a notice instead of an error if the job already exists. Defaults to false.|
-|`timezone`|TEXT|A valid time zone. If `initial_start` is also specified, subsequent executions of the refresh policy will be aligned on its initial start. However, daylight savings time (DST) changes may shift this alignment. Set to a valid time zone if this is an issue you want to mitigate. If omitted, UTC bucketing is performed. Defaults to `NULL`.|
+|`timezone`|TEXT|A valid time zone. If you specify `initial_start`, subsequent executions of the refresh policy are aligned on `initial_start`. However, daylight savings time (DST) changes may shift this alignment. If this is an issue you want to mitigate, set `timezone` to a valid time zone. Default is `NULL`, [UTC bucketing](https://docs.timescale.com/use-timescale/latest/time-buckets/about-time-buckets/) is performed.|
 | `include_tiered_data` | BOOLEAN | Enable/disable reading tiered data. This setting helps override the current settings for the`timescaledb.enable_tiered_reads` GUC. The default is NULL i.e we use the current setting for `timescaledb.enable_tiered_reads` GUC  | |
 
 ### Returns

--- a/api/add_continuous_aggregate_policy.md
+++ b/api/add_continuous_aggregate_policy.md
@@ -49,7 +49,7 @@ about how continuous aggregates use real-time aggregation, see the
 |-|-|-|
 |`if_not_exists`|BOOLEAN|Set to `true` to issue a notice instead of an error if the job already exists. Defaults to false.|
 |`timezone`|TEXT|A valid time zone. If `initial_start` is also specified, subsequent executions of the refresh policy will be aligned on its initial start. However, daylight savings time (DST) changes may shift this alignment. Set to a valid time zone if this is an issue you want to mitigate. If omitted, UTC bucketing is performed. Defaults to `NULL`.|
-| `include_tiered_data` | BOOLEAN | Set true to read tiered data even if `timescaledb.enable_tiered_reads` is false. Defaults to `TRUE`. |
+| `include_tiered_data` | BOOLEAN | Enable/disable reading tiered data. This setting helps override the current settings for the`timescaledb.enable_tiered_reads` GUC. The default is NULL i.e we use the current setting for `timescaledb.enable_tiered_reads` GUC  | |
 
 ### Returns
 

--- a/api/refresh_continuous_aggregate.md
+++ b/api/refresh_continuous_aggregate.md
@@ -99,7 +99,7 @@ END
 $$;
 ```
 
-Forcing the refresh of the continuous aggregate `conditions` between `2020-01-01` and
+Force the  `conditions` continuous aggregate to refresh between `2020-01-01` and
 `2020-02-01` exclusive even if it is already refreshed.
 
 ```sql

--- a/api/refresh_continuous_aggregate.md
+++ b/api/refresh_continuous_aggregate.md
@@ -66,7 +66,7 @@ changes that only occurred in the secondary table used in the JOIN.
 
 |Name|Type|Description|
 |-|-|-|
-| `force` | BOOLEAN | Force refresh of every bucket in the time range even if the bucket is already refreshed. Can be very expensive if a lot of data is refreshed. Default to `FALSE`.|
+| `force` | BOOLEAN | Force refresh every bucket in the time range between `window_start` and `window_end`, even when the bucket has already been refreshed. This can be very expensive when a lot of data is refreshed. Default is `FALSE`.|
 
 ### Sample usage
 

--- a/api/refresh_continuous_aggregate.md
+++ b/api/refresh_continuous_aggregate.md
@@ -103,7 +103,7 @@ Forcing the refresh of the continuous aggregate `conditions` between `2020-01-01
 `2020-02-01` exclusive even if it is already refreshed.
 
 ```sql
-CALL refresh_continuous_aggregate('conditions', '2020-01-01', '2020-02-01', TRUE);
+CALL refresh_continuous_aggregate('conditions', '2020-01-01', '2020-02-01', force => TRUE);
 ```
 
 [modify-parameters]: /use-timescale/:currentVersion/configuration/customize-configuration/

--- a/api/refresh_continuous_aggregate.md
+++ b/api/refresh_continuous_aggregate.md
@@ -100,7 +100,7 @@ $$;
 ```
 
 Force the  `conditions` continuous aggregate to refresh between `2020-01-01` and
-`2020-02-01` exclusive even if it is already refreshed.
+`2020-02-01` exclusive, even if the data has already been refreshed.
 
 ```sql
 CALL refresh_continuous_aggregate('conditions', '2020-01-01', '2020-02-01', force => TRUE);

--- a/api/refresh_continuous_aggregate.md
+++ b/api/refresh_continuous_aggregate.md
@@ -66,7 +66,7 @@ changes that only occurred in the secondary table used in the JOIN.
 
 |Name|Type|Description|
 |-|-|-|
-| `force` | BOOLEAN | Force the refresh even if the window range is already refreshed. Default to `FALSE`.|
+| `force` | BOOLEAN | Force refresh of every bucket in the time range even if the bucket is already refreshed. Can be very expensive if a lot of data is refreshed. Default to `FALSE`.|
 
 ### Sample usage
 

--- a/api/refresh_continuous_aggregate.md
+++ b/api/refresh_continuous_aggregate.md
@@ -62,6 +62,12 @@ not take place when buckets are materialized with no data changes or with
 changes that only occurred in the secondary table used in the JOIN.
 </Highlight>
 
+### Optional arguments
+
+|Name|Type|Description|
+|-|-|-|
+| `force` | BOOLEAN | Force the refresh even if the window range is already refreshed. Default to `FALSE`.|
+
 ### Sample usage
 
 Refresh the continuous aggregate `conditions` between `2020-01-01` and
@@ -93,6 +99,12 @@ END
 $$;
 ```
 
+Forcing the refresh of the continuous aggregate `conditions` between `2020-01-01` and
+`2020-02-01` exclusive even if it is already refreshed.
+
+```sql
+CALL refresh_continuous_aggregate('conditions', '2020-01-01', '2020-02-01', TRUE);
+```
 
 [modify-parameters]: /use-timescale/:currentVersion/configuration/customize-configuration/
 [create_materialized_view]: /api/:currentVersion:/continuous-aggregates/create_materialized_view/


### PR DESCRIPTION
- `add_continuous_aggregate_policy`: added new optional argument `include_tiered_data` introduced by 2.18.0.
- `refresh_continuous_aggregate`: added new optional argument `force` introduced by 2.18.0
