### PR TITLE
Update supported platforms table

### DIFF
--- a/self-hosted/install/installation-linux.md
+++ b/self-hosted/install/installation-linux.md
@@ -89,5 +89,6 @@ TimescaleDB is supported on the following platforms:
 |Debian 10 Buster|Ubuntu 20.04 LTS Focal Fossa|Red Hat Enterprise Linux 7|Fedora 33|Rocky Linux 8|
 |Debian 11 Bullseye|Ubuntu 22.04 LTS Jammy Jellyfish|Red Hat Enterprise Linux 8|Fedora 34|Rocky Linux 9|
 |Debian 12 Bookworm|Ubuntu 23.04 Lunar Lobster|Red Hat Enterprise Linux 9|Fedora 35| |
+||Ubuntu 24.04 LTS Noble Numbat||| |
 
 [install-from-source]: /self-hosted/:currentVersion:/install/installation-source/


### PR DESCRIPTION
Add Ubuntu 24.04 LTS as a supported platform.

# Description

The supported platforms table does not show that Ubuntu 24.04 LTS is a supported platform, though packages exist in the repository for it.

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
