### PR TITLE
Fixes #4563 Changes spelling of "Analyse the data" in the table of co…

### DIFF
--- a/tutorials/page-index/page-index.js
+++ b/tutorials/page-index/page-index.js
@@ -60,7 +60,7 @@ module.exports = [
               "Set up a dataset so you can analyze the Bitcoin blockchain",
           },
           {
-            title: "Analyse the data",
+            title: "Analyze the data",
             href: "analyze-blockchain-query",
             excerpt: "Analyze the Bitcoin blockchain dataset with TimescaleDB hyperfunctions",
           },


### PR DESCRIPTION
…ntents for the tutorials to match surrounding American spellings of "Analyze"

# Description

This is a simple PR to address #4563 
It changes the British spelling of "Analyse" in the tutorial table of contents to match the surrounding American spellings.

# Links

Fixes #4563 

# Writing help

For information about style and word usage, see the [Contribution guide](https://github.com/timescale/docs/blob/latest/CONTRIBUTING.md)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
