### PR TITLE
chore: replace deprecated action by maintained fork

### DIFF
--- a/.github/workflows/daily-link-checker.yml
+++ b/.github/workflows/daily-link-checker.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
 
       - name: Check links
-        uses: gaurav-nelson/github-action-markdown-link-check@0f074c8562c5a8fed38282b7c741d1970bb1512d
+        uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba
         id: linkcheck
         with:
           use-quiet-mode: "yes"

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,4 +1,5 @@
 {
+  "aliveStatusCodes": [429, 200],
   "replacementPatterns": [
     {
       "pattern": ":currentVersion:",


### PR DESCRIPTION
- Also added 429 to `aliveStatusCodes`, since it's returning too many requests it is there and is rate limiting us