### PR TITLE
Fix small typo in _livesync-configure-source-database.md

### DIFF
--- a/_partials/_livesync-configure-source-database.md
+++ b/_partials/_livesync-configure-source-database.md
@@ -3,7 +3,7 @@
    ```sql
    psql $SOURCE <<EOF
    ALTER SYSTEM SET wal_level='logical';
-   ALTER SYSTEM SET max_wal_sender=10;
+   ALTER SYSTEM SET max_wal_senders=10;
    ALTER SYSTEM SET wal_sender_timeout=0;
    EOF
    ```


### PR DESCRIPTION
Small but important typo for anyone copying the sql command:

ALTER SYSTEM SET max_wal_sender=10;
to 
ALTER SYSTEM SET max_wal_senders=10;

# Description

Found this typo in the SQL. Contributing back. 

# Links


# Writing help

For information about style and word usage, see the [Contribution guide](https://github.com/timescale/docs/blob/latest/CONTRIBUTING.md)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
