### PR TITLE
decompress_chunk - remove backfilling statement

### DIFF
--- a/api/compression/decompress_chunk.md
+++ b/api/compression/decompress_chunk.md
@@ -15,17 +15,11 @@ import Deprecated2180 from "versionContent/_partials/_deprecated_2_18_0.mdx";
 
 <Deprecated2180 /> Replaced by <a href="https://docs.tigerdata.com/api/latest/hypercore/convert_to_rowstore/">convert_to_rowstore()</a>.
 
-If you need to modify or add a lot of data to a chunk that has already been
-compressed, you should decompress the chunk first. This is especially
-useful for backfilling old data.
-
 <Highlight type="important">
 
 Before decompressing chunks, stop any compression policy on the hypertable you
 are decompressing. You can use `SELECT alter_job(JOB_ID, scheduled => false);`
-to prevent scheduled execution. When you finish backfilling or updating data,
-turn the policy back on. The database automatically recompresses your chunks in
-the next scheduled job.
+to prevent scheduled execution.
 
 </Highlight>
 


### PR DESCRIPTION
same as https://github.com/timescale/docs/pull/4348 - removing the statement for the need to fully decompressed to backfill
