### PR TITLE
Remove timescale_vector extension

### DIFF
--- a/use-timescale/extensions/index.md
+++ b/use-timescale/extensions/index.md
@@ -21,8 +21,7 @@ supported extensions:
 |--------------------------------------------|----------------------------------------|-----------------------------------------------------------------------|
 | [pgai][pgai]                               | Helper functions for AI workflows      | For services with the [AI and Vector capability][services]            |
 | [pgvector][pgvector]                       | Vector similarity search for PostgreSQL | For services with the [AI and Vector capability][services]            |
-| [pgvectorscale][pgvectorscale]             | Advanced indexing for vector data      | For services with the [AI and Vector capability][services]            | 
-| [timescale_vector][timescale-vector]       | PostgreSQL++ for AI applications       | -                                                                     |
+| [pgvectorscale][pgvectorscale]             | Advanced indexing for vector data      | For services with the [AI and Vector capability][services]            |
 | [timescaledb_toolkit][timescaledb-toolkit] | TimescaleDB Toolkit                    | For services with the [Time series and analytics capability][services]|
 | [timescaledb][timescaledb]                 | TimescaleDB                            | For all services                                                      |
 


### PR DESCRIPTION
# Description

`timescale_vector` is deprecated, no longer available, and was superseded by `pgvectorscale` 

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
