### PR TITLE
Update _migrate_self_postgres_timescaledb_compatibility.md

### DIFF
--- a/_partials/_migrate_self_postgres_timescaledb_compatibility.md
+++ b/_partials/_migrate_self_postgres_timescaledb_compatibility.md
@@ -2,7 +2,7 @@
 | Version number            |PostgreSQL 17|PostgreSQL 16|PostgreSQL 15|PostgreSQL 14|PostgreSQL 13|PostgreSQL 12|PostgreSQL 11|PostgreSQL 10|
 |---------------------------|-|-|-|-|-|-|-|-|
 | TimescaleDB<br/> 2.17.x   |✅|✅|✅|✅|❌|❌|❌|❌|❌|
-| TimescaleDB<br/> 2.16.x   |❌|✅|✅|✅|✅|❌|❌|❌|❌|❌|
+| TimescaleDB<br/> 2.16.x   |❌|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 | TimescaleDB<br/> 2.15.x   |❌|✅|✅|✅|✅|❌|❌|❌|❌|❌|
 | TimescaleDB<br/> 2.14.x   |❌|✅|✅|✅|✅|❌|❌|❌|❌|❌|
 | TimescaleDB<br/> 2.13.x   |❌|✅|✅|✅|✅|❌|❌|❌|❌|

--- a/_partials/_migrate_self_postgres_timescaledb_compatibility.md
+++ b/_partials/_migrate_self_postgres_timescaledb_compatibility.md
@@ -1,6 +1,7 @@
 
 | Version number            |PostgreSQL 17|PostgreSQL 16|PostgreSQL 15|PostgreSQL 14|PostgreSQL 13|PostgreSQL 12|PostgreSQL 11|PostgreSQL 10|
 |---------------------------|-|-|-|-|-|-|-|-|
+| TimescaleDB<br/> 2.18.x   |✅|✅|✅|✅|❌|❌|❌|❌|❌|
 | TimescaleDB<br/> 2.17.x   |✅|✅|✅|✅|❌|❌|❌|❌|❌|
 | TimescaleDB<br/> 2.16.x   |❌|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 | TimescaleDB<br/> 2.15.x   |❌|✅|✅|✅|✅|❌|❌|❌|❌|❌|


### PR DESCRIPTION
# Description

The current compatibility matrix specify an invalid compatibility between postgresql 13 and timescaledb 2.16

cf https://github.com/timescale/timescaledb/blob/eea28951e9eaec71be8d203afd25be7cdcb59a56/CHANGELOG.md#2160-2024-07-31

> PostgreSQL 13 support removal announcement
>
> Following the deprecation announcement for PostgreSQL 13 in TimescaleDB v2.13, PostgreSQL 13 is no longer supported in TimescaleDB v2.16.
>
> The Currently supported PostgreSQL major versions are 14, 15 and 16.

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
