### PR TITLE
chore: replace repository dispatch with workflow dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,6 @@ jobs:
       #     repository: timescale/web-documentation
       #     event-type: build-docs-content
       #     client-payload: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'
-
       - name: Write comment
         uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           repo: timescale/web-documentation
           inputs: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'
           token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
-          ref: "81bd1f438ef68a78828e9de11ec9611a572fd6e4"
+          ref: chore/deploy-by-workflow-dispatch
       # - name: Repository Dispatch
       #   uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
       #   with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,13 +21,20 @@ jobs:
           echo "DEV_FOLDER=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
           echo "HYPHENATED_BRANCH_NAME=$(echo "${GITHUB_HEAD_REF}" | sed 's|/|-|' | sed 's/\./-/g')" >> $GITHUB_ENV
 
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
+      - name: Workflow dispatch
+        uses: benc-uk/workflow-dispatch@v1
         with:
+          repo: timescale/web-documentation
+          inputs: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'
           token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
-          repository: timescale/web-documentation
-          event-type: build-docs-content
-          client-payload: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'
+          ref: "81bd1f438ef68a78828e9de11ec9611a572fd6e4"
+      # - name: Repository Dispatch
+      #   uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
+      #   with:
+      #     token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+      #     repository: timescale/web-documentation
+      #     event-type: build-docs-content
+      #     client-payload: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'
 
       - name: Write comment
         uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Workflow dispatch
         uses: benc-uk/workflow-dispatch@v1
         with:
+          workflow: deploy-dev.yml
           repo: timescale/web-documentation
           inputs: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'
           token: ${{ secrets.ORG_AUTOMATION_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,13 +29,7 @@ jobs:
           inputs: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'
           token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
           ref: chore/deploy-by-workflow-dispatch
-      # - name: Repository Dispatch
-      #   uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
-      #   with:
-      #     token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
-      #     repository: timescale/web-documentation
-      #     event-type: build-docs-content
-      #     client-payload: '{"branch": "${{ steps.timescale.outputs.DEV_FOLDER }}", "pr_number": "${{ env.PR_NUMBER }}"}'
+
       - name: Write comment
         uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd
         with:


### PR DESCRIPTION
This change will allow us to trigger specific branches to run the workflow instead of the main branch as in `repository_dispatch`.

Given a ref set to a specific branch, such as:
```yaml
ref: chore/deploy-by-workflow-dispatch
```
![image](https://github.com/user-attachments/assets/d9533954-a2d3-4b25-a2af-421d57eb1292)
