### PR TITLE
docs: add early access Typescript note

### DIFF
--- a/quick-start/node.md
+++ b/quick-start/node.md
@@ -18,6 +18,11 @@ This quick start guide walks you through:
 *   [Inserting data][insert]
 *   [Executing a query][query]
 
+
+<Highlight type="note">
+	Announcing early acccess of our new TimescaleTS integration for Node.js. Continue below to use Sequelize with TimescaleDB. For more information on TimescaleTS, see the [TimescaleTS documentation](timescalets). 
+</Highlight>
+
 ## Prerequisites
 
 Before you start, make sure you have:
@@ -398,3 +403,4 @@ Now, when you reload the page, you should see all of the rows currently in the
 [insert]: #insert-rows-of-data
 [query]: #execute-a-query
 [install]: /getting-started/latest/
+[timescalets]: https://github.com/timescale/timescaledb-ts

--- a/quick-start/node.md
+++ b/quick-start/node.md
@@ -20,7 +20,7 @@ This quick start guide walks you through:
 
 
 <Highlight type="note">
-	Announcing early acccess of our new TimescaleTS integration for Node.js. Continue below to use Sequelize with TimescaleDB. For more information on TimescaleTS, see the [TimescaleTS documentation](timescalets). 
+	Announcing early access to our new TimescaleTS integration for Node.js. Continue below to use Sequelize with TimescaleDB. For more information on TimescaleTS, see the [TimescaleTS documentation](timescalets). 
 </Highlight>
 
 ## Prerequisites

--- a/quick-start/node.md
+++ b/quick-start/node.md
@@ -20,7 +20,7 @@ This quick start guide walks you through:
 
 
 <Highlight type="note">
-	Announcing early access to our new TimescaleTS integration for Node.js. Continue below to use Sequelize with TimescaleDB. For more information on TimescaleTS, see the [TimescaleTS documentation](timescalets). 
+	Announcing early access to our new Timescale TypeScript integration for Node.js. Continue below to use Sequelize with TimescaleDB. For more information on TimescaleTS, see the [TimescaleTS documentation](timescalets). 
 </Highlight>
 
 ## Prerequisites


### PR DESCRIPTION
We released early access to our Typescript integration last week and would like to capture some traffic and early adopters before a more solidified documentation change. 

