### PR TITLE
fix: replace shell export commands with correct terraform.tfvars syntax

### DIFF
--- a/integrations/terraform.md
+++ b/integrations/terraform.md
@@ -78,9 +78,9 @@ You use the [$COMPANY Terraform provider][terraform-provider] to manage $SERVICE
    1. Create a `terraform.tfvars` file in the same directory as your `main.tf` to pass in the variable values:
 
        ```hcl
-       export TF_VAR_ts_project_id="<your-timescale-project-id>"
-       export TF_VAR_ts_access_key="<your-timescale-access-key>"
-       export TF_VAR_ts_secret_key="<your-timescale-secret-key>"
+       ts_project_id = "<your-timescale-project-id>"
+       ts_access_key = "<your-timescale-access-key>"
+       ts_secret_key = "<your-timescale-secret-key>"
        ```
       
 1. **Add your resources**


### PR DESCRIPTION
The code block instructed users to create a `terraform.tfvars` file but contained shell `export` commands instead of valid HCL variable assignments.

Replaced `export TF_VAR_*="..."` with the correct `key = "value"` tfvars syntax.