### PR TITLE
chore: remove IRSA mentions from cloudwatch-data-exporter.md

### DIFF
--- a/_partials/_cloudwatch-data-exporter.md
+++ b/_partials/_cloudwatch-data-exporter.md
@@ -22,16 +22,13 @@
 
     <Procedure>
 
-    $SERVICE_LONGs run in AWS. Best practice is to use [IAM Roles for Service Accounts (IRSA)][irsa] to
-    manage access between your $SERVICE_SHORTs and your AWS resources.
-
-    Create the IRSA role following this [AWS blog post][cross-account-iam-roles].
+    Create an IAM role following this [AWS blog post][cross-account-iam-roles].
 
     When you create the IAM OIDC provider:
     - Set the URL to the [region where the exporter is being created][reference].
     - Add the role as a trusted entity.
 
-    The following example shows a correctly configured IRSA role:
+    The following example shows a correctly configured role:
 
     - Permission Policy:
     
@@ -130,4 +127,3 @@
 [list-iam-users]: https://console.aws.amazon.com/iam/home#/users
 [create-an-iam-user]: https://console.aws.amazon.com/iam/home#/users/create
 [aws-access-keys]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_console
-[irsa]: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/


### PR DESCRIPTION
The fact we use IRSA internally is an implementation detail and should not be mentioned in the documentation.

# Description

Remove not needed implementation details from Cloudwatch cross-account role usage.

# Links

https://iobeam.slack.com/archives/C01LKN4NQKW/p1746960570641879

# Writing help

For information about style and word usage, see the [Contribution guide](https://github.com/timescale/docs/blob/latest/CONTRIBUTING.md)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
