### PR TITLE
fix: add compression link in caggs intro

### DIFF
--- a/_partials/_caggs-intro.md
+++ b/_partials/_caggs-intro.md
@@ -30,6 +30,7 @@ By default, querying continuous aggregates provides you with real-time data.
 Pre-aggregated data from the materialized view is combined with recent data that
 hasn't been aggregated yet. This gives you up-to-date results on every query.
 
+[compression]: /use-timescale/:currentVersion:/compression/about-compression
 [data-tiering]: /use-timescale/:currentVersion:/data-tiering/
 [hypercore]: /use-timescale/:currentVersion:/hypercore/
 [hierarchical-caggs]: /use-timescale/:currentVersion:/continuous-aggregates/hierarchical-continuous-aggregates/


### PR DESCRIPTION
# Description

This updates the compression link in the [About Continuous Aggregates page](https://docs.timescale.com/use-timescale/latest/continuous-aggregates/about-continuous-aggregates/). Previously there was no `compression` link inside the `_caggs-intro.md` partial. The quote looked like this:

> Because continuous aggregates are based on hypertables, you can query them in exactly the same way as your other tables, and enable [compression][compression] or [tiered storage](https://docs.timescale.com/use-timescale/latest/data-tiering/) on them.

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [Contribution guide](https://github.com/timescale/docs/blob/latest/CONTRIBUTING.md)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
