### PR TITLE
Broken link to API docs

### DIFF
--- a/use-timescale/compression/decompress-chunks.md
+++ b/use-timescale/compression/decompress-chunks.md
@@ -10,7 +10,7 @@ import Deprecated2180 from "versionContent/_partials/_deprecated_2_18_0.mdx";
 
 # Decompression
 
-<Deprecated2180 /> This function has been replaced by [`convert_to_rowstore`](https://docs.tigerdata.com/api/latest/hypercore/convert_to_rowstore/).
+<Deprecated2180 /> This function has been replaced by [`convert_to_rowstore`](api-convert-to-rowstore).
 
 $TIMESCALE_DB automatically supports `INSERT`s into compressed chunks. But if you
 need to insert a lot of data, for example, as part of a bulk backfilling
@@ -76,3 +76,4 @@ SELECT tableoid::regclass FROM metrics
 
 [api-reference-decompress]: /api/:currentVersion:/compression/decompress_chunk/
 [api-reference-alter-job]: /api/:currentVersion:/actions/alter_job/
+[api-convert-to-rowstore]: /api/:currentVersion:/hypercore/convert_to_rowstore/


### PR DESCRIPTION
First link for `convert_to_rowstore` is broken:  https://docs.tigerdata.com/use-timescale/latest/compression/decompress-chunks/