### PR TITLE
Fix typo in approximate percentage query

### DIFF
--- a/use-timescale/hyperfunctions/approximate-percentile.md
+++ b/use-timescale/hyperfunctions/approximate-percentile.md
@@ -42,7 +42,7 @@ information about how long a server takes to respond to API calls.
     ninety-fifth percentile:
 
     ```sql
-    SELECT approx_percentile(0.95, percentile_agg(percentile_agg)) as threshold
+    SELECT approx_percentile(0.95, percentile_agg) as threshold
     FROM response_times_daily
     WHERE bucket >= time_bucket('1 day'::interval, now() - '30 days'::interval);
     ```


### PR DESCRIPTION
# Description

I noticed what seems to be a typo in the re-aggregate query for computing percentiles using the `percentile_agg` function.

# Links

Fixes #3153

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
