### PR TITLE
Fix AWS links on VPC peering page

### DIFF
--- a/use-timescale/security/vpc.md
+++ b/use-timescale/security/vpc.md
@@ -215,8 +215,8 @@ Migration takes a few minutes to complete and requires a change to DNS settings 
 $SERVICE_SHORT. The $SERVICE_SHORT is not accessible during this time. If you receive a DNS error, allow
 some time for DNS propagation.
 
-[aws-dashboard]: https://console.aws.amazon.com/vpc/home#PeeringConnections:
-[aws-security-groups]: https://console.aws.amazon.com/vpcconsole/home#securityGroups:
+[aws-dashboard]: https://console.aws.amazon.com/vpc/home#PeeringConnections
+[aws-security-groups]: https://console.aws.amazon.com/vpcconsole/home#securityGroups
 [console-login]: https://console.cloud.timescale.com/
 [console-vpc]: https://console.cloud.timescale.com/dashboard/vpc
 [console-services]: https://console.cloud.timescale.com/dashboard/services


### PR DESCRIPTION
# Description

PR fixes the links to AWS console pages on the VCP peering page as right now they have a trailing `:` which causes the hyperlink to fail.

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
