### PR TITLE
fix: typo in "Enable columnstore on a continuous aggregate"

### DIFF
--- a/use-timescale/continuous-aggregates/compression-on-continuous-aggregates.md
+++ b/use-timescale/continuous-aggregates/compression-on-continuous-aggregates.md
@@ -32,7 +32,7 @@ For an [existing $CAGG][create-cagg]:
    To enable the $COLUMNSTORE compression on a $CAGG, set `timescaledb.enable_columnstore = true` when you alter the view:
 
    ```sql
-   ALTER MATERIALIZED VIEW <cagg_name> set (timescaledb.enable_columnstore = true,);
+   ALTER MATERIALIZED VIEW <cagg_name> set (timescaledb.enable_columnstore = true);
    ```
    To disable the $COLUMNSTORE compression, set  `timescaledb.enable_columnstore = false`:
 


### PR DESCRIPTION
# Description

You will see the following error without this fix,

```
ALTER MATERIALIZED VIEW metrics_daily set (timescaledb.enable_columnstore = true,);
ERROR:  syntax error at or near ")"
LINE 1: ... metrics_daily set (timescaledb.enable_columnstore = true,);
```

# Links

Fixes #[insert issue link, if any]

# Writing help

For information about style and word usage, see the [Contribution guide](https://github.com/timescale/docs/blob/latest/CONTRIBUTING.md)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
