### PR TITLE
Update how upgrades can be triggered by user

### DIFF
--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -74,7 +74,7 @@ For more information about replicas, see the
 Non-critical upgrades are available before the upgrade is performed
 automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER EXTENSION timescaledb
 UPDATE` in your in your $SERVICE_LONG, or `Pause` and `Resume` your service.
-upgrade is triggered automatically in the next available maintenance window for
+This triggers the upgrade in the next available maintenance window.
 your service if you haven't taken any action to do the upgrade yourself. You
 can configure the maintenance window so that these upgrades are started only at
 a particular time, on a set day of the week. If there are no pending upgrades

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -75,7 +75,6 @@ Non-critical upgrades are available before the upgrade is performed
 automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER EXTENSION timescaledb
 UPDATE` in your in your $SERVICE_LONG, or `Pause` and `Resume` your service.
 This triggers the upgrade in the next available maintenance window.
-your service if you haven't taken any action to do the upgrade yourself. You
 You can configure the maintenance window so that these upgrades are started at
 a particular time, on a set day of the week. 
 

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -74,9 +74,9 @@ For more information about replicas, see the
 Non-critical upgrades are available before the upgrade is performed
 automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER
 EXTENSION timescaledb UPDATE` in your $SERVICE_LONG, or `Pause` and `Resume`.
-If no action is taken by the user, the upgrade is triggered in the next available maintenance window. You can
-configure the maintenance window so that these upgrades are started at a
-particular time, on a set day of the week. 
+If no action is taken by the user, the upgrade is triggered in the next
+available maintenance window. You can configure the maintenance window so that
+these upgrades are started at a particular time, on a set day of the week. 
 
 If there are no pending upgrades available during a regular maintenance window,
 no changes are performed.

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -78,8 +78,8 @@ This triggers the upgrade in the next available maintenance window.
 You can configure the maintenance window so that these upgrades are started at
 a particular time, on a set day of the week. 
 
-If there are no pending upgrades
-available during a regular maintenance window, no changes are performed.
+If there are no pending upgrades available during a regular maintenance window,
+no changes are performed.
 
 When you are considering your maintenance window schedule, you might prefer to
 choose a day and time that usually has very low activity, such as during the

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -73,10 +73,10 @@ For more information about replicas, see the
 
 Non-critical upgrades are available before the upgrade is performed
 automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER
-EXTENSION timescaledb UPDATE` in your $SERVICE_LONG, or `Pause` and `Resume`
-your service. This triggers the upgrade in the next available maintenance
-window. You can configure the maintenance window so that these upgrades are
-started at a particular time, on a set day of the week. 
+EXTENSION timescaledb UPDATE` in your $SERVICE_LONG, or `Pause` and `Resume`.
+This triggers the upgrade in the next available maintenance window. You can
+configure the maintenance window so that these upgrades are started at a
+particular time, on a set day of the week. 
 
 If there are no pending upgrades available during a regular maintenance window,
 no changes are performed.

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -132,7 +132,7 @@ overview page.
 -->
 
 You can also manually upgrade to the newest supported PostgreSQL version
-(PostgreSQL&nbsp;16) from the service overview page.
+(PostgreSQL&nbsp;17) from the service overview page.
 
 Upgrading to a newer version of PostgreSQL allows you to take advantage of new
 features, enhancements, and security fixes. It also ensures that you are using a

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -76,7 +76,7 @@ automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER EXTE
 UPDATE` in your in your $SERVICE_LONG, or `Pause` and `Resume` your service.
 This triggers the upgrade in the next available maintenance window.
 your service if you haven't taken any action to do the upgrade yourself. You
-can configure the maintenance window so that these upgrades are started only at
+You can configure the maintenance window so that these upgrades are started at
 a particular time, on a set day of the week. If there are no pending upgrades
 available during a regular maintenance window, no changes are performed.
 

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -72,11 +72,11 @@ For more information about replicas, see the
 ## Non-critical maintenance updates
 
 Non-critical upgrades are available before the upgrade is performed
-automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER EXTENSION timescaledb
-UPDATE` in your in your $SERVICE_LONG, or `Pause` and `Resume` your service.
-This triggers the upgrade in the next available maintenance window.
-You can configure the maintenance window so that these upgrades are started at
-a particular time, on a set day of the week. 
+automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER
+EXTENSION timescaledb UPDATE` in your $SERVICE_LONG, or `Pause` and `Resume`
+your service. This triggers the upgrade in the next available maintenance
+window. You can configure the maintenance window so that these upgrades are
+started at a particular time, on a set day of the week. 
 
 If there are no pending upgrades available during a regular maintenance window,
 no changes are performed.

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -73,7 +73,7 @@ For more information about replicas, see the
 
 Non-critical upgrades are available before the upgrade is performed
 automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER EXTENSION timescaledb
-UPDATE` in your in your database or `Pause` and `Resume` your service. The
+UPDATE` in your in your $SERVICE_LONG, or `Pause` and `Resume` your service.
 upgrade is triggered automatically in the next available maintenance window for
 your service if you haven't taken any action to do the upgrade yourself. You
 can configure the maintenance window so that these upgrades are started only at

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -74,7 +74,7 @@ For more information about replicas, see the
 Non-critical upgrades are available before the upgrade is performed
 automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER
 EXTENSION timescaledb UPDATE` in your $SERVICE_LONG, or `Pause` and `Resume`.
-This triggers the upgrade in the next available maintenance window. You can
+If no action is taken by the user, the upgrade is triggered in the next available maintenance window. You can
 configure the maintenance window so that these upgrades are started at a
 particular time, on a set day of the week. 
 

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -72,13 +72,13 @@ For more information about replicas, see the
 ## Non-critical maintenance updates
 
 Non-critical upgrades are made available before the upgrade is performed
-automatically. During this time you can click `Apply upgrades` to start the
-upgrade at any time. However, after the time expires, usually around a week,
-the upgrade is triggered automatically in the next available maintenance window
-for your service. You can configure the maintenance window so that these
-upgrades are started only at a particular time, on a set day of the week. If
-there are no pending upgrades available during a regular maintenance window, no
-changes are performed.
+automatically. During this time you can run `ALTER EXTENSION timescaledb
+UPDATE` in your in your database or `Pause` and `Resume` your service. The
+upgrade is triggered automatically in the next available maintenance window for
+your service if you haven't taken any action to do the upgrade yourself. You
+can configure the maintenance window so that these upgrades are started only at
+a particular time, on a set day of the week. If there are no pending upgrades
+available during a regular maintenance window, no changes are performed.
 
 When you are considering your maintenance window schedule, you might prefer to
 choose a day and time that usually has very low activity, such as during the

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -71,7 +71,7 @@ For more information about replicas, see the
 
 ## Non-critical maintenance updates
 
-Non-critical upgrades are made available before the upgrade is performed
+Non-critical upgrades are available before the upgrade is performed
 automatically. During this time you can run `ALTER EXTENSION timescaledb
 UPDATE` in your in your database or `Pause` and `Resume` your service. The
 upgrade is triggered automatically in the next available maintenance window for

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -72,7 +72,7 @@ For more information about replicas, see the
 ## Non-critical maintenance updates
 
 Non-critical upgrades are available before the upgrade is performed
-automatically. During this time you can run `ALTER EXTENSION timescaledb
+automatically by $CLOUD_LONG. To upgrade $TIMESCALE_DB manually, run `ALTER EXTENSION timescaledb
 UPDATE` in your in your database or `Pause` and `Resume` your service. The
 upgrade is triggered automatically in the next available maintenance window for
 your service if you haven't taken any action to do the upgrade yourself. You

--- a/use-timescale/upgrades.md
+++ b/use-timescale/upgrades.md
@@ -77,7 +77,9 @@ UPDATE` in your in your $SERVICE_LONG, or `Pause` and `Resume` your service.
 This triggers the upgrade in the next available maintenance window.
 your service if you haven't taken any action to do the upgrade yourself. You
 You can configure the maintenance window so that these upgrades are started at
-a particular time, on a set day of the week. If there are no pending upgrades
+a particular time, on a set day of the week. 
+
+If there are no pending upgrades
 available during a regular maintenance window, no changes are performed.
 
 When you are considering your maintenance window schedule, you might prefer to


### PR DESCRIPTION
Cloud docs used to instruct users to click a non-existing `Apply upgrades` button. On cloud other ways exist to apply upgrades than on MST.

# Description

Information on the docs was irrelevant

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [Contribution guide](https://github.com/timescale/docs/blob/latest/CONTRIBUTING.md)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
