### PR TITLE
Fix typo in services.md for PostgreSQL reference

### DIFF
--- a/getting-started/services.md
+++ b/getting-started/services.md
@@ -35,7 +35,7 @@ Now that you have an active $ACCOUNT_LONG, you create and manage your $SERVICE_S
 
    ![Create a $SERVICE_LONG](https://assets.timescale.com/docs/images/tiger-cloud-console/create-tiger-cloud-service.png)
 
-   To create a plain $PG $SERVICE_SHORT, without any additional capabilities, click `Looking for plan PostgreSQL?` in the top right.
+   To create a plain $PG $SERVICE_SHORT, without any additional capabilities, click `Looking for plain PostgreSQL?` in the top right.
    
 1. Follow the next steps in `Create a service` to configure the region, compute size, environment, availability, connectivity, and $SERVICE_SHORT name. Then click `Create service`.
 


### PR DESCRIPTION
# Description

Fixes a typo on the services page. "plan" -> "plain"

# Links



# Writing help

For information about style and word usage, see the [Contribution guide](https://github.com/timescale/docs/blob/latest/CONTRIBUTING.md)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
