### PR TITLE
fix: add redirect to old tigerdata path

### DIFF
--- a/lambda/redirects.js
+++ b/lambda/redirects.js
@@ -330,7 +330,11 @@ module.exports = [
   },
   {
     from: "/latest/getting-started/",
-    to: "https://www.tigerdata.com/docs/getting-started/latest/"
+    to: "https://www.tigerdata.com/docs/get-started"
+  },
+  {
+    from: "/latest/getting-started",
+    to: "https://www.tigerdata.com/docs/get-started"
   },
   {
     from: "/latest/getting-started/installation/mac/installation-homebrew",


### PR DESCRIPTION
## Describe your changes

A guide referenced https://www.tigerdata.com/docs/latest/getting-started , yielding a 404. 
I added a redirect to current link: https://www.tigerdata.com/docs/get-started

Not sure if this is the best way to add redirects to these docs, but I wanted to give an update regardless. 

## Related Issues



If there is a related issue, please add it below (just put the number after the # below, and GitHub will automatically create a link):

Issue: #number

## Checklist before requesting a review

- [ ] - Is this ready for review? If not, raise as a draft PR
- [ ] - This has deployed to a staging environment correctly
- [ ] - I have reviewed my changes.
- [ ] - I have confirmed the content is technically accurate.
- [ ] - I have confirmed the content is free of typos or grammar errors.
- [ ] - I have reviewed the deployed version of my changes.
- [ ] - I have tested any code that is added or updated.
- [ ] - I have verified all images and videos are clear, with appropriate zoom.
- [ ] - I have verified all images and videos match production (or dev for unreleased features).
- [ ] - I have tested that the content matches the functionality in production (or dev for unreleased features).
- [ ] - All checks have passed.
- [ ] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release.
