### PR TITLE
Fix broken whitepaper link, remove ref def. + link directly to whitepaper

### DIFF
--- a/about/whitepaper.md
+++ b/about/whitepaper.md
@@ -20,7 +20,7 @@ scalability while preserving $PG’s reliability and transactional guarantees.
 Want to read this whitepaper from the comfort of your own computer?
 
 <center>
-   <Tag type="download">[Tiger Data architecture for real-time analytics (PDF)][tiger-data-architecture-for-real-time-analytics-pdf]</Tag>
+   <Tag type="download">[Tiger Data architecture for real-time analytics (PDF)](https://assets.timescale.com/docs/downloads/tigerdata-whitepaper.pdf)</Tag>
 </center>
 
 
@@ -471,6 +471,3 @@ even on massive datasets that combine current and historic data. Its cloud-nativ
 For developers, this means building high-performance, real-time analytics applications without sacrificing SQL compatibility, transactional guarantees, or operational simplicity.
 
 $CLOUD_LONG delivers the best of $PG, optimized for real-time analytics.
-
-
-[tiger-data-architecture-for-real-time-analytics-pdf]: https://assets.timescale.com/docs/downloads/tigerdata-whitepaper.pdf


### PR DESCRIPTION
# Description

Fixes broken whitepaper download link on whitepaper page.
- https://www.tigerdata.com/docs/about/latest/whitepaper

# Links

no issue created

# Writing help

For information about style and word usage, see the [Contribution guide][contribution-guide]

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [x] Is the content technically accurate?
*   [x] Is the content complete?
*   [x] Is the content presented in a logical order?
*   [x] Does the content use appropriate names for features and products?
*   [x] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [x] Is the content free from typos?
*   [x] Does the content use plain English?
*   [x] Does the content contain clear sections for concepts, tasks, and references?
*   [x] Have any images been uploaded to the correct location, and are resolvable?
*   [x] If the page index was updated, are redirects required
      and have they been implemented?
*   [x] Have you checked the built version of this content?

[contribution-guide]: https://github.com/timescale/docs/blob/latest/CONTRIBUTING.md
